### PR TITLE
Point Constructor compose OpenVault at the VM host

### DIFF
--- a/compose.constructor.yml
+++ b/compose.constructor.yml
@@ -8,8 +8,11 @@ services:
       dockerfile: Dockerfile.constructor
     ports:
       - "8010:8010"
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
     environment:
       PACK: dms
       DMS_REFUSE_DEMO_KEYS: "1"
-      OPENVAULT_BASE_URL: http://127.0.0.1:5000
+      # 127.0.0.1 inside the container is the container, not OpenVault on the VM.
+      OPENVAULT_BASE_URL: http://host.docker.internal:5000
     restart: unless-stopped


### PR DESCRIPTION
## Summary
- `OPENVAULT_BASE_URL=http://127.0.0.1:5000` inside the Cortex container cannot reach OpenVault on the VM.
- Compose now uses `host.docker.internal` plus `extra_hosts: host-gateway`.

## Test plan
- [ ] `docker compose -f compose.constructor.yml config` shows `host.docker.internal`.
- [ ] After Hyperlift/VM deploy, Cortex `ov_` verify hits OpenVault on the host, not the container loopback.