### PR TITLE
fix(answer): route catalog browse by intent (META-01 / #37)

### DIFF
--- a/CortexOS/dms/answer_engine.py
+++ b/CortexOS/dms/answer_engine.py
@@ -617,13 +617,21 @@ def _suggestions(question: str, limit: int = 3) -> list[str]:
             seen.append(qtext)
         if len(seen) >= limit:
             break
-    if not seen:  # cold: offer a stable default trio
-        seen = [
-            "Top 5 selling SKUs by revenue",
-            "Which SKUs are below reorder level in warehouse A?",
-            "Show warehouse capacity utilisation",
-        ][:limit]
-    return seen
+    if not seen:  # cold: certified titles + metric labels from the pack
+        from packs.dms.semantic.catalog_answer import _metric_label
+
+        for cq in model.certified:
+            seen.append(cq.question)
+            if len(seen) >= limit:
+                break
+        if len(seen) < limit:
+            for metric in model.metrics.values():
+                label = _metric_label(metric)
+                if label not in seen:
+                    seen.append(label)
+                if len(seen) >= limit:
+                    break
+    return seen[:limit]
 
 
 def _abstain(
@@ -658,6 +666,43 @@ def _abstain(
         "assumptions": reason,
         "total_count": 0,
         "suggestions": [] if granted_sources else suggestions,
+    }
+
+
+def _catalog_response(question: str, audit_id: str) -> dict[str, Any]:
+    """META-01 — browse what the semantic layer can answer (no SQL)."""
+    from packs.dms.semantic.catalog_answer import build_catalog_answer
+    from packs.dms.semantic.loader import load_all
+
+    payload = build_catalog_answer()
+    model = load_all()
+    suggestions = [cq.question for cq in model.certified[:5]]
+    if len(suggestions) < 3:
+        from packs.dms.semantic.catalog_answer import _metric_label
+
+        for metric in model.metrics.values():
+            label = _metric_label(metric)
+            if label not in suggestions:
+                suggestions.append(label)
+            if len(suggestions) >= 5:
+                break
+    return {
+        "answer": payload["answer"],
+        "sql_used": None,
+        "chart_spec": None,
+        "audit_id": audit_id,
+        "violations_blocked": [],
+        "route": "sql",
+        "rows": [],
+        "source_table": None,
+        "layer": payload["layer"],
+        "badge": payload["badge"],
+        "assumptions": "semantic layer catalog (no SQL)",
+        "total_count": 0,
+        "suggestions": suggestions,
+        "query_plan": _honest_plan(
+            question, None, layer=payload["layer"], assumptions="catalog browse"
+        ),
     }
 
 
@@ -1088,7 +1133,13 @@ def answer(
 
     # L0 certified → L1 metric → L-skill → L3 abstain
     # Skills run after governed routes so golden/certified paths stay authoritative.
+    # Catalog browse is not a named warehouse subject — check it before
+    # undefined_subject, or "data" / "catalog" abstain as unknown nouns.
     if sql is None:
+        from packs.dms.semantic.catalog_answer import is_catalog_intent
+
+        if is_catalog_intent(question):
+            return _done(_catalog_response(question, audit_id))
         unknown = undefined_subject(question)
         if unknown:
             named = ", ".join(_answerable_entities())

--- a/packs/dms/semantic/catalog_answer.py
+++ b/packs/dms/semantic/catalog_answer.py
@@ -1,0 +1,90 @@
+"""META-01 — prose catalog of what the semantic layer can answer.
+
+No SQL, no invented numbers: lists certified questions, governed metrics,
+and table names from ``load_all()`` for browse / metadata intent.
+"""
+from __future__ import annotations
+
+import re
+
+# Intent classes, not a phrase list. A catalog ask is "what exists / what can
+# I query", not a request for a specific measure. Adding a new wording in the
+# same class should not require a new literal.
+_CAPABILITY = re.compile(
+    r"\b(?:what|which)\s+(?:else\s+)?"
+    r"(?:can|could)\s+(?:i|we)\s+"
+    r"(?:ask|search(?:\s+for)?|query|look\s+(?:up|for)|browse)\b",
+    re.I,
+)
+_INVENTORY = re.compile(
+    r"\b(?:what|which)\s+(?:else\s+)?"
+    r"(?:data|tables?|columns?|metrics?|questions?|meta\s*data|metadata)\s+"
+    r"(?:do\s+you\s+have|are\s+(?:available|there)|is\s+available|"
+    r"can\s+(?:i|we)\s+(?:search|query|ask|browse)|in\s+(?:the\s+)?data)\b",
+    re.I,
+)
+_AVAILABLE_IN_DATA = re.compile(
+    r"\bwhat\s+(?:else\s+)?is\s+available\s+in\s+(?:the\s+)?data\b",
+    re.I,
+)
+_BROWSE = re.compile(
+    r"\b(?:show|list|browse|open)\s+(?:me\s+)?(?:the\s+)?(?:available\s+)?"
+    r"(?:catalog|ontology|schema|meta\s*data|metadata|metrics?|tables?|columns?)\b",
+    re.I,
+)
+_METADATA = re.compile(r"\b(?:meta\s*data|metadata)\b", re.I)
+
+
+def is_catalog_intent(question: str) -> bool:
+    """True when the user is asking what they can query, not asking for data."""
+    text = question or ""
+    return bool(
+        _CAPABILITY.search(text)
+        or _INVENTORY.search(text)
+        or _AVAILABLE_IN_DATA.search(text)
+        or _BROWSE.search(text)
+        or _METADATA.search(text)
+    )
+
+
+def _metric_label(metric) -> str:
+    if metric.synonyms:
+        return str(metric.synonyms[0])
+    return metric.id.replace("_", " ")
+
+
+def build_catalog_answer(
+    *,
+    certified_cap: int = 8,
+    metrics_cap: int = 8,
+) -> dict[str, str]:
+    """Prose summary of certified questions, metrics, and tables."""
+    from packs.dms.semantic.loader import load_all
+
+    model = load_all()
+    certified = [cq.question for cq in model.certified[:certified_cap]]
+    metrics: list[str] = []
+    for metric in model.metrics.values():
+        metrics.append(_metric_label(metric))
+        if len(metrics) >= metrics_cap:
+            break
+    tables = list((model.base.get("tables") or {}).keys())
+
+    lines = [
+        "Here is what you can ask from the DMS semantic layer:",
+        "",
+        "**Certified questions** (exact wording gets a verified answer):",
+        *[f"- {q}" for q in certified],
+        "",
+        "**Governed metrics** (paraphrases compile to verified SQL):",
+        *[f"- {m}" for m in metrics],
+        "",
+        f"**Tables covered:** {', '.join(tables)}.",
+        "",
+        "Pick one above, or rephrase using those topics.",
+    ]
+    return {
+        "answer": "\n".join(lines),
+        "layer": "catalog",
+        "badge": "catalog",
+    }

--- a/tests/dms/test_meta01_catalog.py
+++ b/tests/dms/test_meta01_catalog.py
@@ -1,0 +1,58 @@
+"""META-01 — catalog intent before L2; revenue stays governed."""
+from __future__ import annotations
+
+import pytest
+
+from CortexOS.dms.answer_engine import answer as engine_answer
+from packs.dms.semantic.catalog_answer import is_catalog_intent
+from packs.dms.semantic.loader import load_all
+
+# Phrasings that used to split: two routed, two abstained. Also a couple of
+# same-class wordings so the matcher is an intent, not a remembered list.
+CATALOG_PHRASES = (
+    "what can I ask",
+    "what tables are available",
+    "what data do you have",
+    "show me the catalog",
+    "what else meta data that i can search for in the data",
+    "list available metrics",
+    "what columns are there",
+    "browse the ontology",
+)
+
+
+def _assert_catalog_payload(r: dict) -> None:
+    assert r["route"] != "needs_clarification"
+    assert r["layer"] == "catalog"
+    assert r["badge"] == "catalog"
+    assert r["sql_used"] is None
+    assert r["rows"] == []
+    answer = (r.get("answer") or "").lower()
+    assert "certified" in answer
+    assert "table" in answer
+    suggestions = r.get("suggestions") or []
+    assert suggestions
+    model = load_all()
+    certified = {cq.question for cq in model.certified}
+    metric_labels = {
+        (m.synonyms[0] if m.synonyms else m.id.replace("_", " "))
+        for m in model.metrics.values()
+    }
+    assert any(s in certified or s in metric_labels for s in suggestions)
+    assert not all("cctv" in s.lower() for s in suggestions[:3])
+
+
+@pytest.mark.parametrize("question", CATALOG_PHRASES)
+def test_meta01_catalog_intent_class_routes(question: str):
+    assert is_catalog_intent(question)
+    _assert_catalog_payload(engine_answer(question))
+
+
+def test_meta01_revenue_still_governed():
+    from CortexOS.dms.answer_engine import route_to_metric
+
+    q = "What was total revenue?"
+    assert not is_catalog_intent(q)
+    plan = route_to_metric(q)
+    assert plan is not None
+    assert plan.metric_id == "revenue_total"


### PR DESCRIPTION
## Summary
- Catalog / metadata asks now match as an intent class (capability, inventory, browse) instead of a remembered phrase list, so the measured misses reach the catalog layer.
- Catalog is checked before `undefined_subject`, because nouns like data and catalog were treated as unknown and abstained.
- `sql_used` stays null; cold suggestions come from certified questions and metric labels. Revenue stays on `revenue_total`.

## Test plan
- [x] `pytest tests/dms/test_meta01_catalog.py` (8 catalog phrasings + revenue still governed)
- [x] `pytest tests/dms/test_unknown_subject_abstain.py tests/dms/test_q2_answer_engine.py::test_unanswerable_abstains_with_suggestions`
- [ ] Verify Agent on a different run (R-0003)

Addresses Cortex#37. Do not merge until Verify + Gating. Does not close the issue.
