### PR TITLE
Crew ship-gate: govern Netie-AI repos before shipping

### DIFF
--- a/.cursor/AGENTS.md
+++ b/.cursor/AGENTS.md
@@ -10,6 +10,7 @@ See also root `AGENTS.md` and `skill_distill/DISTILL.md`.
 | `Run distill-session against Claude Code` | distill-session |
 | `Distill Cursor multitask + MCP into skill_distill` | distill-session |
 | `Ingest distill captures` | shell: `python scripts/distill_ingest.py` |
+| `Gate the Netie-AI estate before shipping` | crew-ship-gate |
 
 ---
 

--- a/.cursor/skills/crew-ship-gate/SKILL.md
+++ b/.cursor/skills/crew-ship-gate/SKILL.md
@@ -19,6 +19,8 @@ description: Adaptive production ship-gate for github.com/Netie-AI repos via Cor
 | web-only public | Tests + privacy + a11y. |
 | rtl (OpenHBM) | sim/lint/formal. No WCAG. |
 | empty (AIM) | FAIL. Cannot ship. |
+| missing (AirGPT, DMS, chatbot, Pointer, Netie, OMI) | FAIL. Create private Netie-AI origin. |
+| accidental (jian-hong/Vking) | FAIL. Canonical is the org repo. |
 
 File presence is not SOC2/HIPAA/GDPR.
 

--- a/.cursor/skills/crew-ship-gate/SKILL.md
+++ b/.cursor/skills/crew-ship-gate/SKILL.md
@@ -19,7 +19,7 @@ description: Adaptive production ship-gate for github.com/Netie-AI repos via Cor
 | web-only public | Tests + privacy + a11y. |
 | rtl (OpenHBM) | sim/lint/formal. No WCAG. |
 | empty (AIM) | FAIL. Cannot ship. |
-| missing (AirGPT, DMS, chatbot, Pointer, Netie, OMI) | FAIL. Create private Netie-AI origin. |
+| unseen (dms, Netie-KB, Pointer, landing, Space, netie-control, ViKing, RUMA-Houser) | FAIL private_unseen. Grant GitHub App access. 404 is not absence. |
 | accidental (jian-hong/Vking) | FAIL. Canonical is the org repo. |
 
 File presence is not SOC2/HIPAA/GDPR.

--- a/.cursor/skills/crew-ship-gate/SKILL.md
+++ b/.cursor/skills/crew-ship-gate/SKILL.md
@@ -1,0 +1,33 @@
+---
+name: crew-ship-gate
+description: Adaptive production ship-gate for github.com/Netie-AI repos via Cortex Crew. Use when the user says before shipping, production ready, ship gate, SQL injection, WCAG, CI/CD, or govern every repo.
+---
+
+# Crew ship-gate
+
+## Before coding
+
+1. `estate_status` (or read `CortexOS/crew/estate.py` catalog). Surfaces decide domains.
+2. `ship_gate repo=<slug|all>`. Fail closed. Skip is not pass.
+
+## Adaptive
+
+| Kind | Score |
+|------|--------|
+| engine (Cortex) | Security, tests, CI, contract. Demo UI is not WCAG. |
+| keys (OpenVault) | Auth, secrets, rate limit. Not a marketing site. |
+| web-only public | Tests + privacy + a11y. |
+| rtl (OpenHBM) | sim/lint/formal. No WCAG. |
+| empty (AIM) | FAIL. Cannot ship. |
+
+File presence is not SOC2/HIPAA/GDPR.
+
+## Spawn
+
+A sweep is one Gate. Spawn a job-named teammate only for FAIL domains. Do not spawn six specialists. Do not auto-merge. Human is money/decision.
+
+## Verify
+
+```bash
+python -m pytest tests/test_crew -q
+```

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -5,6 +5,7 @@ See `.cursor/AGENTS.md` for full subagent definitions.
 **Quick invoke:**
 - `Use dms-subagent-dispatch to ship the next feature`
 - `Run distill-session` — capture Claude Code / Cursor agentic internals → `skill_distill/`
+- `Gate the Netie-AI estate before shipping`
 - Trace root: `skill_distill/DISTILL.md`
 
 **Sequence:** F1 → F2 → F3 → F4 → F5 → F6 → F7 → V0 → V1 → V2 → V3

--- a/CHANGELOG_DMS.md
+++ b/CHANGELOG_DMS.md
@@ -2,6 +2,14 @@
 
 Agents append one section per shipped feature. Sequential build log.
 
+## Crew production ship-gate (Netie-AI estate) — 2026-08-25
+
+Crew capability templates for Security, Reliability, Infra, Architecture,
+Observability, and Surface, plus a deterministic `ship_gate` over
+github.com/Netie-AI. Surfaces pick domains (RTL skips WCAG; empty AIM fails).
+A six-heading sweep collapses to one Gate. Skip is not pass. File presence
+is not SOC2/HIPAA/GDPR. Tools: `estate_status`, `ship_gate`. Do not auto-merge.
+
 ## Auto-merge perfect PRs — 2026-08-22
 
 CI job `auto-merge` squash-merges a non-draft PR when lint-type-test,

--- a/CHANGELOG_DMS.md
+++ b/CHANGELOG_DMS.md
@@ -10,8 +10,10 @@ github.com/Netie-AI. Surfaces pick domains (RTL skips WCAG; empty AIM fails).
 A six-heading sweep collapses to one Gate. Skip is not pass. File presence
 is not SOC2/HIPAA/GDPR. Tools: `estate_status`, `ship_gate`. Do not auto-merge.
 
-Also scores expected private products that are still local-only (AirGPT, DMS,
-chatbot, Pointer, Netie, OMI) as missing_origin, and flags accidental personal
+Also scores private product repos the operator screenshot confirmed
+(dms, Netie-KB, Pointer, landing, Space, netie-control, ViKing, RUMA-Houser).
+A GitHub 404 from this token is not absence. Grant the GitHub App
+All repositories. Do not build a remote-login box. Flags accidental
 copies on github.com/jian-hong (Vking duplicate, committed venv, optio fork).
 
 ## Auto-merge perfect PRs — 2026-08-22

--- a/CHANGELOG_DMS.md
+++ b/CHANGELOG_DMS.md
@@ -10,6 +10,10 @@ github.com/Netie-AI. Surfaces pick domains (RTL skips WCAG; empty AIM fails).
 A six-heading sweep collapses to one Gate. Skip is not pass. File presence
 is not SOC2/HIPAA/GDPR. Tools: `estate_status`, `ship_gate`. Do not auto-merge.
 
+Also scores expected private products that are still local-only (AirGPT, DMS,
+chatbot, Pointer, Netie, OMI) as missing_origin, and flags accidental personal
+copies on github.com/jian-hong (Vking duplicate, committed venv, optio fork).
+
 ## Auto-merge perfect PRs — 2026-08-22
 
 CI job `auto-merge` squash-merges a non-draft PR when lint-type-test,

--- a/CortexOS/crew/desk.py
+++ b/CortexOS/crew/desk.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from typing import Any
 
-from CortexOS.crew import connectors, github, inbox
+from CortexOS.crew import connectors, estate, github, inbox
 from CortexOS.crew.openvault import cursor_key_status
 
 
@@ -13,6 +13,7 @@ def snapshot(*, uacc_enabled: bool = False, uacc_armed: bool = False) -> dict[st
     prs = github.list_prs()
     mail = inbox.status()
     cursor = cursor_key_status()
+    estate_snap = estate.snapshot()
     return {
         "ok": True,
         "connectors": plugs,
@@ -20,10 +21,12 @@ def snapshot(*, uacc_enabled: bool = False, uacc_armed: bool = False) -> dict[st
         "prs": prs,
         "inbox": mail,
         "cursor": cursor,
+        "estate": estate_snap,
         "law": (
             "Ask in chat to check PRs or mail. Drop files to import. "
             "Human is money and decision authority. Do not auto-merge or auto-send. "
-            "Cursor chats use grok-4.6 (high), not fast. Ticket Runner seats existing writers."
+            "Cursor chats use grok-4.6 (high), not fast. Ticket Runner seats existing writers. "
+            "Before shipping, call ship_gate. File presence is not a compliance certificate."
         ),
     }
 
@@ -52,4 +55,10 @@ def render(snap: dict[str, Any] | None = None) -> str:
     for plug in data.get("connectors") or []:
         state = "connected" if plug.get("connected") else "mapped"
         lines.append(f"- {plug.get('slug')}: {state} ({plug.get('layer')})")
+    estate_snap = data.get("estate") or {}
+    n_estate = estate_snap.get("n") or 0
+    lines.append(
+        f"Estate: {n_estate} {estate_snap.get('org') or 'Netie-AI'} repos. "
+        "Call estate_status for surfaces. Call ship_gate before shipping."
+    )
     return "\n".join(lines)

--- a/CortexOS/crew/detect.py
+++ b/CortexOS/crew/detect.py
@@ -16,6 +16,7 @@ from dataclasses import dataclass
 from typing import Any
 
 from CortexOS.crew import roles
+from CortexOS.crew.estate import PRODUCTION_CAPS
 
 # Word/phrase cues onto capability templates. Names are templates, not agents.
 CUES: dict[str, tuple[str, ...]] = {
@@ -31,7 +32,76 @@ CUES: dict[str, tuple[str, ...]] = {
     ),
     "PRD": ("prd", "requirements doc", "product requirements", "write a spec"),
     "Epic": ("epic", "slice into epics", "sequence the work", "break the prd"),
-    "Gate": ("gate", "invariant", "invariants", "lint-imports", "manifest refusal", "rls-proof"),
+    "Gate": (
+        "gate",
+        "invariant",
+        "invariants",
+        "lint-imports",
+        "manifest refusal",
+        "rls-proof",
+        "before shipping",
+        "production ready",
+        "production essentials",
+        "ship gate",
+        "ship this",
+    ),
+    "Security": (
+        "sql injection",
+        "xss",
+        "csrf",
+        "rbac",
+        "encryption at rest",
+        "secret rotation",
+        "gdpr",
+        "hipaa",
+        "soc 2",
+        "soc2",
+        "input validation",
+    ),
+    "Reliability": (
+        "unit tests",
+        "integration tests",
+        "end-to-end",
+        "load test",
+        "circuit breaker",
+        "graceful degradation",
+        "retry logic",
+        "edge case",
+    ),
+    "Infra": (
+        "ci/cd",
+        "infrastructure as code",
+        "disaster recovery",
+        "kubernetes",
+        "docker",
+        "cdn setup",
+        "database migrations",
+    ),
+    "Architecture": (
+        "connection pooling",
+        "api versioning",
+        "idempotency",
+        "webhook handling",
+        "background jobs",
+        "sharding",
+    ),
+    "Observability": (
+        "distributed tracing",
+        "real user monitoring",
+        "sentry",
+        "vulnerability scanning",
+        "cost optimization",
+        "error tracking",
+    ),
+    "Surface": (
+        "wcag",
+        "accessibility",
+        "internationalization",
+        "i18n",
+        "privacy policy",
+        "feature flags",
+        "a/b testing",
+    ),
     "Marketing": (
         "outbound",
         "founder voice",
@@ -97,6 +167,33 @@ _VERIFY = (
     "gate this",
     "against invariants",
 )
+
+_SHIP = (
+    "before shipping",
+    "production ready",
+    "production essentials",
+    "ship gate",
+    "ship this",
+)
+
+
+def _collapse_production_sweep(text: str, caps: tuple[str, ...]) -> tuple[str, ...]:
+    """A production sweep is one Gate, not six specialists.
+
+    One or two named domains stay (SQL injection, WCAG). Three or more
+    production headings, or explicit ship-gate wording with a sweep,
+    collapse to Gate so max_agents_per_space is not blown.
+    """
+    prod = tuple(c for c in caps if c in PRODUCTION_CAPS)
+    others = tuple(c for c in caps if c not in PRODUCTION_CAPS)
+    sweep = _hit(text, _SHIP) and len(prod) >= 2
+    if sweep or len(prod) >= 3:
+        if "Gate" in others:
+            return others
+        return ("Gate",) + others
+    if _hit(text, _SHIP) and "Gate" not in caps:
+        return ("Gate",) + caps
+    return caps
 
 
 @dataclass(frozen=True)
@@ -198,6 +295,7 @@ def plan(text: str) -> Detected:
         )
 
     caps = match_capabilities(raw)
+    caps = _collapse_production_sweep(raw, caps)
     verify = _hit(raw, _VERIFY)
     rec = None
     try:

--- a/CortexOS/crew/estate.py
+++ b/CortexOS/crew/estate.py
@@ -41,6 +41,11 @@ SURFACE_DOMAINS: dict[str, tuple[str, ...]] = {
     "ci_tool": ("Reliability", "Infra"),
     "manufacturing": ("Security", "Reliability", "Observability"),
     "crew": ("Security", "Reliability"),
+    "chat": ("Security", "Reliability", "Infra", "Surface", "Observability"),
+    "vertical": ("Security", "Reliability", "Infra", "Architecture", "Observability"),
+    "missing": (),
+    "accidental": ("Security",),
+    "fork": ("Architecture",),
 }
 
 
@@ -69,10 +74,19 @@ class Fingerprint:
     has_sentry: bool = False
     has_a11y: bool = False
     empty: bool = False
+    placement: str = "canonical"
     notes: tuple[str, ...] = ()
 
     @property
+    def owner(self) -> str:
+        if "/" in self.full_name:
+            return self.full_name.split("/", 1)[0]
+        return ORG_DEFAULT
+
+    @property
     def kind(self) -> str:
+        if self.placement in {"missing", "accidental", "fork"}:
+            return self.placement
         if self.empty:
             return "empty"
         for name in (
@@ -83,6 +97,8 @@ class Fingerprint:
             "news",
             "ci_tool",
             "manufacturing",
+            "chat",
+            "vertical",
             "docs",
             "web",
             "api",
@@ -120,7 +136,8 @@ CATALOG: tuple[Fingerprint, ...] = (
         notes=(
             "Local-first engine. Demo UI is not a public marketing site.",
             "SOC2/HIPAA/GDPR: not certified by file presence.",
-            "Netie-KB is not a repo in this org as of 2026-08-25.",
+            "Netie-KB / AirGPT / DMS / chatbot / Pointer / OMI are not GitHub repos in this org.",
+            "Create them under Netie-AI. Do not leave SoT on D:\\ or github.com/jian-hong.",
         ),
     ),
     _fp(
@@ -177,7 +194,10 @@ CATALOG: tuple[Fingerprint, ...] = (
         language="Python",
         surfaces=("docs",),
         has_readme=False,
-        notes=("Plan/docs tree. No .github/workflows on 2026-08-25.",),
+        notes=(
+            "Plan/docs tree. No .github/workflows on 2026-08-25.",
+            "Public personal copy also at jian-hong/Vking (older branch run-0003). Canonical is this repo.",
+        ),
     ),
     _fp(
         slug="OpenForge",
@@ -243,7 +263,10 @@ CATALOG: tuple[Fingerprint, ...] = (
         language="",
         surfaces=("empty",),
         empty=True,
-        notes=("Empty repo (LinkedIn Alternative). Cannot ship.",),
+        notes=(
+            "Empty repo (LinkedIn Alternative). Cannot ship.",
+            "jian-hong/aim is a 2025 TypeScript app, not this tree. Name collision only.",
+        ),
     ),
     _fp(
         slug="Vertex",
@@ -258,6 +281,104 @@ CATALOG: tuple[Fingerprint, ...] = (
         has_ci=True,
         notes=("Precision manufacturing samples. Observability compose exists.",),
     ),
+    # Expected private/local products. 404 on GitHub 2026-08-25. Do not ship from D:\ only.
+    _fp(
+        slug="AirGPT",
+        full_name="Netie-AI/AirGPT",
+        private=True,
+        language="Python",
+        surfaces=("missing", "chat"),
+        placement="missing",
+        notes=(
+            "Host shell. Local D:\\AirGPT. Not on GitHub (404). STATUS: initial commit pending.",
+            "Create Netie-AI/AirGPT private. Do not push to jian-hong.",
+        ),
+    ),
+    _fp(
+        slug="DMS",
+        full_name="Netie-AI/DMS",
+        private=True,
+        language="Python",
+        surfaces=("missing", "vertical"),
+        placement="missing",
+        notes=(
+            "Consumer product. Local D:\\DMS. Planned origin github.com/Netie-AI/DMS.git. 404 today.",
+            "Create the private org repo before shipping Spaces to a customer.",
+        ),
+    ),
+    _fp(
+        slug="chatbot",
+        full_name="Netie-AI/chatbot",
+        private=True,
+        language="",
+        surfaces=("missing", "chat"),
+        placement="missing",
+        notes=("CORTEX_WS_CHATBOT -> D:\\chatbot. Not on GitHub. Normal-chat product has no origin.",),
+    ),
+    _fp(
+        slug="Pointer",
+        full_name="Netie-AI/Pointer",
+        private=True,
+        language="",
+        surfaces=("missing",),
+        placement="missing",
+        notes=("Act/computer-control client. Local D:\\Pointer. Not on GitHub.",),
+    ),
+    _fp(
+        slug="Netie",
+        full_name="Netie-AI/Netie",
+        private=True,
+        language="",
+        surfaces=("missing",),
+        placement="missing",
+        notes=("Netie KB / orchestration. Local D:\\Netie. Netie-KB is not a repo in the org.",),
+    ),
+    _fp(
+        slug="OMI",
+        full_name="Netie-AI/OMI",
+        private=True,
+        language="",
+        surfaces=("missing",),
+        placement="missing",
+        notes=("OMI router. Local D:\\OMI. Not on GitHub.",),
+    ),
+    # Accidental stores on github.com/jian-hong (founder personal). Token cannot see private there.
+    _fp(
+        slug="Vking-personal",
+        full_name="jian-hong/Vking",
+        private=False,
+        language="Python",
+        surfaces=("accidental", "docs"),
+        placement="accidental",
+        notes=(
+            "Public personal duplicate of Netie-AI/VKing. Same cortex SKILL card. Branch run-0003 vs org run-0004.",
+            "Archive or make private. Canonical is Netie-AI/VKing. Do not ship from jian-hong.",
+        ),
+    ),
+    _fp(
+        slug="Python_Automation_JH",
+        full_name="jian-hong/Python_Automation_JH",
+        private=False,
+        language="Python",
+        surfaces=("accidental",),
+        placement="accidental",
+        notes=(
+            "Windows venv/ committed (~8809 files). .gitignore does not list venv.",
+            "Not a Cortex copy. Accidental store. Do not treat as a Netie product origin.",
+        ),
+    ),
+    _fp(
+        slug="optio",
+        full_name="jian-hong/optio",
+        private=False,
+        language="",
+        surfaces=("fork",),
+        placement="fork",
+        notes=(
+            "Fork of a third-party agent-swarm orchestrator. Do not merge into Cortex. Cortex is the loop.",
+            "A token-shaped file is committed. Operator must rotate if it was real. Crew does not print it.",
+        ),
+    ),
 )
 
 
@@ -265,13 +386,19 @@ def by_slug(name: str) -> Fingerprint | None:
     key = name.strip()
     if not key:
         return None
-    if "/" in key:
-        key = key.split("/", 1)[1]
     low = key.lower()
     for row in CATALOG:
-        if row.slug.lower() == low:
+        if row.full_name.lower() == low:
             return row
-    return None
+    tail = low.split("/", 1)[-1]
+    hits = [row for row in CATALOG if row.slug.lower() == tail]
+    if not hits:
+        # Allow AirGPT via "airgpt" even when slug has no hyphen variants.
+        hits = [row for row in CATALOG if row.slug.lower().replace("-", "") == tail.replace("-", "")]
+    if not hits:
+        return None
+    org = [h for h in hits if h.full_name.lower().startswith("netie-ai/")]
+    return (org or hits)[0]
 
 
 def required_domains(fp: Fingerprint) -> tuple[str, ...]:
@@ -291,9 +418,11 @@ def public_row(fp: Fingerprint) -> dict[str, Any]:
     return {
         "slug": fp.slug,
         "full_name": fp.full_name,
+        "owner": fp.owner,
         "private": fp.private,
         "language": fp.language,
         "kind": fp.kind,
+        "placement": fp.placement,
         "surfaces": list(fp.surfaces),
         "domains": list(required_domains(fp)),
         "empty": fp.empty,
@@ -321,9 +450,15 @@ def snapshot(*, live: bool | None = None, org: str | None = None) -> dict[str, A
         live_detail = str(listed.get("detail") or "")
         live_names = [str(r.get("name") or "") for r in (listed.get("repos") or []) if r.get("name")]
     rows = [public_row(fp) for fp in CATALOG]
-    catalog_slugs = {fp.slug for fp in CATALOG}
+    catalog_slugs = {fp.slug for fp in CATALOG if fp.owner == org_name}
     unknown = [n for n in live_names if n not in catalog_slugs]
-    missing = [fp.slug for fp in CATALOG if live_names and fp.slug not in live_names]
+    missing = [
+        fp.slug
+        for fp in CATALOG
+        if fp.placement == "canonical" and fp.owner == org_name and live_names and fp.slug not in live_names
+    ]
+    accidental = [public_row(fp) for fp in CATALOG if fp.placement == "accidental"]
+    expected_missing = [public_row(fp) for fp in CATALOG if fp.placement == "missing"]
     return {
         "ok": True,
         "org": org_name,
@@ -332,12 +467,16 @@ def snapshot(*, live: bool | None = None, org: str | None = None) -> dict[str, A
         "live_names": live_names,
         "unknown_live": unknown,
         "missing_from_live": missing,
+        "accidental": accidental,
+        "expected_missing": expected_missing,
         "probed": "2026-08-25",
         "detail": live_detail,
+        "private_jian_hong": "invisible to this token; only public jian-hong repos were scanned",
         "law": (
             "Adaptive ship-gate. Detect the job. Spawn Gate for a sweep, not one "
             "specialist per heading. File presence is not a compliance certificate. "
-            "Human is money/decision. Do not auto-merge."
+            "AirGPT/DMS/chatbot/Pointer/Netie/OMI must live under Netie-AI, not D:\\ only "
+            "and not github.com/jian-hong. Human is money/decision. Do not auto-merge."
         ),
     }
 
@@ -354,6 +493,19 @@ def render(snap: dict[str, Any] | None = None) -> str:
     unknown = data.get("unknown_live") or []
     if unknown:
         lines.append("Live repos not in catalog: " + ", ".join(unknown))
+    accidental = data.get("accidental") or []
+    if accidental:
+        lines.append("Accidental personal copies:")
+        for row in accidental:
+            lines.append(f"- {row.get('full_name')} [{row.get('kind')}]")
+    expected = data.get("expected_missing") or []
+    if expected:
+        lines.append("Expected private products missing from GitHub:")
+        for row in expected:
+            lines.append(f"- {row.get('full_name')} (create under Netie-AI)")
+    jh = data.get("private_jian_hong")
+    if jh:
+        lines.append("jian-hong private: " + str(jh))
     for row in data.get("repos") or []:
         domains = ",".join(row.get("domains") or []) or "(none)"
         empty = " EMPTY" if row.get("empty") else ""

--- a/CortexOS/crew/estate.py
+++ b/CortexOS/crew/estate.py
@@ -1,0 +1,364 @@
+"""Netie-AI GitHub estate: adaptive repo catalog for crew ship-gate.
+
+Live `gh` is optional. The static catalog is the 2026-08-25 probe of
+github.com/Netie-AI so a ship decision still works when CREW_LIVE_PROBES=0.
+Missing evidence is never a pass. File presence is not a SOC 2 / HIPAA /
+GDPR certificate.
+
+Crew does not clone every repo. Surfaces decide which production domains
+apply. RTL does not get WCAG. Empty repos cannot ship.
+"""
+
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass, replace
+from typing import Any
+
+ORG_DEFAULT = "Netie-AI"
+
+# Capability template names in roles.py. Gate is the sweep owner.
+PRODUCTION_CAPS: tuple[str, ...] = (
+    "Security",
+    "Reliability",
+    "Infra",
+    "Architecture",
+    "Observability",
+    "Surface",
+)
+
+# Surface -> production domains that must be scored (skip the rest).
+SURFACE_DOMAINS: dict[str, tuple[str, ...]] = {
+    "empty": (),
+    "docs": ("Reliability",),
+    "web": ("Security", "Reliability", "Infra", "Surface", "Observability"),
+    "api": ("Security", "Reliability", "Infra", "Architecture", "Observability"),
+    "engine": ("Security", "Reliability", "Infra", "Architecture", "Observability"),
+    "keys": ("Security", "Reliability", "Infra", "Observability"),
+    "rtl": ("Reliability", "Infra", "Architecture"),
+    "analog": ("Reliability", "Infra"),
+    "news": ("Security", "Reliability", "Infra", "Surface", "Observability"),
+    "ci_tool": ("Reliability", "Infra"),
+    "manufacturing": ("Security", "Reliability", "Observability"),
+    "crew": ("Security", "Reliability"),
+}
+
+
+@dataclass(frozen=True)
+class Fingerprint:
+    slug: str
+    full_name: str
+    private: bool
+    language: str
+    surfaces: tuple[str, ...]
+    workflows: tuple[str, ...] = ()
+    has_tests: bool = False
+    has_dockerfile: bool = False
+    has_compose: bool = False
+    has_sops: bool = False
+    has_secrets_scan: bool = False
+    has_auth: bool = False
+    has_rbac: bool = False
+    has_rate_limit: bool = False
+    has_csrf: bool = False
+    has_privacy_page: bool = False
+    has_license: bool = False
+    has_readme: bool = False
+    has_ci: bool = False
+    has_dependabot: bool = False
+    has_sentry: bool = False
+    has_a11y: bool = False
+    empty: bool = False
+    notes: tuple[str, ...] = ()
+
+    @property
+    def kind(self) -> str:
+        if self.empty:
+            return "empty"
+        for name in (
+            "engine",
+            "keys",
+            "rtl",
+            "analog",
+            "news",
+            "ci_tool",
+            "manufacturing",
+            "docs",
+            "web",
+            "api",
+        ):
+            if name in self.surfaces:
+                return name
+        return "docs"
+
+
+def _fp(**kwargs: Any) -> Fingerprint:
+    return Fingerprint(**kwargs)
+
+
+# Measured 2026-08-25 via gh api against github.com/Netie-AI. Refresh with
+# estate.snapshot(live=True) when CREW_LIVE_PROBES=1.
+CATALOG: tuple[Fingerprint, ...] = (
+    _fp(
+        slug="Cortex",
+        full_name="Netie-AI/Cortex",
+        private=True,
+        language="Python",
+        surfaces=("engine", "api", "web", "crew"),
+        workflows=("ci.yml", "release.yml", "rls.yml", "secrets.yml", "test.yml"),
+        has_tests=True,
+        has_dockerfile=True,
+        has_compose=True,
+        has_sops=True,
+        has_secrets_scan=True,
+        has_auth=True,
+        has_rbac=True,
+        has_rate_limit=True,
+        has_license=True,
+        has_readme=True,
+        has_ci=True,
+        notes=(
+            "Local-first engine. Demo UI is not a public marketing site.",
+            "SOC2/HIPAA/GDPR: not certified by file presence.",
+            "Netie-KB is not a repo in this org as of 2026-08-25.",
+        ),
+    ),
+    _fp(
+        slug="constructor",
+        full_name="Netie-AI/constructor",
+        private=False,
+        language="JavaScript",
+        surfaces=("web",),
+        workflows=("pages.yml",),
+        has_ci=True,
+        has_readme=True,
+        notes=("Public GitHub Pages app. No tests directory on 2026-08-25.",),
+    ),
+    _fp(
+        slug="OpenVault",
+        full_name="Netie-AI/OpenVault",
+        private=False,
+        language="Python",
+        surfaces=("keys", "api", "web"),
+        workflows=("ci.yml",),
+        has_tests=True,
+        has_dockerfile=True,
+        has_compose=True,
+        has_secrets_scan=True,
+        has_auth=True,
+        has_rate_limit=True,
+        has_csrf=True,
+        has_license=True,
+        has_readme=True,
+        has_ci=True,
+        notes=("Key custody. Secret reveal is a gate, not a pass-through.",),
+    ),
+    _fp(
+        slug="Cassandra",
+        full_name="Netie-AI/Cassandra",
+        private=False,
+        language="Python",
+        surfaces=("news", "api", "web"),
+        workflows=("ci.yml", "deploy.yml"),
+        has_tests=True,
+        has_dockerfile=True,
+        has_compose=True,
+        has_auth=True,
+        has_rate_limit=True,
+        has_privacy_page=True,
+        has_readme=True,
+        has_ci=True,
+        notes=("News sentiment. Privacy page present. Not a trading-prod claim.",),
+    ),
+    _fp(
+        slug="VKing",
+        full_name="Netie-AI/VKing",
+        private=False,
+        language="Python",
+        surfaces=("docs",),
+        has_readme=False,
+        notes=("Plan/docs tree. No .github/workflows on 2026-08-25.",),
+    ),
+    _fp(
+        slug="OpenForge",
+        full_name="Netie-AI/OpenForge",
+        private=False,
+        language="Python",
+        surfaces=("analog",),
+        workflows=("ci.yml",),
+        has_tests=True,
+        has_license=True,
+        has_readme=True,
+        has_ci=True,
+        notes=("Analog CAD/research. Not a user-facing web app.",),
+    ),
+    _fp(
+        slug="AnalogCrawler",
+        full_name="Netie-AI/AnalogCrawler",
+        private=False,
+        language="Python",
+        surfaces=("analog",),
+        has_compose=True,
+        has_readme=True,
+        notes=(
+            "Lab crawler. No GitHub workflows on 2026-08-25.",
+            "A surveillance/ path exists; ship-gate does not review or enable it.",
+        ),
+    ),
+    _fp(
+        slug="OpenHBM",
+        full_name="Netie-AI/OpenHBM",
+        private=False,
+        language="SystemVerilog",
+        surfaces=("rtl",),
+        workflows=(
+            "agent-eval.yml",
+            "asic.yml",
+            "chiplet.yml",
+            "formal.yml",
+            "fpga.yml",
+            "lint.yml",
+            "sim.yml",
+        ),
+        has_tests=True,
+        has_license=True,
+        has_readme=True,
+        has_ci=True,
+        notes=("RTL/IP. WCAG/SEO do not apply. Sim/lint/formal are the gate.",),
+    ),
+    _fp(
+        slug="CI-Doctor",
+        full_name="Netie-AI/CI-Doctor",
+        private=False,
+        language="Python",
+        surfaces=("ci_tool",),
+        has_license=True,
+        has_readme=False,
+        notes=("CI fixer package. No org workflows of its own on 2026-08-25.",),
+    ),
+    _fp(
+        slug="AIM",
+        full_name="Netie-AI/AIM",
+        private=False,
+        language="",
+        surfaces=("empty",),
+        empty=True,
+        notes=("Empty repo (LinkedIn Alternative). Cannot ship.",),
+    ),
+    _fp(
+        slug="Vertex",
+        full_name="Netie-AI/Vertex",
+        private=False,
+        language="Python",
+        surfaces=("manufacturing",),
+        workflows=("python-lint.yml",),
+        has_dockerfile=True,
+        has_compose=True,
+        has_readme=True,
+        has_ci=True,
+        notes=("Precision manufacturing samples. Observability compose exists.",),
+    ),
+)
+
+
+def by_slug(name: str) -> Fingerprint | None:
+    key = name.strip()
+    if not key:
+        return None
+    if "/" in key:
+        key = key.split("/", 1)[1]
+    low = key.lower()
+    for row in CATALOG:
+        if row.slug.lower() == low:
+            return row
+    return None
+
+
+def required_domains(fp: Fingerprint) -> tuple[str, ...]:
+    """Union of domains implied by surfaces. Empty repo: none (overall fail)."""
+    found: list[str] = []
+    seen: set[str] = set()
+    for surface in fp.surfaces:
+        for domain in SURFACE_DOMAINS.get(surface, ()):
+            if domain in seen:
+                continue
+            seen.add(domain)
+            found.append(domain)
+    return tuple(found)
+
+
+def public_row(fp: Fingerprint) -> dict[str, Any]:
+    return {
+        "slug": fp.slug,
+        "full_name": fp.full_name,
+        "private": fp.private,
+        "language": fp.language,
+        "kind": fp.kind,
+        "surfaces": list(fp.surfaces),
+        "domains": list(required_domains(fp)),
+        "empty": fp.empty,
+        "notes": list(fp.notes),
+        "workflows": list(fp.workflows),
+    }
+
+
+def overlay_live_workflows(fp: Fingerprint, workflows: tuple[str, ...]) -> Fingerprint:
+    if not workflows:
+        return fp
+    return replace(fp, workflows=workflows, has_ci=True)
+
+
+def snapshot(*, live: bool | None = None, org: str | None = None) -> dict[str, Any]:
+    """Estate view. Live gh names are extra; catalog remains the scored set."""
+    use_live = live if live is not None else os.environ.get("CREW_LIVE_PROBES", "1") != "0"
+    org_name = org or os.environ.get("CREW_GH_ORG", ORG_DEFAULT)
+    live_names: list[str] = []
+    live_detail = "CREW_LIVE_PROBES=0; static catalog only"
+    if use_live:
+        from CortexOS.crew import github
+
+        listed = github.list_org_repos(org_name)
+        live_detail = str(listed.get("detail") or "")
+        live_names = [str(r.get("name") or "") for r in (listed.get("repos") or []) if r.get("name")]
+    rows = [public_row(fp) for fp in CATALOG]
+    catalog_slugs = {fp.slug for fp in CATALOG}
+    unknown = [n for n in live_names if n not in catalog_slugs]
+    missing = [fp.slug for fp in CATALOG if live_names and fp.slug not in live_names]
+    return {
+        "ok": True,
+        "org": org_name,
+        "n": len(rows),
+        "repos": rows,
+        "live_names": live_names,
+        "unknown_live": unknown,
+        "missing_from_live": missing,
+        "probed": "2026-08-25",
+        "detail": live_detail,
+        "law": (
+            "Adaptive ship-gate. Detect the job. Spawn Gate for a sweep, not one "
+            "specialist per heading. File presence is not a compliance certificate. "
+            "Human is money/decision. Do not auto-merge."
+        ),
+    }
+
+
+def render(snap: dict[str, Any] | None = None) -> str:
+    data = snap or snapshot()
+    lines = [
+        str(data.get("law") or ""),
+        f"Org: {data.get('org')}  catalog={data.get('n')}  probed={data.get('probed')}",
+    ]
+    detail = str(data.get("detail") or "")
+    if detail:
+        lines.append(detail)
+    unknown = data.get("unknown_live") or []
+    if unknown:
+        lines.append("Live repos not in catalog: " + ", ".join(unknown))
+    for row in data.get("repos") or []:
+        domains = ",".join(row.get("domains") or []) or "(none)"
+        empty = " EMPTY" if row.get("empty") else ""
+        lines.append(
+            f"- {row.get('full_name')} [{row.get('kind')}]{empty} "
+            f"lang={row.get('language') or '-'} domains={domains}"
+        )
+    return "\n".join(lines)

--- a/CortexOS/crew/estate.py
+++ b/CortexOS/crew/estate.py
@@ -44,6 +44,7 @@ SURFACE_DOMAINS: dict[str, tuple[str, ...]] = {
     "chat": ("Security", "Reliability", "Infra", "Surface", "Observability"),
     "vertical": ("Security", "Reliability", "Infra", "Architecture", "Observability"),
     "missing": (),
+    "unseen": (),
     "accidental": ("Security",),
     "fork": ("Architecture",),
 }
@@ -85,7 +86,7 @@ class Fingerprint:
 
     @property
     def kind(self) -> str:
-        if self.placement in {"missing", "accidental", "fork"}:
+        if self.placement in {"missing", "unseen", "accidental", "fork"}:
             return self.placement
         if self.empty:
             return "empty"
@@ -136,8 +137,9 @@ CATALOG: tuple[Fingerprint, ...] = (
         notes=(
             "Local-first engine. Demo UI is not a public marketing site.",
             "SOC2/HIPAA/GDPR: not certified by file presence.",
-            "Netie-KB / AirGPT / DMS / chatbot / Pointer / OMI are not GitHub repos in this org.",
-            "Create them under Netie-AI. Do not leave SoT on D:\\ or github.com/jian-hong.",
+            "Private Netie-AI product repos exist (operator screenshot 2026-08-25).",
+            "This token gets GitHub 404 on private repos it cannot read. That is not absence.",
+            "Grant the GitHub App 'All repositories' (or select dms, Netie-KB, Pointer, ...).",
         ),
     ),
     _fp(
@@ -281,29 +283,107 @@ CATALOG: tuple[Fingerprint, ...] = (
         has_ci=True,
         notes=("Precision manufacturing samples. Observability compose exists.",),
     ),
-    # Expected private/local products. 404 on GitHub 2026-08-25. Do not ship from D:\ only.
+    # Private product repos. Operator screenshot 2026-08-25. This token still 404s them.
+    _fp(
+        slug="dms",
+        full_name="Netie-AI/dms",
+        private=True,
+        language="Python",
+        surfaces=("unseen", "vertical"),
+        placement="unseen",
+        notes=(
+            "Operator screenshot: Netie DMS -- ChatGPT for Excel/databases (Cortex consumer).",
+            "This token 404s private repos. Grant GitHub App access. Do not treat 404 as missing.",
+        ),
+    ),
+    _fp(
+        slug="Netie-KB",
+        full_name="Netie-AI/Netie-KB",
+        private=True,
+        language="Python",
+        surfaces=("unseen",),
+        placement="unseen",
+        notes=("Operator screenshot: Netie-KB exists (Python). Token cannot read it.",),
+    ),
+    _fp(
+        slug="Netie",
+        full_name="Netie-AI/Netie",
+        private=True,
+        language="Python",
+        surfaces=("unseen",),
+        placement="unseen",
+        notes=("Operator screenshot: Netie exists (Python). Orchestration KB home.",),
+    ),
+    _fp(
+        slug="Pointer",
+        full_name="Netie-AI/Pointer",
+        private=True,
+        language="JavaScript",
+        surfaces=("unseen",),
+        placement="unseen",
+        notes=("Operator screenshot: Pointer exists (JavaScript). Act/computer-control client.",),
+    ),
+    _fp(
+        slug="landing",
+        full_name="Netie-AI/landing",
+        private=True,
+        language="HTML",
+        surfaces=("unseen", "web"),
+        placement="unseen",
+        notes=("Operator screenshot: landing exists (HTML). Constructor ticket landing#9.",),
+    ),
+    _fp(
+        slug="Space",
+        full_name="Netie-AI/Space",
+        private=True,
+        language="JavaScript",
+        surfaces=("unseen", "web"),
+        placement="unseen",
+        notes=("Operator screenshot: Space exists (JavaScript). DMS Spaces product surface.",),
+    ),
+    _fp(
+        slug="netie-control",
+        full_name="Netie-AI/netie-control",
+        private=True,
+        language="Python",
+        surfaces=("unseen", "crew"),
+        placement="unseen",
+        notes=(
+            "Operator screenshot: operator shell Plane 4. Displays and launches; holds no keys, decides no route.",
+            "Not a key vault. OpenVault holds keys.",
+        ),
+    ),
+    _fp(
+        slug="RUMA-Houser",
+        full_name="Netie-AI/RUMA-Houser",
+        private=True,
+        language="",
+        surfaces=("unseen",),
+        placement="unseen",
+        notes=("Operator screenshot: RUMA-Houser exists. Do not modify packs/ruma unless asked.",),
+    ),
+    _fp(
+        slug="ViKing",
+        full_name="Netie-AI/ViKing",
+        private=True,
+        language="Python",
+        surfaces=("unseen",),
+        placement="unseen",
+        notes=(
+            "Operator screenshot: ViKing exists private. Distinct from public Netie-AI/VKing.",
+            "jian-hong/Vking is still an accidental public copy of the public VKing tree.",
+        ),
+    ),
     _fp(
         slug="AirGPT",
         full_name="Netie-AI/AirGPT",
         private=True,
         language="Python",
-        surfaces=("missing", "chat"),
-        placement="missing",
+        surfaces=("unseen", "chat"),
+        placement="unseen",
         notes=(
-            "Host shell. Local D:\\AirGPT. Not on GitHub (404). STATUS: initial commit pending.",
-            "Create Netie-AI/AirGPT private. Do not push to jian-hong.",
-        ),
-    ),
-    _fp(
-        slug="DMS",
-        full_name="Netie-AI/DMS",
-        private=True,
-        language="Python",
-        surfaces=("missing", "vertical"),
-        placement="missing",
-        notes=(
-            "Consumer product. Local D:\\DMS. Planned origin github.com/Netie-AI/DMS.git. 404 today.",
-            "Create the private org repo before shipping Spaces to a customer.",
+            "Not in the 2026-08-25 screenshot. Local D:\\AirGPT may still be the SoT.",
+            "If it is a private org repo, this token cannot see it. Grant GitHub App access.",
         ),
     ),
     _fp(
@@ -311,36 +391,18 @@ CATALOG: tuple[Fingerprint, ...] = (
         full_name="Netie-AI/chatbot",
         private=True,
         language="",
-        surfaces=("missing", "chat"),
-        placement="missing",
-        notes=("CORTEX_WS_CHATBOT -> D:\\chatbot. Not on GitHub. Normal-chat product has no origin.",),
-    ),
-    _fp(
-        slug="Pointer",
-        full_name="Netie-AI/Pointer",
-        private=True,
-        language="",
-        surfaces=("missing",),
-        placement="missing",
-        notes=("Act/computer-control client. Local D:\\Pointer. Not on GitHub.",),
-    ),
-    _fp(
-        slug="Netie",
-        full_name="Netie-AI/Netie",
-        private=True,
-        language="",
-        surfaces=("missing",),
-        placement="missing",
-        notes=("Netie KB / orchestration. Local D:\\Netie. Netie-KB is not a repo in the org.",),
+        surfaces=("unseen", "chat"),
+        placement="unseen",
+        notes=("CORTEX_WS_CHATBOT. Not in the screenshot. Token cannot confirm presence.",),
     ),
     _fp(
         slug="OMI",
         full_name="Netie-AI/OMI",
         private=True,
         language="",
-        surfaces=("missing",),
-        placement="missing",
-        notes=("OMI router. Local D:\\OMI. Not on GitHub.",),
+        surfaces=("unseen",),
+        placement="unseen",
+        notes=("CORTEX_WS_OMI. Not in the screenshot. Token cannot confirm presence.",),
     ),
     # Accidental stores on github.com/jian-hong (founder personal). Token cannot see private there.
     _fp(
@@ -459,6 +521,7 @@ def snapshot(*, live: bool | None = None, org: str | None = None) -> dict[str, A
     ]
     accidental = [public_row(fp) for fp in CATALOG if fp.placement == "accidental"]
     expected_missing = [public_row(fp) for fp in CATALOG if fp.placement == "missing"]
+    expected_unseen = [public_row(fp) for fp in CATALOG if fp.placement == "unseen"]
     return {
         "ok": True,
         "org": org_name,
@@ -469,14 +532,16 @@ def snapshot(*, live: bool | None = None, org: str | None = None) -> dict[str, A
         "missing_from_live": missing,
         "accidental": accidental,
         "expected_missing": expected_missing,
+        "expected_unseen": expected_unseen,
         "probed": "2026-08-25",
         "detail": live_detail,
         "private_jian_hong": "invisible to this token; only public jian-hong repos were scanned",
         "law": (
             "Adaptive ship-gate. Detect the job. Spawn Gate for a sweep, not one "
             "specialist per heading. File presence is not a compliance certificate. "
-            "AirGPT/DMS/chatbot/Pointer/Netie/OMI must live under Netie-AI, not D:\\ only "
-            "and not github.com/jian-hong. Human is money/decision. Do not auto-merge."
+            "A GitHub 404 from this token is not proof a private repo is missing. "
+            "Grant the GitHub App All repositories. Do not build a remote-login box. "
+            "OpenVault holds keys. Human is money/decision. Do not auto-merge."
         ),
     }
 
@@ -498,10 +563,15 @@ def render(snap: dict[str, Any] | None = None) -> str:
         lines.append("Accidental personal copies:")
         for row in accidental:
             lines.append(f"- {row.get('full_name')} [{row.get('kind')}]")
-    expected = data.get("expected_missing") or []
+    expected = data.get("expected_unseen") or []
     if expected:
-        lines.append("Expected private products missing from GitHub:")
+        lines.append("Private repos this token cannot read (operator confirmed they exist):")
         for row in expected:
+            lines.append(f"- {row.get('full_name')} (grant GitHub App access)")
+    missing_rows = data.get("expected_missing") or []
+    if missing_rows:
+        lines.append("Expected products with no GitHub origin:")
+        for row in missing_rows:
             lines.append(f"- {row.get('full_name')} (create under Netie-AI)")
     jh = data.get("private_jian_hong")
     if jh:

--- a/CortexOS/crew/github.py
+++ b/CortexOS/crew/github.py
@@ -40,6 +40,69 @@ def _repos() -> list[str]:
     return seen
 
 
+def list_org_repos(org: str | None = None, *, runner: RunFn | None = None) -> dict[str, Any]:
+    """List GitHub repos in CREW_GH_ORG (default Netie-AI). Read only."""
+    if os.environ.get("CREW_LIVE_PROBES", "1") == "0":
+        return {
+            "ok": False,
+            "detail": "CREW_LIVE_PROBES=0",
+            "repos": [],
+            "org": org or os.environ.get("CREW_GH_ORG", "Netie-AI"),
+        }
+    run = runner or _run
+    org_name = (org or os.environ.get("CREW_GH_ORG") or "Netie-AI").strip() or "Netie-AI"
+    argv = [
+        "gh",
+        "repo",
+        "list",
+        org_name,
+        "--limit",
+        "100",
+        "--json",
+        "name,description,isPrivate,url,updatedAt,primaryLanguage",
+    ]
+    try:
+        result = run(argv, timeout=20)
+    except FileNotFoundError:
+        return {"ok": False, "detail": "gh not installed", "repos": [], "org": org_name}
+    except (OSError, subprocess.TimeoutExpired) as exc:
+        return {"ok": False, "detail": type(exc).__name__, "repos": [], "org": org_name}
+    if result.returncode != 0:
+        return {
+            "ok": False,
+            "detail": (result.stderr or result.stdout or "gh failed")[:400],
+            "repos": [],
+            "org": org_name,
+        }
+    try:
+        rows = json.loads(result.stdout or "[]")
+    except ValueError:
+        return {"ok": False, "detail": "invalid json", "repos": [], "org": org_name}
+    repos: list[dict[str, Any]] = []
+    for row in rows if isinstance(rows, list) else []:
+        if not isinstance(row, dict):
+            continue
+        lang = row.get("primaryLanguage") or {}
+        lang_name = lang.get("name") if isinstance(lang, dict) else ""
+        repos.append(
+            {
+                "name": row.get("name"),
+                "description": row.get("description") or "",
+                "private": bool(row.get("isPrivate")),
+                "url": row.get("url") or "",
+                "updated": row.get("updatedAt") or "",
+                "language": lang_name or "",
+            }
+        )
+    return {
+        "ok": True,
+        "detail": "",
+        "repos": repos,
+        "org": org_name,
+        "law": "Report in chat. Do not auto-merge. Adaptive catalog lives in crew.estate.",
+    }
+
+
 def list_prs(limit: int = 20, *, runner: RunFn | None = None) -> dict[str, Any]:
     """List open PRs for CLAIMS repos (or CREW_GH_REPOS). Never merges."""
     if os.environ.get("CREW_LIVE_PROBES", "1") == "0":

--- a/CortexOS/crew/github.py
+++ b/CortexOS/crew/github.py
@@ -41,64 +41,77 @@ def _repos() -> list[str]:
 
 
 def list_org_repos(org: str | None = None, *, runner: RunFn | None = None) -> dict[str, Any]:
-    """List GitHub repos in CREW_GH_ORG (default Netie-AI). Read only."""
+    """List GitHub repos for CREW_GH_ORG / CREW_GH_OWNERS. Read only."""
     if os.environ.get("CREW_LIVE_PROBES", "1") == "0":
+        owners = [org] if org else [o.strip() for o in os.environ.get("CREW_GH_OWNERS", "Netie-AI,jian-hong").split(",") if o.strip()]
         return {
             "ok": False,
             "detail": "CREW_LIVE_PROBES=0",
             "repos": [],
-            "org": org or os.environ.get("CREW_GH_ORG", "Netie-AI"),
+            "org": org or (owners[0] if owners else "Netie-AI"),
+            "owners": owners,
         }
     run = runner or _run
-    org_name = (org or os.environ.get("CREW_GH_ORG") or "Netie-AI").strip() or "Netie-AI"
-    argv = [
-        "gh",
-        "repo",
-        "list",
-        org_name,
-        "--limit",
-        "100",
-        "--json",
-        "name,description,isPrivate,url,updatedAt,primaryLanguage",
-    ]
-    try:
-        result = run(argv, timeout=20)
-    except FileNotFoundError:
-        return {"ok": False, "detail": "gh not installed", "repos": [], "org": org_name}
-    except (OSError, subprocess.TimeoutExpired) as exc:
-        return {"ok": False, "detail": type(exc).__name__, "repos": [], "org": org_name}
-    if result.returncode != 0:
-        return {
-            "ok": False,
-            "detail": (result.stderr or result.stdout or "gh failed")[:400],
-            "repos": [],
-            "org": org_name,
-        }
-    try:
-        rows = json.loads(result.stdout or "[]")
-    except ValueError:
-        return {"ok": False, "detail": "invalid json", "repos": [], "org": org_name}
+    if org:
+        owners = [org.strip()]
+    else:
+        owners = [
+            o.strip()
+            for o in os.environ.get("CREW_GH_OWNERS", "Netie-AI,jian-hong").split(",")
+            if o.strip()
+        ]
+        if not owners:
+            owners = [os.environ.get("CREW_GH_ORG") or "Netie-AI"]
     repos: list[dict[str, Any]] = []
-    for row in rows if isinstance(rows, list) else []:
-        if not isinstance(row, dict):
+    errors: list[str] = []
+    for org_name in owners:
+        argv = [
+            "gh",
+            "repo",
+            "list",
+            org_name,
+            "--limit",
+            "100",
+            "--json",
+            "name,description,isPrivate,url,updatedAt,primaryLanguage",
+        ]
+        try:
+            result = run(argv, timeout=20)
+        except FileNotFoundError:
+            return {"ok": False, "detail": "gh not installed", "repos": [], "org": org_name, "owners": owners}
+        except (OSError, subprocess.TimeoutExpired) as exc:
+            errors.append(f"{org_name}:{type(exc).__name__}")
             continue
-        lang = row.get("primaryLanguage") or {}
-        lang_name = lang.get("name") if isinstance(lang, dict) else ""
-        repos.append(
-            {
-                "name": row.get("name"),
-                "description": row.get("description") or "",
-                "private": bool(row.get("isPrivate")),
-                "url": row.get("url") or "",
-                "updated": row.get("updatedAt") or "",
-                "language": lang_name or "",
-            }
-        )
+        if result.returncode != 0:
+            errors.append((result.stderr or result.stdout or "gh failed")[:200])
+            continue
+        try:
+            rows = json.loads(result.stdout or "[]")
+        except ValueError:
+            errors.append(f"{org_name}: invalid json")
+            continue
+        for row in rows if isinstance(rows, list) else []:
+            if not isinstance(row, dict):
+                continue
+            lang = row.get("primaryLanguage") or {}
+            lang_name = lang.get("name") if isinstance(lang, dict) else ""
+            repos.append(
+                {
+                    "name": row.get("name"),
+                    "owner": org_name,
+                    "description": row.get("description") or "",
+                    "private": bool(row.get("isPrivate")),
+                    "url": row.get("url") or "",
+                    "updated": row.get("updatedAt") or "",
+                    "language": lang_name or "",
+                }
+            )
     return {
-        "ok": True,
-        "detail": "",
+        "ok": not errors or bool(repos),
+        "detail": "; ".join(errors)[:400] if errors else "",
         "repos": repos,
-        "org": org_name,
+        "org": owners[0] if owners else "Netie-AI",
+        "owners": owners,
         "law": "Report in chat. Do not auto-merge. Adaptive catalog lives in crew.estate.",
     }
 

--- a/CortexOS/crew/policy.py
+++ b/CortexOS/crew/policy.py
@@ -58,6 +58,8 @@ INTERNAL_TOOLS = frozenset(
         "finish",
         "netie_board",
         "desk_status",
+        "estate_status",
+        "ship_gate",
         "rename_agent",
     }
 )

--- a/CortexOS/crew/roles.py
+++ b/CortexOS/crew/roles.py
@@ -59,12 +59,76 @@ ROLES: tuple[Role, ...] = (
     Role(
         "Gate",
         "G",
-        "Check a change against Cortex invariants and name the verify commands.",
-        "You are the Gate agent. Against Cortex rules: C2 (no CortexOS->packs imports), "
-        "duckdb only under execution/, no hand-edited contract specs, no weakened "
-        "manifest refusals, no git add -A. Report pass/fail with the exact verify command. "
-        "Do not claim tests passed unless cortex_ask or the operator said so.",
-        ("build",),
+        "Ship-gate: Cortex invariants plus adaptive production checks across Netie-AI repos.",
+        "You are the Gate agent. Call estate_status then ship_gate (repo=slug or repo=all). "
+        "Two layers: (1) Cortex invariants when the repo is Cortex: C2 (no CortexOS->packs "
+        "imports), duckdb only under execution/, no hand-edited contract specs, no weakened "
+        "manifest refusals, no git add -A. (2) Production ship-gate for github.com/Netie-AI: "
+        "Security, Reliability, Infra, Architecture, Observability, Surface -- only the "
+        "domains that surface requires. RTL skips WCAG. Empty repos fail. File presence is "
+        "not SOC2/HIPAA/GDPR. Spawn a job-named teammate only for FAIL domains. Do not spawn "
+        "one specialist per heading on a sweep. Do not claim tests passed unless they ran. "
+        "Do not auto-merge. Human is money and decision authority.",
+        ("build", "ship"),
+    ),
+    Role(
+        "Security",
+        "Sec",
+        "Authn/z, input validation, secrets, encryption, audit logs. Not a compliance certificate.",
+        "You are the Security agent. Use ship_gate on the named repo first. Cover auth, "
+        "session, RBAC, validation, SQLi/XSS/CSRF, encryption, secret rotation, audit logs, "
+        "retention. Name missing evidence. Never stamp SOC2/HIPAA/GDPR as certified from "
+        "files. Draft fixes. Do not weaken a refusal to make a test pass. Human merges.",
+        ("ship", "security"),
+    ),
+    Role(
+        "Reliability",
+        "Rel",
+        "Tests, retries, circuit breakers, edge cases. Green means the command ran.",
+        "You are the Reliability agent. Use ship_gate on the named repo first. Cover unit/"
+        "integration/e2e/load, error handling, retries, circuit breakers, graceful "
+        "degradation, regression, test data. Name the exact verify command. Do not claim "
+        "green unless it ran. Do not reclassify a hostile case to make a suite pass.",
+        ("ship", "reliability"),
+    ),
+    Role(
+        "Infra",
+        "Ops",
+        "CI/CD, env promotion, backups, containers. Do not invent a second orchestrator.",
+        "You are the Infra agent. Use ship_gate on the named repo first. Cover CI/CD, "
+        "dev/staging/prod, IaC, migrations, backups, DR, uptime, scaling, cache, CDN, "
+        "Docker/K8s. Skip K8s for a local-first engine unless they claim hosted prod. "
+        "Cortex is the loop. Do not start LangGraph or n8n.",
+        ("ship", "infra"),
+    ),
+    Role(
+        "Architecture",
+        "Arc",
+        "DB, API versioning, queues, webhooks, idempotency. Contract majors are expensive.",
+        "You are the Architecture agent. Use ship_gate on the named repo first. Cover "
+        "indexes/pooling, API versioning, rate limits, queues, background jobs, webhooks, "
+        "idempotency, third-party integrations. Cortex contract field removes are majors. "
+        "Do not change canonical_manifest_bytes. Do not hand-edit contract JSON.",
+        ("ship", "architecture"),
+    ),
+    Role(
+        "Observability",
+        "Obs",
+        "Logs, traces, alerts, vuln scans, cost. Do not invent Sentry from a missing file.",
+        "You are the Observability agent. Use ship_gate on the named repo first. Cover "
+        "logging, tracing, perf, alerting, RUM, error tracking, cost, dependency updates, "
+        "vuln scanning. Skip is not pass. Do not claim Sentry/RUM without evidence.",
+        ("ship", "observability"),
+    ),
+    Role(
+        "Surface",
+        "Surf",
+        "SEO, WCAG, i18n, privacy, analytics, feature flags. Public web only.",
+        "You are the Surface agent. Use ship_gate on the named repo first. Cover SEO, "
+        "WCAG, i18n, legal/privacy, analytics, A/B, feature flags, docs. RTL/analog/empty "
+        "skip this domain. Public Pages apps fail without privacy + a11y evidence. Draft "
+        "copy. Human publishes. Follow skill seo when the job is on-page metadata.",
+        ("ship", "product-surface", "seo"),
     ),
     Role(
         "Marketing",

--- a/CortexOS/crew/runtime.py
+++ b/CortexOS/crew/runtime.py
@@ -62,7 +62,7 @@ tell the user what was denied and why instead of pretending it ran.
 - Do not spawn infinite Cursor cloud chats. One issue per human-opened chat. Ticket Runner seats \
 existing writers.
 - Models go through OpenVault FreeRoute. Cursor chats use grok-4.6 (high), never grok-fast.
-- To check PRs, mail, connectors, or the Cursor key, call desk_status. Do not ask the operator to click import or PR buttons. Dropped files already become spaces.
+- To check PRs, mail, connectors, the Cursor key, or the GitHub org estate, call desk_status or estate_status. Before shipping, call ship_gate (repo=slug or repo=all). Do not ask the operator to click import or PR buttons. Dropped files already become spaces.
 - Your final plain-text reply is the only thing the user reads. Keep it direct. Plain ASCII only.
 
 """ + roles.charter_block()
@@ -520,6 +520,23 @@ class CrewRuntime:
                 [],
             ),
             spec(
+                "estate_status",
+                "List github.com/Netie-AI repos with adaptive surfaces and which production "
+                "domains apply (Security/Reliability/Infra/Architecture/Observability/Surface). "
+                "Static catalog plus optional live gh. Do not clone every repo. Do not auto-merge.",
+                {},
+                [],
+            ),
+            spec(
+                "ship_gate",
+                "Run the deterministic production ship-gate. repo is a Netie-AI slug, "
+                "full_name, or 'all'. Fail closed on missing evidence. Skip is not pass. "
+                "File presence is not SOC2/HIPAA/GDPR. Spawn domain teammates only for FAIL "
+                "items. Do not auto-merge.",
+                {"repo": {"type": "string", "description": "Cortex, Netie-AI/AIM, or all"}},
+                ["repo"],
+            ),
+            spec(
                 "cortex_ask",
                 "Ask the governed Cortex engine a data question. Returns the answer with its"
                 " badge, sources and audit id. The engine may abstain; report that honestly.",
@@ -746,6 +763,22 @@ class CrewRuntime:
             )
             text = render(snap)
             self._persist_tool(ctx, row, "desk_status", {}, text)
+            return text
+
+        if name == "estate_status":
+            from CortexOS.crew.estate import render as estate_render
+            from CortexOS.crew.estate import snapshot as estate_snapshot
+
+            text = estate_render(estate_snapshot())
+            self._persist_tool(ctx, row, "estate_status", {}, text)
+            return text
+
+        if name == "ship_gate":
+            from CortexOS.crew.ship_gate import render_slug
+
+            repo = str(args.get("repo", "")).strip() or "all"
+            text = render_slug(repo)
+            self._persist_tool(ctx, row, "ship_gate", {"repo": repo}, text)
             return text
 
         if name == "cortex_ask":

--- a/CortexOS/crew/ship_gate.py
+++ b/CortexOS/crew/ship_gate.py
@@ -76,6 +76,40 @@ def _score_repo(fp: Fingerprint) -> list[Check]:
     )
     apiish = bool({"api", "engine", "keys", "news"} & set(fp.surfaces))
 
+    if fp.placement == "missing":
+        out.append(
+            _check(
+                "Reliability",
+                "missing_origin",
+                FAIL,
+                "github 404",
+                "Not on GitHub. Create a private Netie-AI repo. Do not leave SoT on D:\\ or jian-hong.",
+            )
+        )
+        return out
+    if fp.placement == "accidental":
+        out.append(
+            _check(
+                "Security",
+                "accidental_personal_copy",
+                FAIL,
+                fp.full_name,
+                "Accidental store on github.com/jian-hong. Canonical is Netie-AI. Archive or make private. Do not ship from here.",
+            )
+        )
+        return out
+    if fp.placement == "fork":
+        out.append(
+            _check(
+                "Architecture",
+                "second_orchestrator",
+                FAIL,
+                fp.full_name,
+                "Third-party agent-swarm fork. Do not merge into Cortex. Cortex is the loop. Rotate any committed token-shaped file.",
+            )
+        )
+        return out
+
     if fp.empty:
         out.append(
             _check(
@@ -343,6 +377,6 @@ def render_slug(name: str) -> str:
     if report is None:
         return (
             f"SHIP FAIL  unknown repo '{name}'. "
-            "Call estate_status. Catalog is github.com/Netie-AI as of 2026-08-25."
+            "Call estate_status. Catalog is github.com/Netie-AI plus expected private products and jian-hong accidentals as of 2026-08-25."
         )
     return render_report(report)

--- a/CortexOS/crew/ship_gate.py
+++ b/CortexOS/crew/ship_gate.py
@@ -1,0 +1,348 @@
+"""Deterministic production ship-gate for the Netie-AI estate.
+
+Claude can scaffold. This module refuses a ship when required evidence is
+missing. It never certifies SOC 2 / HIPAA / GDPR from files on disk.
+
+Adaptive: surfaces from estate.Fingerprint pick the domains. A public static
+web app is scored for privacy/a11y; an RTL tree is not. Empty repos fail.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+from CortexOS.crew.estate import CATALOG, Fingerprint, by_slug, required_domains
+
+PASS = "pass"
+FAIL = "fail"
+SKIP = "skip"
+
+
+@dataclass(frozen=True)
+class Check:
+    domain: str
+    check_id: str
+    status: str
+    evidence: str
+    why: str
+
+    def as_dict(self) -> dict[str, str]:
+        return {
+            "domain": self.domain,
+            "check_id": self.check_id,
+            "status": self.status,
+            "evidence": self.evidence,
+            "why": self.why,
+        }
+
+
+@dataclass(frozen=True)
+class Report:
+    repo: str
+    kind: str
+    verdict: str
+    domains: tuple[str, ...]
+    checks: tuple[Check, ...]
+    notes: tuple[str, ...]
+
+    def as_dict(self) -> dict[str, Any]:
+        return {
+            "repo": self.repo,
+            "kind": self.kind,
+            "verdict": self.verdict,
+            "domains": list(self.domains),
+            "checks": [c.as_dict() for c in self.checks],
+            "notes": list(self.notes),
+            "law": (
+                "Fail closed on missing evidence. Skip is not pass. "
+                "Do not claim SOC2/HIPAA/GDPR from this report. Do not auto-merge."
+            ),
+        }
+
+
+def _check(
+    domain: str, check_id: str, status: str, evidence: str, why: str
+) -> Check:
+    return Check(domain, check_id, status, evidence, why)
+
+
+def _score_repo(fp: Fingerprint) -> list[Check]:
+    out: list[Check] = []
+    domains = set(required_domains(fp))
+    # Public marketing / Pages apps. Local consoles (engine, keys) are not scored as WCAG sites.
+    public_web = (not fp.private) and "web" in fp.surfaces and not (
+        {"engine", "keys"} & set(fp.surfaces)
+    )
+    apiish = bool({"api", "engine", "keys", "news"} & set(fp.surfaces))
+
+    if fp.empty:
+        out.append(
+            _check(
+                "Reliability",
+                "repo_empty",
+                FAIL,
+                "git tree empty",
+                "Empty repo cannot ship to users.",
+            )
+        )
+        return out
+
+    if "Security" in domains:
+        secret_ok = fp.has_sops or fp.has_secrets_scan
+        out.append(
+            _check(
+                "Security",
+                "secrets_hygiene",
+                PASS if secret_ok else (SKIP if not apiish else FAIL),
+                "sops" if fp.has_sops else ("secrets_scan" if fp.has_secrets_scan else "none"),
+                "Need SOPS or a secrets scanner before an API/engine/keys ship."
+                if apiish
+                else "No API surface; scanner optional.",
+            )
+        )
+        if apiish:
+            out.append(
+                _check(
+                    "Security",
+                    "auth",
+                    PASS if (fp.has_auth or fp.has_csrf) else FAIL,
+                    "auth" if fp.has_auth else ("csrf" if fp.has_csrf else "none"),
+                    "API/keys/engine need auth or CSRF evidence.",
+                )
+            )
+            out.append(
+                _check(
+                    "Security",
+                    "rate_limit",
+                    PASS if fp.has_rate_limit else FAIL,
+                    "rate_limit" if fp.has_rate_limit else "none",
+                    "API surfaces need a rate limiter.",
+                )
+            )
+        if "keys" in fp.surfaces or "engine" in fp.surfaces:
+            out.append(
+                _check(
+                    "Security",
+                    "rbac",
+                    PASS if fp.has_rbac else (PASS if "keys" in fp.surfaces and fp.has_auth else FAIL),
+                    "rbac" if fp.has_rbac else ("auth-as-gate" if fp.has_auth else "none"),
+                    "Engine needs RBAC. Vault may use its own auth gate.",
+                )
+            )
+        out.append(
+            _check(
+                "Security",
+                "compliance_cert",
+                SKIP,
+                "none",
+                "File presence is not SOC 2, HIPAA, or GDPR certification. Do not claim it.",
+            )
+        )
+
+    if "Reliability" in domains:
+        out.append(
+            _check(
+                "Reliability",
+                "tests",
+                PASS if fp.has_tests else FAIL,
+                "tests/" if fp.has_tests else "none",
+                "Code that ships to users needs tests.",
+            )
+        )
+
+    if "Infra" in domains:
+        ci_ok = fp.has_ci or bool(fp.workflows)
+        out.append(
+            _check(
+                "Infra",
+                "ci",
+                PASS if ci_ok else FAIL,
+                ",".join(fp.workflows) if fp.workflows else "none",
+                "Need a CI workflow (or Pages workflow) before shipping.",
+            )
+        )
+        if apiish:
+            boxed = fp.has_dockerfile or fp.has_compose
+            out.append(
+                _check(
+                    "Infra",
+                    "container",
+                    PASS if boxed else SKIP,
+                    "docker" if boxed else "none",
+                    "Container evidence helps deploy. Missing is skip, not a fake pass.",
+                )
+            )
+
+    if "Architecture" in domains:
+        if "engine" in fp.surfaces:
+            # Cortex pins cortex-contract; catalog notes that as the versioning story.
+            out.append(
+                _check(
+                    "Architecture",
+                    "contract",
+                    PASS,
+                    "contract/ (catalog)",
+                    "Engine ships a versioned OpenAPI contract. Do not hand-edit it.",
+                )
+            )
+        elif "rtl" in fp.surfaces:
+            out.append(
+                _check(
+                    "Architecture",
+                    "rtl_dv",
+                    PASS if fp.has_tests and fp.has_ci else FAIL,
+                    "sim/lint/formal" if fp.has_ci else "none",
+                    "RTL ships through sim/lint/formal, not WCAG.",
+                )
+            )
+        else:
+            out.append(
+                _check(
+                    "Architecture",
+                    "api_shape",
+                    SKIP,
+                    "unproven",
+                    "No contract artifact in catalog. Do not invent versioning.",
+                )
+            )
+
+    if "Observability" in domains:
+        out.append(
+            _check(
+                "Observability",
+                "vuln_scan",
+                PASS if (fp.has_secrets_scan or fp.has_dependabot or "secrets.yml" in fp.workflows) else SKIP,
+                "secrets.yml" if "secrets.yml" in fp.workflows else (
+                    "secrets_scan" if fp.has_secrets_scan else "none"
+                ),
+                "Vuln/secrets scan is evidence. Sentry/RUM is not inferred.",
+            )
+        )
+        out.append(
+            _check(
+                "Observability",
+                "sentry_rum",
+                SKIP,
+                "sentry" if fp.has_sentry else "none",
+                "No Sentry/RUM claim from file presence.",
+            )
+        )
+
+    if "Surface" in domains:
+        out.append(
+            _check(
+                "Surface",
+                "readme",
+                PASS if fp.has_readme else FAIL,
+                "README.md" if fp.has_readme else "none",
+                "Public or shippable code needs a README.",
+            )
+        )
+        if not fp.private:
+            out.append(
+                _check(
+                    "Surface",
+                    "license",
+                    PASS if fp.has_license else FAIL,
+                    "LICENSE" if fp.has_license else "none",
+                    "Public repos need a LICENSE.",
+                )
+            )
+        if public_web:
+            out.append(
+                _check(
+                    "Surface",
+                    "privacy",
+                    PASS if fp.has_privacy_page else FAIL,
+                    "privacy page" if fp.has_privacy_page else "none",
+                    "Public web app needs a privacy page before user traffic.",
+                )
+            )
+            out.append(
+                _check(
+                    "Surface",
+                    "a11y",
+                    PASS if fp.has_a11y else FAIL,
+                    "wcag" if fp.has_a11y else "none",
+                    "Public web app needs WCAG evidence. Missing is fail, not skip.",
+                )
+            )
+        else:
+            out.append(
+                _check(
+                    "Surface",
+                    "a11y",
+                    SKIP,
+                    "n/a",
+                    "Not a public marketing/web-only surface. Demo UI is not scored as WCAG.",
+                )
+            )
+
+    return out
+
+
+def evaluate(fp: Fingerprint) -> Report:
+    checks = tuple(_score_repo(fp))
+    fails = [c for c in checks if c.status == FAIL]
+    verdict = FAIL if fails else PASS
+    return Report(
+        repo=fp.full_name,
+        kind=fp.kind,
+        verdict=verdict,
+        domains=required_domains(fp),
+        checks=checks,
+        notes=fp.notes,
+    )
+
+
+def evaluate_slug(name: str) -> Report | None:
+    fp = by_slug(name)
+    if fp is None:
+        return None
+    return evaluate(fp)
+
+
+def evaluate_all() -> list[Report]:
+    return [evaluate(fp) for fp in CATALOG]
+
+
+def render_report(report: Report) -> str:
+    lines = [
+        f"SHIP {report.verdict.upper()}  {report.repo}  kind={report.kind}",
+        "Fail closed on missing evidence. Skip is not pass. Do not auto-merge.",
+        "Do not claim SOC2/HIPAA/GDPR from this report.",
+        "domains: " + (",".join(report.domains) or "(none)"),
+    ]
+    for note in report.notes:
+        lines.append(f"note: {note}")
+    for check in report.checks:
+        lines.append(
+            f"- {check.status.upper()} {check.domain}/{check.check_id} "
+            f"evidence={check.evidence} -- {check.why}"
+        )
+    fails = [c for c in report.checks if c.status == FAIL]
+    if fails:
+        lines.append("Next: spawn a job-named teammate only for FAIL domains.")
+    else:
+        lines.append("Next: human merge. Spawn 0 domain specialists.")
+    return "\n".join(lines)
+
+
+def render_slug(name: str) -> str:
+    if name.strip() in {"*", "all", "estate"}:
+        reports = evaluate_all()
+        lines = [f"Estate ship-gate: {len(reports)} repos"]
+        failed = [r for r in reports if r.verdict == FAIL]
+        lines.append(f"FAIL={len(failed)} PASS={len(reports) - len(failed)}")
+        for report in reports:
+            lines.append("")
+            lines.append(render_report(report))
+        return "\n".join(lines)
+    report = evaluate_slug(name)
+    if report is None:
+        return (
+            f"SHIP FAIL  unknown repo '{name}'. "
+            "Call estate_status. Catalog is github.com/Netie-AI as of 2026-08-25."
+        )
+    return render_report(report)

--- a/CortexOS/crew/ship_gate.py
+++ b/CortexOS/crew/ship_gate.py
@@ -76,6 +76,19 @@ def _score_repo(fp: Fingerprint) -> list[Check]:
     )
     apiish = bool({"api", "engine", "keys", "news"} & set(fp.surfaces))
 
+    if fp.placement == "unseen":
+        out.append(
+            _check(
+                "Reliability",
+                "private_unseen",
+                FAIL,
+                "github 404-to-this-token",
+                "Repo exists. This token cannot read private Netie-AI repos (GitHub returns 404). "
+                "Grant the GitHub App All repositories. Do not claim the repo is missing. "
+                "Do not build a remote-login box or share GPU from this agent VM.",
+            )
+        )
+        return out
     if fp.placement == "missing":
         out.append(
             _check(

--- a/CortexOS/crew/skill_packs/architecture.md
+++ b/CortexOS/crew/skill_packs/architecture.md
@@ -1,0 +1,10 @@
+Architecture: additive is cheap. Subtractive is a major.
+
+Cover: indexes, pooling, API versioning, rate limits, queues, background jobs, webhooks, idempotency, third-party integrations.
+
+Rules:
+- Call ship_gate first.
+- Cortex contract: add = minor; remove/rename/retype = major. Bump version.py and pyproject.toml together. Regenerate OpenAPI. Never hand-edit contract/*.json.
+- Do not change canonical_manifest_bytes. DMS signs those bytes.
+- duckdb only under CortexOS/execution/.
+- Idempotency and webhook retries need a test, not a comment.

--- a/CortexOS/crew/skill_packs/build.md
+++ b/CortexOS/crew/skill_packs/build.md
@@ -11,5 +11,4 @@ Rules:
 - Cursor model: grok-4.6 high, not fast. Do not spawn one cloud agent per issue.
 
 Verify default for crew code:
-cd D:\Cortex-crew
-D:\Cortex\.venv\Scripts\python.exe -m pytest tests/test_crew -q
+python -m pytest tests/test_crew -q

--- a/CortexOS/crew/skill_packs/infra.md
+++ b/CortexOS/crew/skill_packs/infra.md
@@ -1,0 +1,12 @@
+Infra: one CI, one loop. Cortex is the orchestrator.
+
+Cover: CI/CD, env promotion, IaC, migrations, backups, DR, uptime, scaling, cache, CDN, Docker/K8s.
+
+Rules:
+- Call ship_gate first.
+- Pages workflow counts as CI for a static app.
+- Skip Kubernetes for a local-first engine unless they claim hosted prod.
+- Do not start LangGraph, n8n, or a second ticket cron.
+- Backups/DR: skip is not pass. Do not invent a runbook.
+
+Law: Ticket Runner seats existing writers. Human is money/decision.

--- a/CortexOS/crew/skill_packs/observability.md
+++ b/CortexOS/crew/skill_packs/observability.md
@@ -1,0 +1,10 @@
+Observability: identifiers and numbers. No silent swallow.
+
+Cover: logs, tracing, perf, alerting, RUM, Sentry, cost, dependency updates, vuln scanning.
+
+Rules:
+- Call ship_gate first.
+- Skip is not pass. Do not claim Sentry/RUM from a missing file.
+- Cortex ActionEvent / F1 ledger: identifiers, never prompts or titles.
+- A failed audit write is reported, never swallowed.
+- secrets.yml / secrets_scan is vuln evidence. Dependabot is extra, not required.

--- a/CortexOS/crew/skill_packs/product-surface.md
+++ b/CortexOS/crew/skill_packs/product-surface.md
@@ -1,0 +1,12 @@
+Surface: public web only. RTL and empty repos skip.
+
+Cover: SEO, WCAG, i18n, legal/privacy, analytics, A/B, feature flags, docs.
+
+Rules:
+- Call ship_gate first.
+- Public Pages/web-only apps fail without privacy page + a11y evidence.
+- Engine/vault consoles are not marketing sites. Skip WCAG there.
+- Do not invent rankings, traffic, or backlinks. Skill seo for on-page drafts.
+- Human publishes. Draft only.
+
+When the job is metadata only, follow skill seo.

--- a/CortexOS/crew/skill_packs/reliability.md
+++ b/CortexOS/crew/skill_packs/reliability.md
@@ -1,0 +1,14 @@
+Reliability: the command ran, or it is not green.
+
+Cover: unit, integration, e2e, load/stress, retries, circuit breakers, graceful degradation, edge cases, regression, test data.
+
+Rules:
+- Call ship_gate first.
+- Name the exact verify command. Paste output, not a vibe.
+- Do not reclassify a hostile SQL case to allow_but_predicate_must_apply.
+- Answer-path tests assert rendered text and rows, not only SQL.
+- Missing tests on a user-facing repo is FAIL.
+
+Verify examples:
+python -m pytest tests/test_crew -q
+python -m pytest tests/ -q

--- a/CortexOS/crew/skill_packs/security.md
+++ b/CortexOS/crew/skill_packs/security.md
@@ -1,0 +1,14 @@
+Security: evidence or fail. Not a certificate mill.
+
+Cover: authn/z, session, RBAC, validation, SQLi, XSS, CSRF, encryption at rest/in transit, secret rotation, audit logs, retention.
+
+Rules:
+- Call ship_gate first. Name the missing file or test.
+- Do not weaken a refusal to make a query or test pass.
+- Do not stamp SOC2/HIPAA/GDPR as certified because a privacy.html exists.
+- Secrets stay in OpenVault / SOPS. Never commit keys.
+- Draft the fix. Human merges.
+
+Verify examples:
+python -m scripts.secrets_scan
+python -m pytest tests/dms/test_f7_rbac.py -q

--- a/CortexOS/crew/skill_packs/ship.md
+++ b/CortexOS/crew/skill_packs/ship.md
@@ -12,8 +12,10 @@ Order:
 Adaptive:
 - RTL/OpenHBM: sim/lint/formal. No WCAG.
 - Empty/AIM: fail. Cannot ship.
-- Missing origin (AirGPT, DMS, chatbot, Pointer, Netie, OMI): fail. Create under Netie-AI. Not D:\\ only. Not jian-hong.
-- Accidental personal copy (jian-hong/Vking): fail. Canonical is Netie-AI/VKing. Archive or make private.
+- Missing origin: fail only when the repo truly does not exist.
+- Private unseen (dms, Netie-KB, Pointer, landing, Space, netie-control, ViKing, RUMA-Houser): fail private_unseen. Grant GitHub App All repositories. 404 from this token is not absence.
+- Do not build a remote-login website. OpenVault holds keys. Computer control stays confirm-gated.
+- Accidental personal copy (jian-hong/Vking): fail. Canonical is Netie-AI/VKing.
 - jian-hong/optio: fail. Third-party swarm fork. Do not merge into Cortex.
 - Public Pages/web-only: privacy + a11y required.
 - Local engine/vault consoles: not scored as marketing sites.

--- a/CortexOS/crew/skill_packs/ship.md
+++ b/CortexOS/crew/skill_packs/ship.md
@@ -1,0 +1,18 @@
+Ship-gate: fail closed. Skip is not pass. Human merges.
+
+When: before shipping, production ready, "is this safe for users".
+
+Order:
+1. estate_status. Name the repo kind (engine/keys/web/rtl/analog/empty).
+2. ship_gate repo=<slug|all>. Read FAIL rows. Do not invent green.
+3. Spawn a job-named teammate only for FAIL domains. A sweep is one Gate, not six specialists.
+4. Cortex extras when the repo is Cortex: C2, duckdb only under execution/, no hand-edited contract JSON, no weakened manifest refusals, no git add -A.
+5. File presence is not SOC2, HIPAA, or GDPR. Say so if asked.
+
+Adaptive:
+- RTL/OpenHBM: sim/lint/formal. No WCAG.
+- Empty/AIM: fail. Cannot ship.
+- Public Pages/web-only: privacy + a11y required.
+- Local engine/vault consoles: not scored as marketing sites.
+
+Law: Do not auto-merge. Ticket Runner seats existing writers.

--- a/CortexOS/crew/skill_packs/ship.md
+++ b/CortexOS/crew/skill_packs/ship.md
@@ -12,6 +12,9 @@ Order:
 Adaptive:
 - RTL/OpenHBM: sim/lint/formal. No WCAG.
 - Empty/AIM: fail. Cannot ship.
+- Missing origin (AirGPT, DMS, chatbot, Pointer, Netie, OMI): fail. Create under Netie-AI. Not D:\\ only. Not jian-hong.
+- Accidental personal copy (jian-hong/Vking): fail. Canonical is Netie-AI/VKing. Archive or make private.
+- jian-hong/optio: fail. Third-party swarm fork. Do not merge into Cortex.
 - Public Pages/web-only: privacy + a11y required.
 - Local engine/vault consoles: not scored as marketing sites.
 

--- a/STATUS.md
+++ b/STATUS.md
@@ -5,7 +5,9 @@
 > before shipping. Capability templates: Security, Reliability, Infra,
 > Architecture, Observability, Surface. Deterministic `ship_gate` +
 > `estate_status`. Detect collapses a production sweep to Gate. File
-> presence is not a compliance certificate. Human merges.
+> presence is not a compliance certificate. Human merges. AirGPT/DMS and
+> other local products are missing GitHub origins. jian-hong/Vking is an
+> accidental personal copy of Netie-AI/VKing.
 
 > **2026-08-22 (auto-merge):** CI job `auto-merge` squash-merges non-draft PRs when
 > every required check is green. Rule `.cursor/rules/merge-perfect.mdc`.

--- a/STATUS.md
+++ b/STATUS.md
@@ -5,9 +5,10 @@
 > before shipping. Capability templates: Security, Reliability, Infra,
 > Architecture, Observability, Surface. Deterministic `ship_gate` +
 > `estate_status`. Detect collapses a production sweep to Gate. File
-> presence is not a compliance certificate. Human merges. AirGPT/DMS and
-> other local products are missing GitHub origins. jian-hong/Vking is an
-> accidental personal copy of Netie-AI/VKing.
+> presence is not a compliance certificate. Human merges. Private product
+> repos (dms, Netie-KB, Pointer, landing, Space, netie-control, ViKing) exist;
+> this token cannot read them. Grant GitHub App All repositories. Do not
+> build a remote-login box. jian-hong/Vking is an accidental public copy.
 
 > **2026-08-22 (auto-merge):** CI job `auto-merge` squash-merges non-draft PRs when
 > every required check is green. Rule `.cursor/rules/merge-perfect.mdc`.

--- a/STATUS.md
+++ b/STATUS.md
@@ -1,5 +1,11 @@
 # STATUS.md
-**Last updated:** 2026-08-22 | **Gate:** G2.3 OSR **SHIPPED** | **Active:** auto-merge perfect PRs
+**Last updated:** 2026-08-25 | **Gate:** G2.3 OSR **SHIPPED** | **Active:** crew production ship-gate
+
+> **2026-08-25 (crew ship-gate):** Cortex Crew governs github.com/Netie-AI
+> before shipping. Capability templates: Security, Reliability, Infra,
+> Architecture, Observability, Surface. Deterministic `ship_gate` +
+> `estate_status`. Detect collapses a production sweep to Gate. File
+> presence is not a compliance certificate. Human merges.
 
 > **2026-08-22 (auto-merge):** CI job `auto-merge` squash-merges non-draft PRs when
 > every required check is green. Rule `.cursor/rules/merge-perfect.mdc`.

--- a/docs/subagents_findings/2026-08-25_crew-ship-gate-estate.md
+++ b/docs/subagents_findings/2026-08-25_crew-ship-gate-estate.md
@@ -1,32 +1,28 @@
 ---
 keywords: [crew, ship-gate, estate, netie-ai, production, security, wcag, detect, jian-hong, airgpt, dms]
-main_idea: Production headings are capability templates plus a deterministic ship-gate. Sweep collapses to Gate. Surfaces pick domains. File presence is not SOC2/HIPAA/GDPR. AirGPT/DMS are missing GitHub origins. jian-hong/Vking is an accidental personal copy.
+main_idea: Production headings are capability templates plus a deterministic ship-gate. Private Netie-AI repos exist; this token 404s them. Grant GitHub App access. Do not build a remote-login box. jian-hong/Vking is an accidental public copy.
 ---
 
 # Crew production ship-gate across Netie-AI
 
 ## Main idea
 
-Claude can scaffold. Crew now refuses a ship when required evidence is missing. `estate.py` catalogs github.com/Netie-AI plus expected private products and public jian-hong accidentals (probed 2026-08-25). `ship_gate.py` scores Security / Reliability / Infra / Architecture / Observability / Surface from surfaces, not a fixed roster. Detect collapses a six-heading sweep to one Gate so `max_agents_per_space` is not blown. Spawn domain teammates only for FAIL rows.
+Claude can scaffold. Crew now refuses a ship when required evidence is missing. `estate.py` catalogs github.com/Netie-AI plus private products the operator screenshot confirmed and public jian-hong accidentals. A GitHub 404 from this cloud token is not proof of absence.
 
 ## Golden rule
 
-> Detect the job. Gate the estate. Skip is not pass. Human merges. SoT is Netie-AI, not D:\\ and not jian-hong.
+> Detect the job. Gate the estate. Skip is not pass. Human merges. Grant the GitHub App All repositories. Do not build a remote-login box. OpenVault holds keys.
 
 ## Adaptive notes (2026-08-25)
 
 - Cortex: local-first engine. PASS on catalog evidence. WCAG skipped (demo UI).
 - constructor: public Pages. FAIL tests/privacy/a11y/license.
-- OpenHBM: RTL. sim/lint/formal. No WCAG.
-- AIM: empty. Cannot ship.
-- AnalogCrawler: no CI. surveillance/ path is noted, not reviewed.
-- AirGPT, DMS, chatbot, Pointer, Netie, OMI: not on GitHub (404). Local D:\\ only. FAIL missing_origin.
-- jian-hong/Vking: public personal duplicate of Netie-AI/VKing (run-0003 vs run-0004). FAIL accidental_personal_copy.
-- jian-hong/Python_Automation_JH: venv committed (~8809 files). Accidental store, not a Cortex copy.
-- jian-hong/optio: third-party swarm fork + token-shaped file. Do not merge into Cortex.
-- jian-hong private repos: invisible to this token.
-
-GitHub MCP was down this session. `gh` against Netie-AI and public jian-hong worked.
+- Operator screenshot (private, this token 404s): dms, Netie-KB, Netie, Pointer, landing, Space, netie-control, RUMA-Houser, ViKing. FAIL private_unseen.
+- AirGPT / chatbot / OMI: not in the screenshot. Still unseen to this token.
+- jian-hong/Vking: public personal duplicate of Netie-AI/VKing. FAIL accidental_personal_copy.
+- jian-hong/Python_Automation_JH: venv committed (~8809 files).
+- jian-hong/optio: third-party swarm fork. Do not merge into Cortex.
+- Do not share this VM as a laptop login or GPU rental. Computer control stays confirm-gated.
 
 ## Verify
 

--- a/docs/subagents_findings/2026-08-25_crew-ship-gate-estate.md
+++ b/docs/subagents_findings/2026-08-25_crew-ship-gate-estate.md
@@ -1,0 +1,31 @@
+---
+keywords: [crew, ship-gate, estate, netie-ai, production, security, wcag, detect]
+main_idea: Production headings are capability templates plus a deterministic ship-gate. Sweep collapses to Gate. Surfaces pick domains. File presence is not SOC2/HIPAA/GDPR.
+---
+
+# Crew production ship-gate across Netie-AI
+
+## Main idea
+
+Claude can scaffold. Crew now refuses a ship when required evidence is missing. `estate.py` catalogs github.com/Netie-AI (probed 2026-08-25). `ship_gate.py` scores Security / Reliability / Infra / Architecture / Observability / Surface from surfaces, not a fixed roster. Detect collapses a six-heading sweep to one Gate so `max_agents_per_space` is not blown. Spawn domain teammates only for FAIL rows.
+
+## Golden rule
+
+> Detect the job. Gate the estate. Skip is not pass. Human merges.
+
+## Adaptive notes (2026-08-25)
+
+- Cortex: local-first engine. PASS on catalog evidence. WCAG skipped (demo UI).
+- constructor: public Pages. FAIL tests/privacy/a11y/license.
+- OpenHBM: RTL. sim/lint/formal. No WCAG.
+- AIM: empty. Cannot ship.
+- AnalogCrawler: no CI. surveillance/ path is noted, not reviewed.
+- Netie-KB: not a repo in the org. Do not scrape sibling machines.
+
+GitHub MCP was down this session. `gh` against Netie-AI worked. Crew uses `gh`, not a second orchestrator.
+
+## Verify
+
+```bash
+python -m pytest tests/test_crew -q
+```

--- a/docs/subagents_findings/2026-08-25_crew-ship-gate-estate.md
+++ b/docs/subagents_findings/2026-08-25_crew-ship-gate-estate.md
@@ -1,17 +1,17 @@
 ---
-keywords: [crew, ship-gate, estate, netie-ai, production, security, wcag, detect]
-main_idea: Production headings are capability templates plus a deterministic ship-gate. Sweep collapses to Gate. Surfaces pick domains. File presence is not SOC2/HIPAA/GDPR.
+keywords: [crew, ship-gate, estate, netie-ai, production, security, wcag, detect, jian-hong, airgpt, dms]
+main_idea: Production headings are capability templates plus a deterministic ship-gate. Sweep collapses to Gate. Surfaces pick domains. File presence is not SOC2/HIPAA/GDPR. AirGPT/DMS are missing GitHub origins. jian-hong/Vking is an accidental personal copy.
 ---
 
 # Crew production ship-gate across Netie-AI
 
 ## Main idea
 
-Claude can scaffold. Crew now refuses a ship when required evidence is missing. `estate.py` catalogs github.com/Netie-AI (probed 2026-08-25). `ship_gate.py` scores Security / Reliability / Infra / Architecture / Observability / Surface from surfaces, not a fixed roster. Detect collapses a six-heading sweep to one Gate so `max_agents_per_space` is not blown. Spawn domain teammates only for FAIL rows.
+Claude can scaffold. Crew now refuses a ship when required evidence is missing. `estate.py` catalogs github.com/Netie-AI plus expected private products and public jian-hong accidentals (probed 2026-08-25). `ship_gate.py` scores Security / Reliability / Infra / Architecture / Observability / Surface from surfaces, not a fixed roster. Detect collapses a six-heading sweep to one Gate so `max_agents_per_space` is not blown. Spawn domain teammates only for FAIL rows.
 
 ## Golden rule
 
-> Detect the job. Gate the estate. Skip is not pass. Human merges.
+> Detect the job. Gate the estate. Skip is not pass. Human merges. SoT is Netie-AI, not D:\\ and not jian-hong.
 
 ## Adaptive notes (2026-08-25)
 
@@ -20,9 +20,13 @@ Claude can scaffold. Crew now refuses a ship when required evidence is missing. 
 - OpenHBM: RTL. sim/lint/formal. No WCAG.
 - AIM: empty. Cannot ship.
 - AnalogCrawler: no CI. surveillance/ path is noted, not reviewed.
-- Netie-KB: not a repo in the org. Do not scrape sibling machines.
+- AirGPT, DMS, chatbot, Pointer, Netie, OMI: not on GitHub (404). Local D:\\ only. FAIL missing_origin.
+- jian-hong/Vking: public personal duplicate of Netie-AI/VKing (run-0003 vs run-0004). FAIL accidental_personal_copy.
+- jian-hong/Python_Automation_JH: venv committed (~8809 files). Accidental store, not a Cortex copy.
+- jian-hong/optio: third-party swarm fork + token-shaped file. Do not merge into Cortex.
+- jian-hong private repos: invisible to this token.
 
-GitHub MCP was down this session. `gh` against Netie-AI worked. Crew uses `gh`, not a second orchestrator.
+GitHub MCP was down this session. `gh` against Netie-AI and public jian-hong worked.
 
 ## Verify
 

--- a/docs/subagents_findings/INDEX.md
+++ b/docs/subagents_findings/INDEX.md
@@ -2,6 +2,7 @@
 
 | Date | Topic | Keywords | Main idea | Path |
 |------|-------|----------|-----------|------|
+| 2026-08-25 | crew-ship-gate-estate | crew, ship-gate, estate, netie-ai, production, security, wcag, detect | Production headings are capability templates plus a deterministic ship-gate. Sweep collapses to Gate. Surfaces pick domains. File presence is not SOC2/HIPAA/GDPR. | `2026-08-25_crew-ship-gate-estate.md` |
 | 2026-08-24 | crew-golden-checkouts | crew, golden, worktree, merge, origin/main, governed-metric | Crew golden is D:\Cortex-crew. Engine golden is D:\Cortex ANS branch. origin/main is published engine. Do not merge pin worktrees into crew. | `2026-08-24_crew-skill-passdown.md` |
 | 2026-08-24 | overnight-watchdog-tickets | overnight, watchdog, night_watch, tickets, verify, paging-file, ram, schtask | Overnight died because schtask skipped Crew/OV. estate now calls night_watch -SkipEstate. Scale = seat existing writers. Low RAM skips gh/gate. | `2026-08-24_overnight-watchdog-tickets.md` |
 | 2026-08-23 | workflows-tasks-500 | workflows, tasks, sqlite, wal, disk-io, 500 | GET /api/workflows/tasks 500 = store disk I/O (wedged WAL). Activity already isolated it. Retry WAL then DELETE. Restart wedged :8010. | `2026-08-23_workflows-tasks-500.md` |

--- a/docs/subagents_findings/INDEX.md
+++ b/docs/subagents_findings/INDEX.md
@@ -2,7 +2,7 @@
 
 | Date | Topic | Keywords | Main idea | Path |
 |------|-------|----------|-----------|------|
-| 2026-08-25 | crew-ship-gate-estate | crew, ship-gate, estate, netie-ai, production, security, wcag, detect, jian-hong, airgpt, dms | Production headings are capability templates plus a deterministic ship-gate. Sweep collapses to Gate. Surfaces pick domains. File presence is not SOC2/HIPAA/GDPR. AirGPT/DMS are missing GitHub origins. jian-hong/Vking is an accidental personal copy. | `2026-08-25_crew-ship-gate-estate.md` |
+| 2026-08-25 | crew-ship-gate-estate | crew, ship-gate, estate, netie-ai, production, security, wcag, detect, jian-hong, airgpt, dms | Production headings are capability templates plus a deterministic ship-gate. Private Netie-AI repos exist; this token 404s them. Grant GitHub App access. Do not build a remote-login box. | `2026-08-25_crew-ship-gate-estate.md` |
 | 2026-08-24 | crew-golden-checkouts | crew, golden, worktree, merge, origin/main, governed-metric | Crew golden is D:\Cortex-crew. Engine golden is D:\Cortex ANS branch. origin/main is published engine. Do not merge pin worktrees into crew. | `2026-08-24_crew-skill-passdown.md` |
 | 2026-08-24 | overnight-watchdog-tickets | overnight, watchdog, night_watch, tickets, verify, paging-file, ram, schtask | Overnight died because schtask skipped Crew/OV. estate now calls night_watch -SkipEstate. Scale = seat existing writers. Low RAM skips gh/gate. | `2026-08-24_overnight-watchdog-tickets.md` |
 | 2026-08-23 | workflows-tasks-500 | workflows, tasks, sqlite, wal, disk-io, 500 | GET /api/workflows/tasks 500 = store disk I/O (wedged WAL). Activity already isolated it. Retry WAL then DELETE. Restart wedged :8010. | `2026-08-23_workflows-tasks-500.md` |

--- a/docs/subagents_findings/INDEX.md
+++ b/docs/subagents_findings/INDEX.md
@@ -2,7 +2,7 @@
 
 | Date | Topic | Keywords | Main idea | Path |
 |------|-------|----------|-----------|------|
-| 2026-08-25 | crew-ship-gate-estate | crew, ship-gate, estate, netie-ai, production, security, wcag, detect | Production headings are capability templates plus a deterministic ship-gate. Sweep collapses to Gate. Surfaces pick domains. File presence is not SOC2/HIPAA/GDPR. | `2026-08-25_crew-ship-gate-estate.md` |
+| 2026-08-25 | crew-ship-gate-estate | crew, ship-gate, estate, netie-ai, production, security, wcag, detect, jian-hong, airgpt, dms | Production headings are capability templates plus a deterministic ship-gate. Sweep collapses to Gate. Surfaces pick domains. File presence is not SOC2/HIPAA/GDPR. AirGPT/DMS are missing GitHub origins. jian-hong/Vking is an accidental personal copy. | `2026-08-25_crew-ship-gate-estate.md` |
 | 2026-08-24 | crew-golden-checkouts | crew, golden, worktree, merge, origin/main, governed-metric | Crew golden is D:\Cortex-crew. Engine golden is D:\Cortex ANS branch. origin/main is published engine. Do not merge pin worktrees into crew. | `2026-08-24_crew-skill-passdown.md` |
 | 2026-08-24 | overnight-watchdog-tickets | overnight, watchdog, night_watch, tickets, verify, paging-file, ram, schtask | Overnight died because schtask skipped Crew/OV. estate now calls night_watch -SkipEstate. Scale = seat existing writers. Low RAM skips gh/gate. | `2026-08-24_overnight-watchdog-tickets.md` |
 | 2026-08-23 | workflows-tasks-500 | workflows, tasks, sqlite, wal, disk-io, 500 | GET /api/workflows/tasks 500 = store disk I/O (wedged WAL). Activity already isolated it. Retry WAL then DELETE. Restart wedged :8010. | `2026-08-23_workflows-tasks-500.md` |

--- a/tests/test_crew/test_board.py
+++ b/tests/test_crew/test_board.py
@@ -48,6 +48,8 @@ def test_skill_packs_seed_without_overwrite(tmp_path) -> None:
     names = {p.name for p in written}
     assert "outreach.md" in names
     assert "chat-human.md" in names
+    assert "ship.md" in names
+    assert "security.md" in names
     assert (folder / "tone.md").exists()
     body = read_skill(folder, "outreach")
     assert "Jian Hong" in body

--- a/tests/test_crew/test_config_policy.py
+++ b/tests/test_crew/test_config_policy.py
@@ -91,6 +91,8 @@ def test_policy_master_switch_and_arming_fail_closed() -> None:
     assert policy.decide("cortex_ask", server=None, armed=False, master_on=False)[0] == policy.ALLOW
     assert policy.decide("netie_board", server=None, armed=False, master_on=False)[0] == policy.ALLOW
     assert policy.decide("desk_status", server=None, armed=False, master_on=False)[0] == policy.ALLOW
+    assert policy.decide("estate_status", server=None, armed=False, master_on=False)[0] == policy.ALLOW
+    assert policy.decide("ship_gate", server=None, armed=False, master_on=False)[0] == policy.ALLOW
     assert policy.decide("rm_rf", server=None, armed=False, master_on=False)[0] == policy.DENY
     denied, reason = policy.decide(
         "click",

--- a/tests/test_crew/test_connectors_import.py
+++ b/tests/test_crew/test_connectors_import.py
@@ -120,7 +120,7 @@ def test_github_list_org_repos_uses_injected_runner(monkeypatch) -> None:
             '"primaryLanguage":{"name":"Python"}}]',
         )
 
-    out = github_mod.list_org_repos(runner=runner)
+    out = github_mod.list_org_repos("Netie-AI", runner=runner)
     assert out["ok"] is True
     assert out["org"] == "Netie-AI"
     assert out["repos"][0]["name"] == "Cortex"

--- a/tests/test_crew/test_connectors_import.py
+++ b/tests/test_crew/test_connectors_import.py
@@ -99,6 +99,35 @@ def test_github_list_prs_uses_injected_runner(monkeypatch) -> None:
     assert "auto-merge" in out["law"].lower() or "Do not auto-merge" in out["law"]
 
 
+def test_github_list_org_repos_uses_injected_runner(monkeypatch) -> None:
+    from CortexOS.crew import github as github_mod
+
+    monkeypatch.setenv("CREW_LIVE_PROBES", "1")
+    monkeypatch.setenv("CREW_GH_ORG", "Netie-AI")
+
+    class Result:
+        def __init__(self, code: int, stdout: str) -> None:
+            self.returncode = code
+            self.stdout = stdout
+            self.stderr = ""
+
+    def runner(argv, timeout=20):  # noqa: ANN001, ARG001
+        assert "repo" in argv and "list" in argv and "Netie-AI" in argv
+        return Result(
+            0,
+            '[{"name":"Cortex","description":"engine","isPrivate":true,'
+            '"url":"https://github.com/Netie-AI/Cortex","updatedAt":"2026-08-25T00:00:00Z",'
+            '"primaryLanguage":{"name":"Python"}}]',
+        )
+
+    out = github_mod.list_org_repos(runner=runner)
+    assert out["ok"] is True
+    assert out["org"] == "Netie-AI"
+    assert out["repos"][0]["name"] == "Cortex"
+    assert out["repos"][0]["private"] is True
+    assert "auto-merge" in out["law"].lower()
+
+
 def test_inbox_without_creds_tells_operator_to_drop(monkeypatch) -> None:
     from CortexOS.crew import inbox as inbox_mod
 

--- a/tests/test_crew/test_roles_mcp.py
+++ b/tests/test_crew/test_roles_mcp.py
@@ -20,6 +20,12 @@ def test_catalog_names_the_specialists() -> None:
         "Skills",
         "Routines",
         "Watchdog",
+        "Security",
+        "Reliability",
+        "Infra",
+        "Architecture",
+        "Observability",
+        "Surface",
     }
     prd = by_name("prd")
     assert prd is not None and "PRD agent" in prd.role

--- a/tests/test_crew/test_runtime.py
+++ b/tests/test_crew/test_runtime.py
@@ -88,6 +88,8 @@ async def test_desk_status_lands_in_transcript(rig, monkeypatch) -> None:
     tools = [m for m in rig.store.list_messages(space["id"]) if m["role"] == "tool"]
     assert tools and "Cursor key" in tools[0]["content"]
     assert "auto-merge" in tools[0]["content"].lower() or "Do not auto-merge" in tools[0]["content"]
+    assert "Estate:" in tools[0]["content"]
+    assert "ship_gate" in tools[0]["content"]
     answer = [m for m in rig.store.list_messages(space["id"]) if m["role"] == "assistant"][-1]
     assert "chat" in answer["content"].lower()
 
@@ -147,6 +149,27 @@ async def test_netie_board_is_in_the_transcript(rig, tmp_path, monkeypatch) -> N
     answer = [m for m in rig.store.list_messages(space["id"]) if m["role"] == "assistant"][-1]
     assert "ANS-01" in answer["content"]
     assert "SEATED" in answer["content"]
+
+
+async def test_ship_gate_lands_fail_in_the_transcript(rig, monkeypatch) -> None:
+    monkeypatch.setenv("CREW_LIVE_PROBES", "0")
+    space = rig.store.create_space("Ship")
+    rig.llm.manager.extend(
+        [
+            LLMResult(tool_calls=[_tc("ship_gate", repo="AIM")]),
+            LLMResult(text="AIM is empty. SHIP FAIL. Cannot ship. No merge."),
+        ]
+    )
+    await rig.runtime.on_user_message(space["id"], "before shipping AIM")
+    await wait_run_done(rig.runtime, space["id"])
+    tools = [m for m in rig.store.list_messages(space["id"]) if m["role"] == "tool"]
+    assert tools
+    assert "SHIP FAIL" in tools[0]["content"]
+    assert "Empty repo cannot ship" in tools[0]["content"]
+    assert "auto-merge" in tools[0]["content"].lower() or "Do not auto-merge" in tools[0]["content"]
+    answer = [m for m in rig.store.list_messages(space["id"]) if m["role"] == "assistant"][-1]
+    assert "FAIL" in answer["content"]
+    assert "empty" in answer["content"].lower()
 
 
 async def test_dead_model_is_a_visible_system_message(rig) -> None:

--- a/tests/test_crew/test_ship_gate.py
+++ b/tests/test_crew/test_ship_gate.py
@@ -1,0 +1,127 @@
+"""Production ship-gate + Netie-AI estate. Assert the operator-visible report."""
+
+from __future__ import annotations
+
+from CortexOS.crew.detect import attached_skills, plan
+from CortexOS.crew.estate import CATALOG, by_slug, required_domains, snapshot
+from CortexOS.crew.roles import by_name, catalog
+from CortexOS.crew.ship_gate import FAIL, PASS, SKIP, evaluate, evaluate_all, render_slug
+
+
+def test_catalog_includes_production_templates() -> None:
+    names = {r["name"] for r in catalog()}
+    assert {"Security", "Reliability", "Infra", "Architecture", "Observability", "Surface"} <= names
+    gate = by_name("Gate")
+    assert gate is not None
+    assert "ship" in gate.skills
+    assert "estate_status" in gate.role
+    sec = by_name("Security")
+    assert sec is not None
+    assert "SOC2" in sec.role
+    assert attached_skills(("Surface",)) == ("ship", "product-surface", "seo")
+
+
+def test_estate_catalog_covers_netie_ai() -> None:
+    slugs = {fp.slug for fp in CATALOG}
+    assert slugs == {
+        "Cortex",
+        "constructor",
+        "OpenVault",
+        "Cassandra",
+        "VKing",
+        "OpenForge",
+        "AnalogCrawler",
+        "OpenHBM",
+        "CI-Doctor",
+        "AIM",
+        "Vertex",
+    }
+    aim = by_slug("Netie-AI/AIM")
+    assert aim is not None and aim.empty is True
+    hbm = by_slug("OpenHBM")
+    assert hbm is not None
+    assert "Surface" not in required_domains(hbm)
+    ctor = by_slug("constructor")
+    assert ctor is not None
+    assert "Surface" in required_domains(ctor)
+
+
+def test_estate_snapshot_offline_names_the_law(monkeypatch) -> None:
+    monkeypatch.setenv("CREW_LIVE_PROBES", "0")
+    snap = snapshot()
+    assert snap["org"] == "Netie-AI"
+    assert snap["n"] == 11
+    text_law = snap["law"]
+    assert "compliance certificate" in text_law.lower() or "certificate" in text_law
+    assert "auto-merge" in text_law.lower()
+
+
+def test_ship_gate_adaptive_verdicts_are_in_the_report() -> None:
+    cortex = evaluate(by_slug("Cortex"))  # type: ignore[arg-type]
+    text = render_slug("Cortex")
+    assert cortex.verdict == PASS
+    assert "SHIP PASS" in text
+    assert "SOC2" in text
+    assert "Do not auto-merge" in text
+    assert "WCAG" not in text or "not a public marketing" in text.lower() or "n/a" in text
+
+    aim = render_slug("AIM")
+    assert "SHIP FAIL" in aim
+    assert "Empty repo cannot ship" in aim
+
+    ctor = render_slug("constructor")
+    assert "SHIP FAIL" in ctor
+    assert "Surface/a11y" in ctor
+    assert "Surface/privacy" in ctor
+
+    hbm = render_slug("OpenHBM")
+    assert "SHIP PASS" in hbm
+    assert "rtl_dv" in hbm
+    assert "Surface/a11y" not in hbm
+
+    analog = render_slug("AnalogCrawler")
+    assert "SHIP FAIL" in analog
+    assert "Infra/ci" in analog
+    assert "does not review or enable" in analog
+
+
+def test_unknown_repo_fails_closed() -> None:
+    text = render_slug("not-a-netie-repo")
+    assert "SHIP FAIL" in text
+    assert "estate_status" in text
+
+
+def test_estate_sweep_counts_fails() -> None:
+    reports = evaluate_all()
+    text = render_slug("all")
+    failed = [r for r in reports if r.verdict == FAIL]
+    assert len(reports) == 11
+    assert len(failed) >= 1
+    assert f"FAIL={len(failed)}" in text
+    assert "AIM" in text
+    # skip is recorded, never turned into pass
+    cortex = next(r for r in reports if r.repo.endswith("/Cortex"))
+    skips = [c for c in cortex.checks if c.status == SKIP]
+    assert any(c.check_id == "compliance_cert" for c in skips)
+
+
+def test_detect_collapses_production_sweep_to_gate() -> None:
+    sweep = plan(
+        "before shipping govern sql injection xss unit tests ci/cd "
+        "connection pooling sentry wcag for every repo"
+    )
+    assert sweep.capabilities == ("Gate",)
+    assert sweep.spawn is True
+    assert "ship" in attached_skills(sweep.capabilities)
+
+    deep = plan("sql injection review of the ledger API")
+    assert deep.capabilities == ("Security",)
+    assert "security" in attached_skills(deep.capabilities)
+
+    a11y = plan("WCAG on constructor")
+    assert "Surface" in a11y.capabilities
+    assert "seo" in attached_skills(a11y.capabilities)
+
+    ship_one = plan("before shipping Cortex")
+    assert "Gate" in ship_one.capabilities
+    assert "Security" not in ship_one.capabilities

--- a/tests/test_crew/test_ship_gate.py
+++ b/tests/test_crew/test_ship_gate.py
@@ -22,7 +22,7 @@ def test_catalog_includes_production_templates() -> None:
 
 
 def test_estate_catalog_covers_netie_ai() -> None:
-    slugs = {fp.slug for fp in CATALOG}
+    slugs = {fp.slug for fp in CATALOG if fp.placement == "canonical"}
     assert slugs == {
         "Cortex",
         "constructor",
@@ -44,13 +44,24 @@ def test_estate_catalog_covers_netie_ai() -> None:
     ctor = by_slug("constructor")
     assert ctor is not None
     assert "Surface" in required_domains(ctor)
+    assert by_slug("VKing") is not None
+    assert by_slug("VKing").full_name == "Netie-AI/VKing"
+    personal = by_slug("jian-hong/Vking")
+    assert personal is not None
+    assert personal.placement == "accidental"
+    assert by_slug("AirGPT").placement == "missing"
+    assert by_slug("DMS").placement == "missing"
 
 
 def test_estate_snapshot_offline_names_the_law(monkeypatch) -> None:
     monkeypatch.setenv("CREW_LIVE_PROBES", "0")
     snap = snapshot()
     assert snap["org"] == "Netie-AI"
-    assert snap["n"] == 11
+    assert snap["n"] == len(CATALOG)
+    assert snap["expected_missing"]
+    assert any(r["full_name"] == "Netie-AI/AirGPT" for r in snap["expected_missing"])
+    assert any(r["full_name"] == "Netie-AI/DMS" for r in snap["expected_missing"])
+    assert any(r["full_name"] == "jian-hong/Vking" for r in snap["accidental"])
     text_law = snap["law"]
     assert "compliance certificate" in text_law.lower() or "certificate" in text_law
     assert "auto-merge" in text_law.lower()
@@ -84,6 +95,19 @@ def test_ship_gate_adaptive_verdicts_are_in_the_report() -> None:
     assert "Infra/ci" in analog
     assert "does not review or enable" in analog
 
+    air = render_slug("AirGPT")
+    assert "SHIP FAIL" in air
+    assert "missing_origin" in air
+    assert "jian-hong" in air
+    dms = render_slug("DMS")
+    assert "missing_origin" in dms
+    vking_copy = render_slug("jian-hong/Vking")
+    assert "accidental_personal_copy" in vking_copy
+    assert "Do not ship from here" in vking_copy
+    optio = render_slug("jian-hong/optio")
+    assert "second_orchestrator" in optio
+    assert "Do not merge into Cortex" in optio
+
 
 def test_unknown_repo_fails_closed() -> None:
     text = render_slug("not-a-netie-repo")
@@ -95,7 +119,7 @@ def test_estate_sweep_counts_fails() -> None:
     reports = evaluate_all()
     text = render_slug("all")
     failed = [r for r in reports if r.verdict == FAIL]
-    assert len(reports) == 11
+    assert len(reports) == len(CATALOG)
     assert len(failed) >= 1
     assert f"FAIL={len(failed)}" in text
     assert "AIM" in text

--- a/tests/test_crew/test_ship_gate.py
+++ b/tests/test_crew/test_ship_gate.py
@@ -49,8 +49,13 @@ def test_estate_catalog_covers_netie_ai() -> None:
     personal = by_slug("jian-hong/Vking")
     assert personal is not None
     assert personal.placement == "accidental"
-    assert by_slug("AirGPT").placement == "missing"
-    assert by_slug("DMS").placement == "missing"
+    assert by_slug("AirGPT").placement == "unseen"
+    assert by_slug("dms").placement == "unseen"
+    assert by_slug("DMS").full_name == "Netie-AI/dms"
+    assert by_slug("Netie-KB").placement == "unseen"
+    assert by_slug("netie-control").placement == "unseen"
+    assert by_slug("ViKing").full_name == "Netie-AI/ViKing"
+    assert by_slug("VKing").full_name == "Netie-AI/VKing"
 
 
 def test_estate_snapshot_offline_names_the_law(monkeypatch) -> None:
@@ -58,9 +63,9 @@ def test_estate_snapshot_offline_names_the_law(monkeypatch) -> None:
     snap = snapshot()
     assert snap["org"] == "Netie-AI"
     assert snap["n"] == len(CATALOG)
-    assert snap["expected_missing"]
-    assert any(r["full_name"] == "Netie-AI/AirGPT" for r in snap["expected_missing"])
-    assert any(r["full_name"] == "Netie-AI/DMS" for r in snap["expected_missing"])
+    assert snap["expected_unseen"]
+    assert any(r["full_name"] == "Netie-AI/dms" for r in snap["expected_unseen"])
+    assert any(r["full_name"] == "Netie-AI/Netie-KB" for r in snap["expected_unseen"])
     assert any(r["full_name"] == "jian-hong/Vking" for r in snap["accidental"])
     text_law = snap["law"]
     assert "compliance certificate" in text_law.lower() or "certificate" in text_law
@@ -97,10 +102,15 @@ def test_ship_gate_adaptive_verdicts_are_in_the_report() -> None:
 
     air = render_slug("AirGPT")
     assert "SHIP FAIL" in air
-    assert "missing_origin" in air
-    assert "jian-hong" in air
-    dms = render_slug("DMS")
-    assert "missing_origin" in dms
+    assert "private_unseen" in air
+    assert "remote-login" in air
+    dms = render_slug("dms")
+    assert "private_unseen" in dms
+    assert "Do not claim the repo is missing" in dms
+    kb = render_slug("Netie-KB")
+    assert "private_unseen" in kb
+    control = render_slug("netie-control")
+    assert "private_unseen" in control
     vking_copy = render_slug("jian-hong/Vking")
     assert "accidental_personal_copy" in vking_copy
     assert "Do not ship from here" in vking_copy


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Crew now refuses a ship when required evidence is missing. Claude can still scaffold; this is the production layer.

## What landed

1. Capability templates: Security, Reliability, Infra, Architecture, Observability, Surface.
2. `estate_status` + `ship_gate` over github.com/Netie-AI, private product repos, and public jian-hong accidentals.
3. Fail closed. Skip is not pass. File presence is not SOC 2 / HIPAA / GDPR.
4. A six-heading sweep collapses to one Gate. Human merges.

## Private repos (operator screenshot 2026-08-25)

These exist. This cloud token still gets GitHub 404 because it cannot read private org repos. That is **not** absence.

dms, Netie-KB, Netie, Pointer, landing, Space, netie-control, RUMA-Houser, ViKing.

**Fix:** GitHub -> Netie-AI -> Settings -> GitHub Apps -> the Cursor/cloud-agent app -> Repository access -> **All repositories** (or select those names). Do not build a remote-login website. Do not share this VM as a laptop or GPU. OpenVault holds keys. Computer control stays confirm-gated.

## Accidental personal copies (github.com/jian-hong)

- `jian-hong/Vking` public duplicate of `Netie-AI/VKing`. Archive or make private.
- `jian-hong/Python_Automation_JH` committed a Windows venv (~8809 files).
- `jian-hong/optio` third-party swarm fork. Do not merge into Cortex.

## Verify

```bash
python -m pytest tests/test_crew -q
```

Say `ship_gate repo=dms` or `estate_status` in Crew.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-01a03acb-fcab-7966-8dbe-c3c498d7391f?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-01a03acb-fcab-7966-8dbe-c3c498d7391f&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

