### PR TITLE
fix(dms): L2 SQL gate abstain reason names the actual violations (FF-03)

### DIFF
--- a/CHANGELOG_DMS.md
+++ b/CHANGELOG_DMS.md
@@ -2,6 +2,21 @@
 
 Agents append one section per shipped feature. Sequential build log.
 
+## FF-03 — L2 gate abstention names the actual SQL violations — 2026-08-22
+
+`SqlGateAbstain` already stored `violations` (unknown column, unbound table,
+disallowed construct, EXPLAIN failure) and `gate_with_retry` passed them in.
+`Exception.__str__` only returns `args[0]`, so `answer_engine` interpolated
+`{exc}` as "SQL validation gate exhausted retries" and threw the cause away.
+
+`SqlGateAbstain.__str__` now appends the violation list. Any future
+`str(exc)` / `f"{exc}"` site keeps the refusals (R-0004). The sibling
+EXPLAIN raise in `execution/submit.py` still puts DuckDB detail in the
+message. Test: `test_sql_gate_abstain_str_includes_violations` fails if
+violations disappear from `str(SqlGateAbstain)`.
+
+GitHub: Netie-AI/dms#59 (Cortex-side).
+
 ## Router audit — generalization benchmark, routing fixes, hot-path perf — 2026-07-27
 
 **New measurement.** `bench/paraphrase.py` + `bench/golden/dms_paraphrase_v1.yaml`:

--- a/CortexOS/dms/sql_validate_gate.py
+++ b/CortexOS/dms/sql_validate_gate.py
@@ -30,6 +30,14 @@ class SqlGateAbstain(Exception):
         super().__init__(message)
         self.violations = list(violations or [])
 
+    def __str__(self) -> str:
+        # R-0004: str(exc) / f"{exc}" must carry the refusal list, not only
+        # the generic message (answer_engine interpolates this into the reason).
+        base = super().__str__()
+        if not self.violations:
+            return base
+        return f"{base}: {'; '.join(self.violations)}"
+
 
 def explain_dry_run(con: Any, sql: str) -> tuple[bool, str]:
     """Run EXPLAIN without executing the query body. Returns (ok, detail)."""

--- a/STATUS.md
+++ b/STATUS.md
@@ -1,5 +1,5 @@
 # STATUS.md
-**Last updated:** 2026-07-29 | **Gate:** G2.3 OSR **SHIPPED** | **Active:** Pointer demo A0–A3 done · DMS Studio + lake→Q2 sync · `NEXT_LANES.md`
+**Last updated:** 2026-08-22 | **Gate:** G2.3 OSR **SHIPPED** | **Active:** FF-03 L2 gate reason names violations (`SqlGateAbstain.__str__`) · Pointer demo A0–A3 done · DMS Studio + lake→Q2 sync · `NEXT_LANES.md`
 **Rule:** Update after every gate. Read `CURSOR_HANDOFF.md` first. **Always leave next prompts in `docs/dms/packets/NEXT_LANES.md`.**
 
 > **2026-07-29 (Pointer demo + DMS Excel-swamp week):**

--- a/tests/dms/test_sql_validate_gate.py
+++ b/tests/dms/test_sql_validate_gate.py
@@ -45,6 +45,43 @@ def test_explain_passes_valid_select(semantic):
         con.close()
 
 
+def test_sql_gate_abstain_str_includes_violations():
+    """R-0004: str(SqlGateAbstain) must carry the gate's refusal list.
+
+    answer_engine interpolates ``{exc}`` into the L2 abstention reason. If
+    violations stay only on the attribute, callers see 'exhausted retries'
+    and lose unknown-column / unbound-table / disallowed-construct detail.
+    """
+    violations = [
+        "UNKNOWN_COLUMN:not_a_col",
+        "UNKNOWN_TABLE:ghost",
+        "DDL_ATTEMPT",
+    ]
+    exc = SqlGateAbstain(
+        "SQL validation gate exhausted retries",
+        violations=violations,
+    )
+    text = str(exc)
+    assert "exhausted retries" in text
+    for item in violations:
+        assert item in text, f"str(SqlGateAbstain) dropped {item!r}: {text!r}"
+    # f-string / answer_engine path uses the same conversion
+    assert "UNKNOWN_COLUMN:not_a_col" in f"L2 generation failed validation gate: {exc}"
+
+
+def test_explain_abstain_str_keeps_detail():
+    """Sibling EXPLAIN raise already puts detail in the message; keep it."""
+    detail = "Referenced column \"nope\" not found in FROM clause"
+    exc = SqlGateAbstain(
+        f"EXPLAIN rejected SQL: {detail}",
+        violations=[f"EXPLAIN_FAILED:{detail}"],
+    )
+    text = str(exc)
+    assert "EXPLAIN rejected SQL" in text
+    assert detail in text
+    assert "EXPLAIN_FAILED" in text
+
+
 def test_retry_exhausted_abstains(semantic):
     attempts = {"n": 0}
 
@@ -56,6 +93,9 @@ def test_retry_exhausted_abstains(semantic):
         gate_with_retry(bad, "x", semantic, con=None, max_retries=2)
     assert attempts["n"] == 3  # initial + 2 retries
     assert ei.value.violations
+    reason = str(ei.value)
+    for item in ei.value.violations:
+        assert item in reason, f"exhausted-retries path dropped {item!r}: {reason!r}"
 
 
 def test_l2_without_model_abstains(monkeypatch):


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Fixes Netie-AI/dms#59 (FF-03). Cortex-side only.

## Problem

L2 abstains with only:

`L2 generation failed validation gate: SQL validation gate exhausted retries`

`SqlGateAbstain.violations` already holds the real refusals (unknown column, unbound table, disallowed construct, EXPLAIN failure). `Exception.__str__` returns only `args[0]`, so `answer_engine` interpolating `{exc}` throws that list away.

## Change

- `SqlGateAbstain.__str__` appends the violation list. Any future `str(exc)` / `f"{exc}"` site keeps the refusals (R-0004). Call sites in `answer_engine.py` are unchanged.
- Exhausted-retries path now includes the violation list in the reason string.
- Sibling EXPLAIN raise in `CortexOS/execution/submit.py` still puts DuckDB detail in the message; `__str__` keeps that detail.

## Tests

- `test_sql_gate_abstain_str_includes_violations` fails if violations are missing from `str(SqlGateAbstain)`.
- `test_explain_abstain_str_keeps_detail` keeps the EXPLAIN path informative.
- `test_retry_exhausted_abstains` asserts each stored violation appears in `str(exc)`.

## Out of scope

No MSSQL plugin, no second key vault, no third orchestrator, no Kafka/TF production.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-a300208a-73f1-4547-99bb-f5a30ced7591?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a300208a-73f1-4547-99bb-f5a30ced7591&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

