### PR TITLE
test(bench): pin customers unknown-subject abstain in the golden corpus

### DIFF
--- a/bench/golden/dms_adversarial_v1.yaml
+++ b/bench/golden/dms_adversarial_v1.yaml
@@ -30,6 +30,9 @@ categories:
     - id: gen_unknown_entity_literal
       question: "what is PEGASUS-MOON on-time rate last quarter"
       expect: abstain
+    - id: unknown_subject_customers
+      question: "top 3 customers by amount"
+      expect: abstain
 
   abstain_out_of_scope:
     - id: weather_joke

--- a/bench/golden/dms_golden_v1.yaml
+++ b/bench/golden/dms_golden_v1.yaml
@@ -388,3 +388,9 @@ items:
     question: "Tell me a joke about robots"
     match: abstain
     tags: [abstain]
+
+  - id: abstain_unknown_subject_customers
+    tier: safety
+    question: "top 3 customers by amount"
+    match: abstain
+    tags: [abstain, unknown-subject]


### PR DESCRIPTION
## Problem

Cortex#39 leftover step 3: merged PR #46 (`fbe3ff79`) already abstains on `top 3 customers by amount`, but `bench/golden/*.yaml` had zero customer hits. A future reroute could substitute SKUs again and the golden/adversarial gates would not fail here.

## Change

Seed the measured unknown-subject question into the existing corpus schema. No engine change.

- `dms_golden_v1.yaml`: safety item `abstain_unknown_subject_customers` with `match: abstain` (gated by `test_safety_tier_all_pass`)
- `dms_adversarial_v1.yaml`: `ambiguous_entity` item `unknown_subject_customers` with `expect: abstain` (gated category, `wrong==0`)

Regression shape: SKU rows + `route=sql` / `governed_metric` scores `wrong`. Live score on this SHA: safety 5/5, `ambiguous_entity` 3/3.

## Still true

- Did not close Cortex#39 or edit EPIC-001 #11
- Did not touch ANS-01/02/03 PR #48 files
- Did not mint a Space grant
- Did not weaken `tests/dms/test_unknown_subject_abstain.py`
- Isolated worktree `cursor/ans04-golden-corpus-pin` from `origin/main`

## Tests

- `tests/dms/test_unknown_subject_abstain.py`: 12 passed
- Targeted: new golden item `correct` / `needs_clarification`; new adversarial item `correct` / 0 rows
- Fake SKU substitution on the adversarial scorer: `wrong`

Made with [Cursor](https://cursor.com)