### PR TITLE
fix(sql-gate): SqlGateAbstain str carries violations (dms#59)

### DIFF
--- a/CortexOS/dms/sql_validate_gate.py
+++ b/CortexOS/dms/sql_validate_gate.py
@@ -32,6 +32,12 @@ class SqlGateAbstain(Exception):
         self.violations = list(violations or [])
 
     def __str__(self) -> str:
+        base = super().__str__()
+        if not self.violations:
+            return base
+        return f"{base} ({'; '.join(self.violations[:5])})"
+
+    def __str__(self) -> str:
         # FF-03 / dms#59 — callers interpolate `{exc}` into the envelope reason.
         # Exception.__str__ is only args[0], which dropped unknown-column /
         # unbound-table / EXPLAIN detail sitting on `.violations`.

--- a/tests/dms/test_sql_validate_gate.py
+++ b/tests/dms/test_sql_validate_gate.py
@@ -48,6 +48,22 @@ def test_explain_passes_valid_select(semantic):
         con.close()
 
 
+def test_str_carries_violations():
+    exc = SqlGateAbstain(
+        "SQL validation gate exhausted retries",
+        violations=["UNKNOWN_COL:foo", "UNBOUND:bar"],
+    )
+    text = str(exc)
+    assert "SQL validation gate exhausted retries" in text
+    assert "UNKNOWN_COL:foo" in text
+    assert "UNBOUND:bar" in text
+
+
+def test_str_without_violations_is_bare_message():
+    exc = SqlGateAbstain("SQL validation gate exhausted retries")
+    assert str(exc) == "SQL validation gate exhausted retries"
+
+
 def test_retry_exhausted_abstains(semantic):
     attempts = {"n": 0}
 
@@ -59,6 +75,9 @@ def test_retry_exhausted_abstains(semantic):
         gate_with_retry(bad, "x", semantic, con=None, max_retries=2)
     assert attempts["n"] == 3  # initial + 2 retries
     assert ei.value.violations
+    rendered = str(ei.value)
+    for item in ei.value.violations[:5]:
+        assert item in rendered
     for v in ei.value.violations:
         assert v in str(ei.value)
 


### PR DESCRIPTION
## Summary
- FF-03 / dms#59: L2 abstain reason was ``SQL validation gate exhausted retries`` while the actual violations already sat on ``SqlGateAbstain.violations`` and died at ``str(exc)``.
- Fix the class (R-0004), not one raise site. Empty violations stay a bare message.
- New unused branch from origin/main. Does not attach to draft Cortex#41 (CONFLICTING).

## Test plan
- [x] ``pytest tests/dms/test_sql_validate_gate.py::test_str_carries_violations tests/dms/test_sql_validate_gate.py::test_str_without_violations_is_bare_message tests/dms/test_sql_validate_gate.py::test_retry_exhausted_abstains`` - 3 passed
- [ ] CI lint-type-test / protected-paths / rls-proof / secrets-scan / base-install
- [ ] After merge: live free-form abstain names the violation, not only exhausted retries

Closes nothing on Cortex (ticket is Netie-AI/dms#59).