### PR TITLE
Reject ov_ tokens when OpenVault verify is valid false

### DIFF
--- a/Dockerfile.constructor
+++ b/Dockerfile.constructor
@@ -10,6 +10,8 @@ ENV PYTHONDONTWRITEBYTECODE=1 \
     PACK=dms \
     DMS_REFUSE_DEMO_KEYS=1 \
     PORT=8080
+# Hyperlift: set PORT=8080 in the manager if you override it. Pair OpenVault via
+# OPENVAULT_BASE_URL, or set DMS_API_KEYS there. Never bake keys into this image.
 
 WORKDIR /app
 

--- a/packs/dms/security/api_auth.py
+++ b/packs/dms/security/api_auth.py
@@ -80,8 +80,12 @@ def _caller_from_openvault(token: str) -> Caller | None:
     out = post_json("/api/apikeys/verify", {"token": token}, timeout=3.0)
     if not out or out.get("ok") is not True:
         return None
+    if out.get("valid") is False:
+        return None
     key = out.get("key") if isinstance(out.get("key"), dict) else {}
-    actor = str(key.get("key_id") or key.get("id") or "openvault")
+    actor = str(key.get("key_id") or key.get("id") or out.get("key_id") or "")
+    if not actor:
+        return None
     return Caller(role="viewer", actor=f"ov_{actor}")
 
 

--- a/tests/dms/test_constructor_graph.py
+++ b/tests/dms/test_constructor_graph.py
@@ -337,3 +337,29 @@ def test_ov_token_resolves_via_openvault(monkeypatch):
     assert caller is not None
     assert caller.role == "viewer"
     assert caller.actor == "ov_k1"
+
+
+def test_ov_token_rejects_valid_false(monkeypatch):
+    monkeypatch.setenv("DMS_REFUSE_DEMO_KEYS", "1")
+    monkeypatch.delenv("DMS_API_KEYS", raising=False)
+    monkeypatch.setattr(
+        "CortexOS.integrations.openvault_client.post_json",
+        lambda *a, **k: {"ok": True, "valid": False},
+    )
+    from packs.dms.security.api_auth import resolve_caller
+
+    assert resolve_caller("ov_dead") is None
+
+
+def test_ov_token_accepts_flat_valid_true(monkeypatch):
+    monkeypatch.setenv("DMS_REFUSE_DEMO_KEYS", "1")
+    monkeypatch.delenv("DMS_API_KEYS", raising=False)
+    monkeypatch.setattr(
+        "CortexOS.integrations.openvault_client.post_json",
+        lambda *a, **k: {"ok": True, "valid": True, "key_id": "flat1", "tier": "free"},
+    )
+    from packs.dms.security.api_auth import resolve_caller
+
+    caller = resolve_caller("ov_flat")
+    assert caller is not None
+    assert caller.actor == "ov_flat1"


### PR DESCRIPTION
## Summary
- `ok: true` plus `valid: false` was accepted as a Constructor viewer.
- Resolve also reads flat `key_id` (OpenVault verify shape), not only nested `key`.
- Dockerfile.constructor notes Hyperlift must set `OPENVAULT_BASE_URL` or `DMS_API_KEYS`; no baked keys.

## Test plan
- [x] `pytest tests/dms/test_constructor_graph.py::test_ov_token_rejects_valid_false tests/dms/test_constructor_graph.py::test_ov_token_accepts_flat_valid_true tests/dms/test_constructor_graph.py::test_ov_token_resolves_via_openvault`