### PR TITLE
Tell Hyperlift operators to paste DMS_API_KEYS when OpenVault is absent

### DIFF
--- a/packs/dms/constructor_routes.py
+++ b/packs/dms/constructor_routes.py
@@ -87,7 +87,7 @@ label,input,button{display:block;margin:.5rem 0}input{padding:.5rem;min-width:20
 button{padding:.5rem .8rem;background:#111;color:#e5e5e5;border:1px solid #333}</style>
 </head><body>
 <h1>Cortex</h1>
-<p>Engine path. Paste an OpenVault issued key (ov_...). Keys live in OpenVault, not Cortex.</p>
+<p>Engine path. Paste an ov_ OpenVault key, or an operator key from DMS_API_KEYS. Demo keys are refused. Generate only works when OpenVault is on this machine.</p>
 <form id="login" method="post" action="/cortex/session">
 <label for="key">OpenVault key</label>
 <input id="key" name="key" type="password" autocomplete="off" required/>
@@ -150,7 +150,13 @@ def constructor_issue_key(request: Request, body: IssueKeyBody = IssueKeyBody())
     out = post_json("/api/apikeys", payload, timeout=5.0)
     token = str((out or {}).get("token") or (out or {}).get("token") or "").strip()
     if not out or not token:
-        raise HTTPException(status_code=503, detail="OpenVault did not issue a key")
+        raise HTTPException(
+            status_code=503,
+            detail=(
+                "OpenVault did not issue a key. Generate needs OpenVault on loopback. "
+                "On Hyperlift, set DMS_API_KEYS in the manager and paste that key."
+            ),
+        )
     out = dict(out)
     out["token"] = token
     return out

--- a/tests/dms/test_constructor_graph.py
+++ b/tests/dms/test_constructor_graph.py
@@ -119,6 +119,7 @@ def test_login_open_constructor_redirects_without_key(dms_client):
     login = dms_client.get("/cortex/login")
     assert login.status_code == 200
     assert "OpenVault" in login.text
+    assert "DMS_API_KEYS" in login.text
     assert "Generate OpenVault key" in login.text
     bare = dms_client.get("/cortex/constructor/", follow_redirects=False)
     assert bare.status_code == 303
@@ -313,6 +314,16 @@ def test_issue_key_uses_openvault_token(dms_client, monkeypatch):
     res = dms_client.post("/cortex/constructor/issue-key", json={})
     assert res.status_code == 200
     assert res.json()["token"].startswith("ov_")
+
+
+def test_issue_key_503_tells_hyperlift_to_set_keys(dms_client, monkeypatch):
+    monkeypatch.setattr(
+        "CortexOS.integrations.openvault_client.post_json",
+        lambda *a, **k: None,
+    )
+    res = dms_client.post("/cortex/constructor/issue-key", json={})
+    assert res.status_code == 503
+    assert "DMS_API_KEYS" in res.text
 
 
 def test_demo_keys_rejected_when_refused(monkeypatch):


### PR DESCRIPTION
## Summary
- Login copy: paste ov_ or an operator key from DMS_API_KEYS. Demo keys refused.
- Generate still needs loopback OpenVault. 503 names Hyperlift Manager DMS_API_KEYS.

## Test plan
- [x] pytest login + issue-key 503 + issue-key success