### PR TITLE
fix(ask): refused is abstain; keep L2 violations; certified synonyms

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -32,7 +32,7 @@ DATA       DuckDB analytics | DuckLake lakehouse (L0) | SQLite ops | Postgres (t
 | DAG runner | Partial — no Temporal, limited fan-out |
 | Cost ledger | Partial |
 | Model routing T0–T3 | Partial |
-| Hybrid RAG | Partial — not wired to demo |
+| Hybrid RAG | Retrieve + fusion shipped (`CortexOS/rag/*`, extras). Route-then-doc-RAG shipped (`RAG_KEYWORDS` → `rag_answer` over the contract corpus). Live Qdrant in the demo is still not wired. RAG-02 / RAG-03 closed; RAG-01 remainder is demo Qdrant, not the retrieve stack. |
 | WASM sandbox | Scaffold only |
 | A2A / personality | Planned (RUMA) |
 
@@ -74,7 +74,7 @@ DATA       DuckDB analytics | DuckLake lakehouse (L0) | SQLite ops | Postgres (t
 - Production WASM / microVM
 - Postgres ledger CI verification / RLS proof (DSN optional locally) — Claude Code packet
 - SOPS production secrets hygiene — Claude Code packet
-- Live Qdrant RAG in demo
+- Live Qdrant RAG in demo (retrieve + route-then-doc-RAG are shipped; this is the RAG-01 remainder)
 - `@agent` chat dispatch + DBOS durable resume (S1 remainder)
 - U0 Data Studio single page
 - F8 governed tool-call publish

--- a/CHANGELOG_DMS.md
+++ b/CHANGELOG_DMS.md
@@ -2,6 +2,24 @@
 
 Agents append one section per shipped feature. Sequential build log.
 
+## DMS handoff — F40 / FF-03 / VQ-01 / EPIC-015 / ledger honesty — 2026-08-25
+
+Cortex engine half of the DMS handoff. Did not re-implement DMS envelope mapping.
+
+- **F40:** `_is_abstain_signal` treats `refused` as abstain. `_abstain_refused`
+  emits route/layer/badge=`refused`. Contract ask never stamps `Badge.SESSION`
+  on a refusal. Manifest refusals use `_abstain_refused`.
+- **FF-03:** `SqlGateAbstain.__str__` names `.violations`. `L2Attempt` returns
+  them instead of dropping them. Draft Cortex PR #41 left conflicting.
+- **VQ-01:** certified queries load `synonyms:`; L0 match is exact on canonical
+  or declared synonym; BETA rewrites to SKU-BETA before lookup; certified SQL
+  runs `normalize_sql_literals`.
+- **EPIC-015:** re-sliced in ARCHITECTURE.md. Retrieve + route-then-doc-RAG are
+  shipped; live Qdrant demo is the RAG-01 remainder.
+- **ledger.verify:** append read-back via existing `list_entries`. Phantom
+  id+hash → 500 `ledger_append_not_on_chain`. Verify fails closed past the tip
+  and on seq gaps. No sixth DMS port.
+
 ## Crew production ship-gate (Netie-AI estate) — 2026-08-25
 
 Crew capability templates for Security, Reliability, Infra, Architecture,

--- a/CortexOS/api/contract_routes.py
+++ b/CortexOS/api/contract_routes.py
@@ -101,6 +101,7 @@ _FLAT_BADGE: dict[str, Badge] = {
     "generated": Badge.QUERY_SKILL,  # L2_VALIDATED on DMS side
     "l2_validated": Badge.QUERY_SKILL,
     "abstain": Badge.ABSTAIN,
+    "refused": Badge.ABSTAIN,  # F40 — contract has no REFUSED badge; never SESSION
     "blocked": Badge.BLOCKED,
 }
 
@@ -119,10 +120,13 @@ def _is_abstain_signal(data: dict[str, Any]) -> bool:
     route = str(data.get("route") or "").lower()
     badge = str(data.get("badge") or "").lower()
     layer = str(data.get("layer") or "").lower()
-    return route in {"needs_clarification", "abstain", "blocked"} or badge in {
+    # "refused" is an engine abstain (F40 / Cortex#11). It is none of the
+    # older tokens, so omitting it stamped Badge.SESSION on a refusal.
+    return route in {"needs_clarification", "abstain", "blocked", "refused"} or badge in {
         "abstain",
         "blocked",
-    } or layer in {"abstain", "blocked"}
+        "refused",
+    } or layer in {"abstain", "blocked", "refused"}
 
 
 def _provenance_from_flat(data: dict[str, Any]) -> Provenance:
@@ -303,8 +307,41 @@ def _ledger() -> Any:
 async def contract_ledger_append(body: LedgerAppendRequest) -> LedgerEntry:
     # No docstring: FastAPI publishes it as the operation `description`, and the
     # released spec (contract/openapi-1.1.0.json) has none for this operation.
-    entry = _ledger().append(body.actor, body.event_type, body.payload)
-    return LedgerEntry.model_validate(_as_mapping(entry))
+    ledger = _ledger()
+    entry = LedgerEntry.model_validate(_as_mapping(ledger.append(body.actor, body.event_type, body.payload)))
+    if not _entry_is_on_chain(ledger, entry):
+        # Honesty: id+hash that never landed is indistinguishable from a write
+        # to DMS, which then calls ledger.verify (whole-chain ok) and trusts it.
+        # There is no get-entry in cortex-contract 1.2.0 — fail closed here.
+        raise HTTPException(
+            status_code=500,
+            detail={
+                "code": "ledger_append_not_on_chain",
+                "message": "append returned id+hash that is not on the chain",
+            },
+        )
+    return entry
+
+
+def _entry_is_on_chain(ledger: Any, entry: LedgerEntry) -> bool:
+    """True when list_entries can see this id+hash. Missing list_entries → fail closed."""
+    if not hasattr(ledger, "list_entries"):
+        return False
+    try:
+        rows = ledger.list_entries(from_seq=entry.seq, limit=1)
+    except TypeError:
+        rows = ledger.list_entries()
+    except Exception:  # noqa: BLE001 — a chain we cannot read is not proven
+        return False
+    for row in rows or []:
+        mapped = _as_mapping(row) if not isinstance(row, LedgerEntry) else {
+            "id": row.id,
+            "entry_hash": row.entry_hash,
+            "seq": row.seq,
+        }
+        if mapped.get("id") == entry.id and mapped.get("entry_hash") == entry.entry_hash:
+            return True
+    return False
 
 
 @router.post("/ledger/verify", response_model=ChainVerification, operation_id="ledger.verify")
@@ -315,7 +352,11 @@ async def contract_ledger_verify(body: LedgerVerifyRequest) -> ChainVerification
         result = ledger.verify_chain(start_seq=body.start_seq)
     else:
         result = ledger.verify(start_seq=body.start_seq)
-    return ChainVerification.model_validate(_as_mapping(result))
+    mapped = _as_mapping(result)
+    # Fail closed: an implementation that cannot produce ok=True/False is a miss.
+    if "ok" not in mapped:
+        return ChainVerification(ok=False, broken_at=body.start_seq or 0)
+    return ChainVerification.model_validate(mapped)
 
 
 @router.get("/tools", response_model=ToolRegistryResponse, operation_id="tool.registry")

--- a/CortexOS/dms/answer_engine.py
+++ b/CortexOS/dms/answer_engine.py
@@ -1218,13 +1218,11 @@ def answer(
             planned_tables = tuple(cq.tables)
             # VQ-01 — certified SQL is a trusted asset; literals still must
             # match the column encoding (BETA → SKU-BETA). Unresolved → abstain.
-            from packs.dms.generative.literal_normalize import normalize_sql_literals
+            from packs.dms.semantic.loader import normalize_certified_sql
 
-            norm = normalize_sql_literals(sql)
-            if not norm.ok:
-                return _abs(f"certified query {cq.id} unresolved literal {norm.violations}")
-            if norm.sql:
-                sql = norm.sql
+            sql, violations = normalize_certified_sql(cq)
+            if violations:
+                return _abs(f"certified query {cq.id} unresolved literal {violations}")
         else:
             plan = route_to_metric(question)
             if plan is not None:

--- a/CortexOS/dms/answer_engine.py
+++ b/CortexOS/dms/answer_engine.py
@@ -89,13 +89,46 @@ def _certified_index() -> dict[str, Any]:
     from packs.dms.semantic.loader import load_all
 
     model = load_all()
-    return {_normalize(cq.question): cq for cq in model.certified}
+    index: dict[str, Any] = {}
+    for cq in model.certified:
+        for phrase in (cq.question, *cq.synonyms):
+            key = _normalize(phrase)
+            if key:
+                index[key] = cq
+    return index
 
 
 def match_certified(question: str):
-    """L0 — EXACT normalized match only (high precision; never fuzzy, so a
-    scoped question can't collide with an unscoped certified query)."""
-    return _certified_index().get(_normalize(question))
+    """L0 — exact normalized match on the canonical question or a declared synonym.
+
+    Synonyms are SME-declared aliases, not fuzzy overlap. A scoped question
+    still cannot collide with an unscoped certified query unless that alias
+    was written down. Value-norm: SKU-shaped tokens are rewritten to the
+    column encoding (BETA → SKU-BETA) before lookup (VQ-01).
+    """
+    key = _normalize(question)
+    hit = _certified_index().get(key)
+    if hit is not None:
+        return hit
+    rewritten = _normalize(_rewrite_certified_value_tokens(question))
+    if rewritten != key:
+        return _certified_index().get(rewritten)
+    return None
+
+
+def _rewrite_certified_value_tokens(question: str) -> str:
+    """Replace SKU-shaped tokens with the warehouse encoding. Fail open on miss."""
+    from packs.dms.semantic import values as valuedict
+
+    def _one(match: re.Match[str]) -> str:
+        raw = match.group(0)
+        res = valuedict.resolve(raw, "sku")
+        if res.ok and res.value and res.value.lower() != raw.lower():
+            return res.value
+        return raw
+
+    # SKU-BETA / bare BETA — never rewrite counts ("top 5") into SKU-00005.
+    return re.sub(r"\bSKU[-\s]?[A-Za-z0-9-]+\b|\bBETA\b", _one, question, flags=re.I)
 
 
 # ── slot extractors ──────────────────────────────────────────────────────────
@@ -669,6 +702,36 @@ def _abstain(
     }
 
 
+def _abstain_refused(
+    question: str,
+    audit_id: str,
+    *,
+    reason: str,
+) -> dict[str, Any]:
+    """Policy / manifest refusal. Distinct from coverage abstain.
+
+    Emits route/layer/badge = ``refused``. Contract mapping must treat this as
+    an abstain signal (F40) — never Badge.SESSION. DMS owns the customer
+    envelope; this is the engine half only.
+    """
+    del question
+    return {
+        "answer": f"I can't answer that ({reason}).",
+        "sql_used": None,
+        "chart_spec": None,
+        "audit_id": audit_id,
+        "violations_blocked": [],
+        "route": "refused",
+        "rows": [],
+        "source_table": None,
+        "layer": "refused",
+        "badge": "refused",
+        "assumptions": reason,
+        "total_count": 0,
+        "suggestions": [],
+    }
+
+
 def _catalog_response(question: str, audit_id: str) -> dict[str, Any]:
     """META-01 — browse what the semantic layer can answer (no SQL)."""
     from packs.dms.semantic.catalog_answer import build_catalog_answer
@@ -1153,6 +1216,15 @@ def answer(
             assumptions = f"certified query {cq.id}"
             metric_id = cq.id
             planned_tables = tuple(cq.tables)
+            # VQ-01 — certified SQL is a trusted asset; literals still must
+            # match the column encoding (BETA → SKU-BETA). Unresolved → abstain.
+            from packs.dms.generative.literal_normalize import normalize_sql_literals
+
+            norm = normalize_sql_literals(sql)
+            if not norm.ok:
+                return _abs(f"certified query {cq.id} unresolved literal {norm.violations}")
+            if norm.sql:
+                sql = norm.sql
         else:
             plan = route_to_metric(question)
             if plan is not None:
@@ -1280,7 +1352,13 @@ def answer(
                 entry.passed = False
                 entry.violations = [type(exc).__name__]
                 log_audit(entry)
-                return _abs(f"{type(exc).__name__}: {exc}")
+                return _done(
+                    _abstain_refused(
+                        question,
+                        audit_id,
+                        reason=f"{type(exc).__name__}: {exc}",
+                    )
+                )
             total_count = _true_count(gate.safe_sql, verified=verified)
             entry.row_count = len(rows)
             log_audit(entry)

--- a/CortexOS/dms/l2_generation.py
+++ b/CortexOS/dms/l2_generation.py
@@ -84,6 +84,7 @@ class L2Attempt:
     layer: str = "generated"
     badge: str = "L2_VALIDATED"
     assumptions: str = ""
+    violations: list[str] | None = None
 
 
 def attempt_l2(question: str, *, verified: Any = None) -> L2Attempt | None:
@@ -135,13 +136,19 @@ def attempt_l2(question: str, *, verified: Any = None) -> L2Attempt | None:
             max_retries=2,
         )
     except SqlGateAbstain as exc:
-        return L2Attempt(reason=f"L2 generation failed validation gate: {exc}")
+        return L2Attempt(
+            reason=f"L2 generation failed validation gate: {exc}",
+            violations=list(exc.violations),
+        )
     finally:
         if con_explain is not None:
             con_explain.close()
 
     if not gate.passed or not gate.safe_sql:
-        return L2Attempt(reason="L2 generation failed validation gate")
+        return L2Attempt(
+            reason="L2 generation failed validation gate",
+            violations=list(gate.violations),
+        )
 
     sql = gate.safe_sql
     try:

--- a/CortexOS/dms/sql_validate_gate.py
+++ b/CortexOS/dms/sql_validate_gate.py
@@ -31,6 +31,15 @@ class SqlGateAbstain(Exception):
         super().__init__(message)
         self.violations = list(violations or [])
 
+    def __str__(self) -> str:
+        # FF-03 / dms#59 — callers interpolate `{exc}` into the envelope reason.
+        # Exception.__str__ is only args[0], which dropped unknown-column /
+        # unbound-table / EXPLAIN detail sitting on `.violations`.
+        base = super().__str__()
+        if not self.violations:
+            return base
+        return f"{base}: {', '.join(self.violations)}"
+
 
 def explain_dry_run(con: Any, sql: str) -> tuple[bool, str]:
     """Run EXPLAIN without executing the query body. Returns (ok, detail)."""

--- a/STATUS.md
+++ b/STATUS.md
@@ -1,5 +1,22 @@
 # STATUS.md
-**Last updated:** 2026-08-25 | **Gate:** G2.3 OSR **SHIPPED** | **Active:** crew production ship-gate
+**Last updated:** 2026-08-25 | **Gate:** G2.3 OSR **SHIPPED** | **Active:** DMS handoff (F40 / FF-03 / VQ-01 / EPIC-015)
+
+> **2026-08-25 (DMS handoff — Cortex engine half):**
+> **F40 / Cortex#11:** `route|layer|badge=refused` is an abstain signal. Contract
+> provenance is `Badge.ABSTAIN`, never `SESSION`. `_abstain_refused` is the
+> engine emitter. DMS envelope mapping stays in DMS (PR #66).
+> **FF-03 / dms#59:** `SqlGateAbstain.__str__` and `L2Attempt.violations` keep
+> the gate's refusal list. Isolated from draft PR #41 (conflicting).
+> **VQ-01 / dms#39:** tree was clean (R-0006). Certified queries match declared
+> synonyms; BETA → SKU-BETA on L0 lookup; certified SQL runs value-norm.
+> **EPIC-015 / #34:** RAG-02 retrieve and RAG-03 route-then-doc-RAG are closed
+> in this tree (`CortexOS/rag/*`, `RAG_KEYWORDS` → `rag_answer`). Re-slice:
+> RAG-01 remainder is live Qdrant in the demo, not "PARTIAL retrieve". DMS
+> RAG-04/05 stay closed. GitHub issues API is 403 here so boxes are sliced in
+> ARCHITECTURE.md / this file, not closed on the epic.
+> **ledger.verify:** append fails closed if the returned id+hash is not on the
+> chain (`list_entries`). No get-entry port. Verify fails closed past the tip
+> and on seq gaps. DMS PR #92 can keep calling whole-chain verify.
 
 > **2026-08-25 (crew ship-gate):** Cortex Crew governs github.com/Netie-AI
 > before shipping. Capability templates: Security, Reliability, Infra,

--- a/docs/subagents_findings/2026-08-25_dms-handoff-f40-ff03.md
+++ b/docs/subagents_findings/2026-08-25_dms-handoff-f40-ff03.md
@@ -1,0 +1,6 @@
+# F40 refused badge, FF-03 L2 violations, VQ-01 certified synonyms
+
+- Date: 2026-08-25
+- Keywords: F40, refused, Badge.SESSION, FF-03, SqlGateAbstain, VQ-01, certified synonyms, EPIC-015, ledger.verify
+- Main idea: Engine `route=refused` must be an abstain signal (never SESSION). L2 must return gate `violations` on the result/`str(exc)`. Certified L0 may match declared synonyms and BETA→SKU-BETA. Append fails closed if id+hash is not on the chain via `list_entries` (no get-entry port). EPIC-015 RAG-02/03 are shipped; RAG-01 remainder is live Qdrant demo.
+- Path: this file

--- a/docs/subagents_findings/INDEX.md
+++ b/docs/subagents_findings/INDEX.md
@@ -2,6 +2,7 @@
 
 | Date | Topic | Keywords | Main idea | Path |
 |------|-------|----------|-----------|------|
+| 2026-08-25 | dms-handoff-f40-ff03 | F40, refused, SESSION, FF-03, SqlGateAbstain, VQ-01, certified, EPIC-015, ledger.verify | Refused is abstain not SESSION. L2 must return gate violations. Certified L0 takes declared synonyms + BETA value-norm. Append fails closed without a get-entry port. RAG-02/03 shipped; RAG-01 is demo Qdrant. | `2026-08-25_dms-handoff-f40-ff03.md` |
 | 2026-08-25 | crew-ship-gate-estate | crew, ship-gate, estate, netie-ai, production, security, wcag, detect, jian-hong, airgpt, dms | Production headings are capability templates plus a deterministic ship-gate. Private Netie-AI repos exist; this token 404s them. Grant GitHub App access. Do not build a remote-login box. | `2026-08-25_crew-ship-gate-estate.md` |
 | 2026-08-24 | crew-golden-checkouts | crew, golden, worktree, merge, origin/main, governed-metric | Crew golden is D:\Cortex-crew. Engine golden is D:\Cortex ANS branch. origin/main is published engine. Do not merge pin worktrees into crew. | `2026-08-24_crew-skill-passdown.md` |
 | 2026-08-24 | overnight-watchdog-tickets | overnight, watchdog, night_watch, tickets, verify, paging-file, ram, schtask | Overnight died because schtask skipped Crew/OV. estate now calls night_watch -SkipEstate. Scale = seat existing writers. Low RAM skips gh/gate. | `2026-08-24_overnight-watchdog-tickets.md` |

--- a/packs/dms/audit/ledger.py
+++ b/packs/dms/audit/ledger.py
@@ -332,12 +332,25 @@ def _sqlite_verify(*, db_path: Path, start_seq: int) -> VerifyResult:
                 (start_seq - 1,),
             ).fetchone()
             prev_hash = prior["entry_hash"] if prior else GENESIS_HASH
+        if not rows:
+            if start_seq > 0:
+                # Fail closed: asking to verify past the tip is not "ok".
+                return VerifyResult(ok=False, broken_at=start_seq)
+            return VerifyResult(ok=True)
+        first = int(rows[0]["seq"])
+        if start_seq == 0 and first != 0:
+            return VerifyResult(ok=False, broken_at=first)
+        expected_seq = start_seq if start_seq > 0 else first
         for row in rows:
+            seq = int(row["seq"])
+            if seq != expected_seq:
+                return VerifyResult(ok=False, broken_at=seq)
             payload = json.loads(row["payload"])
-            expected = compute_entry_hash(int(row["seq"]), prev_hash or GENESIS_HASH, payload, row["created_at"])
+            expected = compute_entry_hash(seq, prev_hash or GENESIS_HASH, payload, row["created_at"])
             if row["entry_hash"] != expected or row["prev_hash"] != (prev_hash or GENESIS_HASH):
-                return VerifyResult(ok=False, broken_at=int(row["seq"]))
+                return VerifyResult(ok=False, broken_at=seq)
             prev_hash = row["entry_hash"]
+            expected_seq = seq + 1
         return VerifyResult(ok=True)
     finally:
         con.close()
@@ -364,12 +377,24 @@ def _postgres_verify(*, start_seq: int) -> VerifyResult:
                 {"seq": start_seq - 1},
             ).mappings().first()
             prev_hash = prior["entry_hash"] if prior else GENESIS_HASH
+        if not rows:
+            if start_seq > 0:
+                return VerifyResult(ok=False, broken_at=start_seq)
+            return VerifyResult(ok=True)
+        first = int(rows[0]["seq"])
+        if start_seq == 0 and first != 0:
+            return VerifyResult(ok=False, broken_at=first)
+        expected_seq = start_seq if start_seq > 0 else first
         for row in rows:
+            seq = int(row["seq"])
+            if seq != expected_seq:
+                return VerifyResult(ok=False, broken_at=seq)
             payload = json.loads(row["payload"])
-            expected = compute_entry_hash(int(row["seq"]), prev_hash or GENESIS_HASH, payload, row["created_at"])
+            expected = compute_entry_hash(seq, prev_hash or GENESIS_HASH, payload, row["created_at"])
             if row["entry_hash"] != expected or row["prev_hash"] != (prev_hash or GENESIS_HASH):
-                return VerifyResult(ok=False, broken_at=int(row["seq"]))
+                return VerifyResult(ok=False, broken_at=seq)
             prev_hash = row["entry_hash"]
+            expected_seq = seq + 1
         return VerifyResult(ok=True)
 
 

--- a/packs/dms/semantic/certified_queries.yaml
+++ b/packs/dms/semantic/certified_queries.yaml
@@ -9,6 +9,9 @@
 certified:
   - id: cq_sku_count
     question: "How many SKUs do we have in inventory?"
+    synonyms:
+      - "How many SKUs in inventory?"
+      - "SKU count in inventory"
     sql: "SELECT COUNT(DISTINCT sku) AS sku_count FROM inventory"
     verified_by: seed
     verified_at: "2026-07-20"
@@ -27,6 +30,9 @@ certified:
 
   - id: cq_sales_top5_value
     question: "Top 5 selling SKUs by revenue"
+    synonyms:
+      - "Top 5 selling SKUs by sales"
+      - "Top 5 SKUs by revenue"
     sql: >
       SELECT sku, ROUND(SUM(quantity_kg * unit_cost_myr), 2) AS sales_value_myr
       FROM transactions WHERE txn_type = 'OUT'

--- a/packs/dms/semantic/loader.py
+++ b/packs/dms/semantic/loader.py
@@ -64,6 +64,7 @@ class CertifiedQuery:
     verified_at: str = ""
     tags: list[str] = field(default_factory=list)
     tables: tuple[str, ...] = ()
+    synonyms: list[str] = field(default_factory=list)
 
 
 @dataclass(slots=True)
@@ -253,17 +254,26 @@ def _load_metrics() -> dict[str, Metric]:
 def _load_certified() -> list[CertifiedQuery]:
     data = yaml.safe_load(CERTIFIED_PATH.read_text(encoding="utf-8"))
     seen: set[str] = set()
+    phrases: set[str] = set()
     out: list[CertifiedQuery] = []
     for raw in data.get("certified", []):
         if raw["id"] in seen:
             raise SemanticError(f"duplicate certified id {raw['id']!r}")
         seen.add(raw["id"])
         sql = raw["sql"].strip()
+        synonyms = list(raw.get("synonyms") or [])
+        for phrase in (raw["question"], *synonyms):
+            key = re.sub(r"[^a-z0-9]+", " ", (phrase or "").lower()).strip()
+            if key and key in phrases:
+                raise SemanticError(f"duplicate certified phrase {phrase!r}")
+            if key:
+                phrases.add(key)
         out.append(CertifiedQuery(
             id=raw["id"], question=raw["question"], sql=sql,
             verified_by=raw.get("verified_by", ""), verified_at=raw.get("verified_at", ""),
             tags=list(raw.get("tags") or []),
             tables=stated_tables(sql),
+            synonyms=synonyms,
         ))
     return out
 

--- a/packs/dms/semantic/loader.py
+++ b/packs/dms/semantic/loader.py
@@ -296,6 +296,16 @@ def reload() -> SemanticModel:
     return load_all()
 
 
+def normalize_certified_sql(cq: CertifiedQuery) -> tuple[str, list[str]]:
+    """Value-norm certified SQL (VQ-01). Pack-side so the engine never names generative."""
+    from packs.dms.generative.literal_normalize import normalize_sql_literals
+
+    norm = normalize_sql_literals(cq.sql)
+    if not norm.ok:
+        return cq.sql, list(norm.violations)
+    return (norm.sql or cq.sql), []
+
+
 def validate_all(*, execute: bool = True) -> dict[str, Any]:
     """Compile every metric with sample params and execute every certified query.
 

--- a/tests/dms/test_certified_synonyms.py
+++ b/tests/dms/test_certified_synonyms.py
@@ -1,0 +1,70 @@
+"""VQ-01 — certified assets match declared synonyms; BETA value-norm on lookup."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+
+from CortexOS.dms.answer_engine import (
+    _rewrite_certified_value_tokens,
+    match_certified,
+)
+
+
+@pytest.fixture(scope="module", autouse=True)
+def ensure_db():
+    from bench.accuracy import _ensure_db_loaded
+    from packs.dms.semantic import values as valuedict
+    from packs.dms.semantic.loader import reload
+
+    _ensure_db_loaded()
+    reload()
+    valuedict.refresh()
+    yield
+
+
+def test_certified_synonym_hits_l0():
+    cq = match_certified("SKU count in inventory")
+    assert cq is not None
+    assert cq.id == "cq_sku_count"
+
+    from CortexOS.dms.answer_engine import answer
+
+    r = answer("SKU count in inventory")
+    assert r["layer"] == "certified"
+    assert r["badge"] == "certified"
+    assert r["route"] == "sql"
+    assert r.get("rows") is not None
+    text = (r.get("answer") or "").lower()
+    assert "sku" in text or r["rows"]
+
+
+def test_certified_sales_synonym_hits_l0():
+    cq = match_certified("Top 5 SKUs by revenue")
+    assert cq is not None
+    assert cq.id == "cq_sales_top5_value"
+
+
+def test_rewrite_beta_to_sku_beta():
+    out = _rewrite_certified_value_tokens("stock of BETA")
+    assert "SKU-BETA" in out
+    assert "BETA" not in out.replace("SKU-BETA", "")
+
+
+def test_value_norm_lookup_hits_certified_canonical(monkeypatch):
+    from CortexOS.dms import answer_engine as ae
+
+    fake = SimpleNamespace(
+        id="cq_beta",
+        question="stock of SKU-BETA",
+        sql="SELECT 1 AS x",
+        synonyms=[],
+        tables=("inventory",),
+    )
+    monkeypatch.setattr(
+        ae, "_certified_index", lambda: {"stock of sku beta": fake}
+    )
+    hit = ae.match_certified("stock of BETA")
+    assert hit is not None
+    assert hit.id == "cq_beta"

--- a/tests/dms/test_enrich_answer_provenance.py
+++ b/tests/dms/test_enrich_answer_provenance.py
@@ -4,9 +4,8 @@ from __future__ import annotations
 
 from types import SimpleNamespace
 
-from packages.cortex_contract.answer import Badge, Provenance
-
 from CortexOS.api.contract_routes import _enrich_answer, _provenance_from_flat
+from packages.cortex_contract.answer import Badge, Provenance
 
 
 def test_provenance_from_flat_needs_clarification_is_abstain():

--- a/tests/dms/test_enrich_answer_provenance.py
+++ b/tests/dms/test_enrich_answer_provenance.py
@@ -28,6 +28,30 @@ def test_provenance_from_flat_blocked():
     assert prov.badge == Badge.BLOCKED
 
 
+def test_provenance_from_flat_refused_is_abstain_not_session():
+    """F40 / Cortex#11 — route=refused must not fall through to SESSION."""
+    prov = _provenance_from_flat(
+        {
+            "route": "refused",
+            "badge": "refused",
+            "layer": "refused",
+            "assumptions": "manifest refused the read",
+        }
+    )
+    assert prov.badge == Badge.ABSTAIN
+    assert prov.layer == "refused"
+    assert prov.assumptions == "manifest refused the read"
+
+
+def test_provenance_from_flat_refused_route_with_session_badge():
+    """The live bug: engine route=refused, badge still session."""
+    prov = _provenance_from_flat(
+        {"route": "refused", "badge": "session", "layer": "refused"}
+    )
+    assert prov.badge == Badge.ABSTAIN
+    assert prov.badge != Badge.SESSION
+
+
 def test_enrich_answer_never_stamps_session_on_abstain():
     verified = SimpleNamespace(manifest={"tables": {}})
     data = _enrich_answer(
@@ -67,3 +91,33 @@ def test_enrich_answer_overrides_preexisting_session_on_abstain():
     prov = data["provenance"]
     badge = prov.badge if isinstance(prov, Provenance) else Provenance.model_validate(prov).badge
     assert badge == Badge.ABSTAIN
+
+
+def test_enrich_answer_never_stamps_session_on_refused():
+    verified = SimpleNamespace(manifest={"tables": {}})
+    data = _enrich_answer(
+        {
+            "answer": "I can't answer that",
+            "route": "refused",
+            "badge": "session",
+            "layer": "refused",
+            "audit_id": "aud_refused",
+            "sql_used": "SELECT 1",
+        },
+        session_id="ses_1",
+        verified=verified,
+    )
+    prov = data["provenance"]
+    badge = prov.badge if isinstance(prov, Provenance) else Provenance.model_validate(prov).badge
+    assert badge == Badge.ABSTAIN
+    assert data.get("drillthrough_token") is None
+    assert data.get("sql_used") is None
+
+
+def test_abstain_refused_emits_refused_fields():
+    from CortexOS.dms.answer_engine import _abstain_refused
+
+    data = _abstain_refused("q", "aud_z", reason="manifest refused")
+    assert data["route"] == "refused"
+    assert data["layer"] == "refused"
+    assert data["badge"] == "refused"

--- a/tests/dms/test_f1_ledger.py
+++ b/tests/dms/test_f1_ledger.py
@@ -158,9 +158,10 @@ def test_postgres_concurrent_appends_consistent(postgres_ledger):
 
 
 def test_postgres_append_only_trigger(postgres_ledger):
-    from packs.dms.audit.ledger import append
     from sqlalchemy import text
     from sqlalchemy.exc import DBAPIError
+
+    from packs.dms.audit.ledger import append
 
     append("pg-tester", "immutable.check", {"ok": True})
 

--- a/tests/dms/test_f1_ledger.py
+++ b/tests/dms/test_f1_ledger.py
@@ -33,6 +33,31 @@ def test_chain_append_and_verify_ok(ledger_db):
     assert result.broken_at is None
 
 
+def test_verify_past_the_tip_fails_closed(ledger_db):
+    from packs.dms.audit.ledger import append, verify
+
+    append("tester", "seed", {"x": 1}, db_path=ledger_db)
+    result = verify(db_path=ledger_db, start_seq=99)
+    assert result.ok is False
+    assert result.broken_at == 99
+
+
+def test_verify_seq_gap_fails_closed(ledger_db):
+    from packs.dms.audit.ledger import append, verify
+
+    append("tester", "seed", {"x": 0}, db_path=ledger_db)
+    append("tester", "seed", {"x": 1}, db_path=ledger_db)
+    con = sqlite3.connect(str(ledger_db))
+    try:
+        con.execute("DELETE FROM dms_audit_ledger WHERE seq = 0")
+        con.commit()
+    finally:
+        con.close()
+    result = verify(db_path=ledger_db)
+    assert result.ok is False
+    assert result.broken_at is not None
+
+
 def test_tamper_detected(ledger_db):
     from packs.dms.audit.ledger import append, verify
 

--- a/tests/dms/test_sql_validate_gate.py
+++ b/tests/dms/test_sql_validate_gate.py
@@ -56,6 +56,51 @@ def test_retry_exhausted_abstains(semantic):
         gate_with_retry(bad, "x", semantic, con=None, max_retries=2)
     assert attempts["n"] == 3  # initial + 2 retries
     assert ei.value.violations
+    for v in ei.value.violations:
+        assert v in str(ei.value)
+
+
+def test_sql_gate_abstain_str_includes_violations():
+    exc = SqlGateAbstain(
+        "SQL validation gate exhausted retries",
+        violations=["UNKNOWN_COLUMN:nope", "EXPLAIN_FAILED:x"],
+    )
+    text = str(exc)
+    assert "UNKNOWN_COLUMN:nope" in text
+    assert "EXPLAIN_FAILED:x" in text
+    assert "exhausted retries" in text
+
+
+def test_sql_gate_abstain_str_without_violations_is_bare():
+    assert str(SqlGateAbstain("SQL validation gate exhausted retries")) == (
+        "SQL validation gate exhausted retries"
+    )
+
+
+def test_l2_attempt_keeps_gate_violations(monkeypatch):
+    from CortexOS.dms import l2_generation
+
+    class _Port:
+        def is_configured(self) -> bool:
+            return True
+
+        def retrieve_schema(self, question: str) -> dict:
+            return {"tables": {"inventory": {}}}
+
+        def generate_candidates(self, question, schema, *, prior_violations=None):
+            return ["SELEC bad FROM nowhere"]
+
+        def record_validated(self, question, sql):
+            return None
+
+    monkeypatch.setenv("DMS_L2_ENABLED", "1")
+    monkeypatch.setattr(l2_generation, "resolve_l2_generation", lambda: _Port())
+    out = l2_generation.attempt_l2("free form anything")
+    assert out is not None
+    assert out.sql is None
+    assert out.violations
+    for v in out.violations:
+        assert v in (out.reason or "")
 
 
 def test_l2_without_model_abstains(monkeypatch):

--- a/tests/dms/test_sql_validate_gate.py
+++ b/tests/dms/test_sql_validate_gate.py
@@ -15,6 +15,9 @@ from CortexOS.dms.warehouse_db import DEFAULT_DB, get_connection, load_semantic_
 
 @pytest.fixture(scope="module")
 def semantic():
+    from bench.accuracy import _ensure_db_loaded
+
+    _ensure_db_loaded()
     return load_semantic_layer()
 
 

--- a/tests/test_api/test_contract_ledger_seam.py
+++ b/tests/test_api/test_contract_ledger_seam.py
@@ -37,19 +37,34 @@ class _StubLedger:
     def __init__(self) -> None:
         self.appended: list[tuple[str, str, dict]] = []
         self.verified: list[int] = []
+        self.entries: list[dict] = []
 
     def append(self, actor: str, event_type: str, payload: dict) -> dict:
         self.appended.append((actor, event_type, payload))
-        return {
-            "id": "e1",
+        entry = {
+            "id": f"e{len(self.appended)}",
             "seq": len(self.appended),
             "actor": actor,
             "event_type": event_type,
             "payload": payload,
             "prev_hash": "0" * 64,
-            "entry_hash": "a" * 64,
+            "entry_hash": ("a" * 63) + str(len(self.appended) % 10),
             "created_at": "2026-07-30T00:00:00Z",
         }
+        self.entries.append(entry)
+        return entry
+
+    def list_entries(
+        self,
+        *,
+        from_seq: int = 0,
+        limit: int = 100,
+        event_type: str | None = None,
+    ) -> list[dict]:
+        rows = [e for e in self.entries if e["seq"] >= from_seq]
+        if event_type:
+            rows = [e for e in rows if e["event_type"] == event_type]
+        return rows[:limit]
 
     def verify(self, *, start_seq: int = 0) -> dict:
         self.verified.append(start_seq)
@@ -92,6 +107,44 @@ def test_ledger_routes_go_through_the_registry() -> None:
     assert stub.verified == [3]
     assert entry.actor == "tester"
     assert chain.ok is True
+
+
+class _LyingLedger:
+    """Append returns id+hash; list_entries and verify see an empty chain."""
+
+    def append(self, actor: str, event_type: str, payload: dict) -> dict:
+        return {
+            "id": "phantom",
+            "seq": 1,
+            "actor": actor,
+            "event_type": event_type,
+            "payload": payload,
+            "prev_hash": "0" * 64,
+            "entry_hash": "b" * 64,
+            "created_at": "2026-07-30T00:00:00Z",
+        }
+
+    def list_entries(self, **_kwargs) -> list:
+        return []
+
+    def verify(self, *, start_seq: int = 0) -> dict:
+        return {"ok": True, "broken_at": None}
+
+
+def test_append_fails_closed_when_entry_is_not_on_the_chain() -> None:
+    ledger_registry.register_ledger(_LyingLedger())
+
+    with pytest.raises(HTTPException) as excinfo:
+        asyncio.run(
+            contract_routes.contract_ledger_append(
+                contract_routes.LedgerAppendRequest(
+                    actor="tester", event_type="demo.event", payload={"k": "v"}
+                )
+            )
+        )
+
+    assert excinfo.value.status_code == 500
+    assert excinfo.value.detail["code"] == "ledger_append_not_on_chain"
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Cortex engine half of the DMS handoff. DMS already owns the customer envelope; this does not re-implement DMS mapping.

## 1. F40 / Cortex#11 (P0)

`_abstain_refused` emits `route/layer/badge=refused`. `_is_abstain_signal` only knew `needs_clarification|abstain|blocked`, so `_provenance_from_flat` stamped `Badge.SESSION` on a refusal.

Treat `refused` as an abstain signal. Contract ask never emits SESSION on a refusal. Manifest refusals use `_abstain_refused`. DMS PR #66 still maps the envelope.

## 2. FF-03 / dms#59

L2 dropped `SqlGateAbstain.violations` because `{exc}` is only `args[0]`. `__str__` now names the list. `L2Attempt.violations` returns them on the gate result.

Isolated from draft PR #41 (conflicting, extra C2/contract/SKU-BETA pile-on). Leave #41 to close.

## 3. VQ-01 / dms#39

Working tree was clean (R-0006). Certified queries load `synonyms:`. L0 match is exact on the canonical question or a declared synonym. `BETA` rewrites to `SKU-BETA` before lookup. Certified SQL runs `normalize_sql_literals`. Parent EPIC-019 / sibling dms#40 unchanged.

## 4. EPIC-015 / #34

Re-sliced in `ARCHITECTURE.md` / `STATUS.md`:

- RAG-02 retrieve: shipped (`CortexOS/rag/*`)
- RAG-03 route-then-doc-RAG: shipped (`RAG_KEYWORDS` -> `rag_answer`)
- RAG-01 remainder: live Qdrant in the demo
- DMS RAG-04/05 stay closed

GitHub issues API is 403 from this token, so the epic boxes are not closed on GitHub.

## 5. ledger.verify honesty

No get-entry in cortex-contract 1.2.0. No sixth DMS port.

`POST /v1/contract/ledger/append` fails closed (`500 ledger_append_not_on_chain`) if the returned id+hash is not visible via existing `list_entries`. `verify` fails closed past the tip and on seq gaps. DMS PR #92 can keep calling whole-chain verify after append.

## Tests

- `test_provenance_from_flat_refused_*` / `test_enrich_answer_never_stamps_session_on_refused`
- `test_sql_gate_abstain_str_includes_violations` / `test_l2_attempt_keeps_gate_violations`
- `test_certified_synonym_hits_l0` / `test_value_norm_lookup_hits_certified_canonical`
- `test_append_fails_closed_when_entry_is_not_on_the_chain`
- `test_verify_past_the_tip_fails_closed`

## Out of scope

No DMS envelope rewrite. No new contract field. No `_C2_ALLOWLIST` names. Did not touch frozen `contract/*.json`.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-01a03af1-6566-7361-8f76-c6044c55ceb6?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-01a03af1-6566-7361-8f76-c6044c55ceb6&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

