### PR TITLE
test(bench): pin ANS-01/02/03 shapes in the golden corpus

### DIFF
--- a/bench/golden/dms_adversarial_v1.yaml
+++ b/bench/golden/dms_adversarial_v1.yaml
@@ -22,6 +22,13 @@ categories:
       assert_sql_contains: ["SKU-BETA"]
       assert_rows_exclude: ["SKU-BETA"]
       assert_answer_excludes: ["SKU-BETA"]
+    # ANS-01: trailing skip token after "and" must not force a confirm chip.
+    - id: exclude_exact_sku_conjunction
+      question: "ignore SKU-BETA and also show the top 5 SKUs by revenue"
+      expect: correct_rows
+      assert_sql_contains: ["SKU-BETA"]
+      assert_rows_exclude: ["SKU-BETA"]
+      assert_answer_excludes: ["SKU-BETA"]
 
   ambiguous_entity:
     - id: exclude_nonexistent_sku
@@ -85,6 +92,14 @@ categories:
     - id: gen_no_silent_template
       # Outside L0/L1 templates; without FreeRoute L2 must abstain (never invent).
       question: "rank carriers by on-time percentage for hazmat only"
+      expect: abstain
+    # ANS-02: a sum over a ranking is adjacent to the ranking itself.
+    - id: sum_of_ranking
+      question: "i mean the sum of top 5 selling skus"
+      expect: abstain
+    # ANS-03: category ranking must not leak the warehouse-wide total.
+    - id: category_ranking
+      question: "top 3 categories by total revenue"
       expect: abstain
 
   # Covered primarily by paraphrase_benchmark + accuracy_benchmark;

--- a/bench/golden/dms_golden_v1.yaml
+++ b/bench/golden/dms_golden_v1.yaml
@@ -62,6 +62,20 @@ items:
     tags: [sales, rank, value_normalization]
     category: value_normalization
 
+  # ANS-01: exact SKU + conjunction + trailing skip token must exclude and answer.
+  - id: exclude_exact_sku_conjunction
+    tier: core
+    question: "ignore SKU-BETA and also show the top 5 SKUs by revenue"
+    match: resultset
+    canonical_sql: >
+      SELECT sku, ROUND(SUM(quantity_kg * unit_cost_myr), 2) AS sales_value_myr
+      FROM transactions WHERE txn_type = 'OUT' AND sku NOT IN ('SKU-BETA')
+      GROUP BY sku ORDER BY sales_value_myr DESC, sku ASC LIMIT 5
+    key_columns: [sku, sales_value_myr]
+    round: 2
+    tags: [sales, rank, value_normalization, ans-01]
+    category: value_normalization
+
   - id: sales_top3_volume
     tier: core
     question: "Top 3 SKUs by quantity sold"
@@ -388,3 +402,17 @@ items:
     question: "Tell me a joke about robots"
     match: abstain
     tags: [abstain]
+
+  # ANS-02: aggregate-over-ranking has no governed metric.
+  - id: abstain_sum_of_ranking
+    tier: safety
+    question: "i mean the sum of top 5 selling skus"
+    match: abstain
+    tags: [abstain, ans-02]
+
+  # ANS-03: grouped ranking must not return the warehouse as one row.
+  - id: abstain_category_ranking
+    tier: safety
+    question: "top 3 categories by total revenue"
+    match: abstain
+    tags: [abstain, ans-03]


### PR DESCRIPTION
## Problem

Cortex#8 / #36 / #38 leftover corpus seeds: DRAFT PR #48 (`7f9e3c4`) already answers exclusion+conjunction, abstains on sum-of-ranking, and abstains on category ranking, but `bench/golden/*.yaml` was a 0-file skip. A future adjacent `governed_metric` answer would not fail the golden/adversarial gates.

## Change

Seed the three measured shapes into the existing corpus schema. No engine change.

- `dms_golden_v1.yaml`:
  - core `exclude_exact_sku_conjunction` (`match: resultset`) for `ignore SKU-BETA and also show the top 5 SKUs by revenue`
  - safety `abstain_sum_of_ranking` (`match: abstain`) for `i mean the sum of top 5 selling skus`
  - safety `abstain_category_ranking` (`match: abstain`) for `top 3 categories by total revenue`
- `dms_adversarial_v1.yaml`:
  - gated `value_normalization` item `exclude_exact_sku_conjunction` (`expect: correct_rows`)
  - gated `fallback_hazard` items `sum_of_ranking` and `category_ranking` (`expect: abstain`)

The ticket's three basic ANS-01 phrasings already answer on `origin/main`. This pin uses the adverb residual that still abstains there and answers on `7f9e3c4`.

## Still true

- Did not close Cortex#8 / #36 / #38 or edit EPIC-001 #11
- Did not attach to PR #48 / `cursor/ans-01-02-03-governed-metric`
- Did not mint Cortex#42
- Did not weaken unit tests
- Isolated worktree `cursor/ans-01-02-03-golden-pins` from `origin/main`
- Did not depend on unmerged PR #49

## Tests

- Live score on SHA `7f9e3c4`: all 3 golden `correct`; all 3 adversarial `correct`
- Same items on `origin/main`: ANS-01 abstains; ANS-02 answers 5 ranking rows; ANS-03 answers 1 warehouse row — all fail the new gates
- Fake SKU leak / ranking / warehouse-total substitutions on the adversarial scorer: `wrong`

CI on this branch stays red until PR #48 lands. Merge this after that engine change, or rebase onto it. Do not merge this draft onto main alone.
