### PR TITLE
fix(answer): refuse adjacent governed_metric answers (ANS-01/02/03)

### DIFF
--- a/CHANGELOG_DMS.md
+++ b/CHANGELOG_DMS.md
@@ -71,6 +71,23 @@ HTTP: `GET /api/connectors` (UI), `/workspaces`, `POST /dispatch`,
 `/cursor/chats`, `/cursor/chats/{id}/messages`, `/instruct`.
 distill: skill_distill/captures/2026-08-22_cursor_orchestration-outside-editor.md
 
+## ANS-01/02/03 answer-path shape — 2026-08-22
+
+Three tickets, one funnel. The router was answering a question adjacent to
+the one asked, badged `governed_metric`.
+
+- ANS-01: an exclusion clause that names an exact SKU plus a conjunction
+  (`and` / `dan` / Malay `keluarkan`…`dari`) now ends at the entities that
+  resolve, so the two stop/skip lists cannot disagree. Applied and answered.
+- ANS-02: an aggregate over a ranking (sum/average/total of top N) abstains
+  and names the two-step path that works. Discourse lead-in `i mean` is not
+  an average.
+- ANS-03: a ranking grouped by a known non-SKU dimension abstains rather
+  than returning the warehouse-wide `revenue_total` as one row. SKU rankings
+  that say "by total revenue" still rank.
+- Asserted on rendered text and rows, not SQL. ANS-04 unknown-subject
+  abstain is unchanged.
+
 ## ANS-04 unknown subject abstain — 2026-08-22
 
 `answer("top 3 customers by amount")` was badged `governed_metric` and rendered

--- a/CortexOS/dms/answer_engine.py
+++ b/CortexOS/dms/answer_engine.py
@@ -219,31 +219,123 @@ def _location(question: str) -> str | None:
 
 _EXCLUSION_STOP = re.compile(
     r"\b(?:what|show|list|give|find|get|top|bottom|best|worst|highest|lowest|"
-    r"ranked?|numbers?|ranks?|selling|sold)\b",
+    r"ranked?|numbers?|ranks?|selling|sold|"
+    r"tunjukkan|tunjuk|senaraikan|senarai|bagi|papar|paparkan)\b",
     re.I,
 )
+# Fillers only. Conjunctions live here so they can be stripped when trailing,
+# and must not be copied into `_EXCLUSION_STOP` - that is the ANS-01 class.
 _EXCLUSION_SKIP = frozenset(
-    {"THE", "A", "AN", "SKU", "AND", "OR", "FROM", "BY", "OF", "ALL", "ANY"}
+    {
+        "THE", "A", "AN", "SKU", "SKUS", "AND", "OR", "FROM", "BY", "OF", "ALL",
+        "ANY", "DARI", "DALAM", "DAN", "ATAU", "YANG", "ITU", "INI",
+    }
 )
+_EXCLUSION_VERB_RE = re.compile(
+    r"\b(?:ignor(?:e|ing)|exclud(?:e|ing)|remov(?:e|ing)|drop(?:ping)?|"
+    r"without|except|"
+    r"kecuali|buang|selain|keluarkan)\s+(?:the\s+)?(.+)",
+    flags=re.I,
+)
+_EXCLUSION_JOINER_RE = re.compile(r"[,/]+|\b(?:and|or|dan|atau)\b", re.I)
+_SKU_SHAPED_RE = re.compile(r"^SKU[-_]?[A-Za-z0-9]+$", re.I)
+
+
+def _strip_trailing_filler(clause: str) -> str:
+    """Drop filler the clause ends on, so the resolver sees only entities.
+
+    ANS-01. `_EXCLUSION_STOP` used to decide where the clause ends and omitted
+    ``and`` / ``dan``; `_EXCLUSION_SKIP` contained them. The stop path then
+    handed ``sku-beta and`` to the fuzzy resolver, which cannot match exactly.
+    One list decides the trailing strip (R-0004). Only *trailing* tokens go, so
+    ``ignore BETA and GAMMA`` keeps the joiner.
+    """
+    tokens = clause.split()
+    while tokens and tokens[-1].strip("'\".,").upper() in _EXCLUSION_SKIP:
+        tokens.pop()
+    return " ".join(tokens)
+
+
+def _resolves_at_all(text: str) -> bool:
+    token = text.strip().strip("'\".,")
+    if not token:
+        return False
+    try:
+        from packs.dms.semantic import values as vd
+
+        res = vd.resolve(token, "sku")
+    except Exception:
+        return False
+    return bool(res.ok and res.value)
+
+
+def _looks_named(part: str) -> bool:
+    """True when *part* is an entity the customer named, not a stray adverb.
+
+    A fuzzy hit counts (the clarify/compile path decides). SKU-shaped tokens
+    count even when the warehouse does not encode them, so a later unknown
+    SKU is reported rather than silently dropped. Adverbs get no hit.
+    """
+    bare = part.strip().strip("'\".,")
+    if not bare:
+        return False
+    return _resolves_at_all(bare) or bool(_SKU_SHAPED_RE.match(bare))
+
+
+def _entity_parts(cand: str) -> str | None:
+    parts = [p.strip().strip("'\".,") for p in _EXCLUSION_JOINER_RE.split(cand)]
+    parts = [p for p in parts if p]
+    if not parts or not all(_looks_named(p) for p in parts):
+        return None
+    return " and ".join(parts)
+
+
+def _entity_span(clause: str) -> str | None:
+    """Longest leading span of entities joined by conjunctions.
+
+    Ends the clause positively, at what resolves, so an unknown adverb cannot
+    reopen ANS-01 (R-0004). Returns None when nothing resolves, leaving the
+    trailing-filler fallback.
+    """
+    whole = clause.strip().strip("'\".,")
+    if not whole:
+        return None
+    named_whole = _entity_parts(whole)
+    if named_whole is not None:
+        return named_whole
+    tokens = whole.split()
+    for end in range(len(tokens) - 1, 0, -1):
+        named = _entity_parts(" ".join(tokens[:end]))
+        if named is not None:
+            return named
+    return None
+
+
+def _exclusion_clauses(q: str) -> list[str]:
+    out: list[str] = []
+    for m in _EXCLUSION_VERB_RE.finditer(q):
+        clause = m.group(1)
+        stop = _EXCLUSION_STOP.search(clause)
+        if stop:
+            clause = clause[: stop.start()]
+        clause = clause.strip().strip("'\".,")
+        anchored = _entity_span(clause)
+        clause = anchored if anchored is not None else _strip_trailing_filler(clause)
+        if clause and clause.lower() not in out:
+            out.append(clause)
+    return out
 
 
 def _excluded_skus(q: str) -> list[str]:
     """Named SKUs to drop from a ranking.
 
     Captures the full exclusion clause so ``excluding SKU-A and SKU-B`` keeps
-    both tokens (the old regex only took the first token after the verb).
+    both tokens. Trailing skip-list words are stripped before the resolver
+    so `_EXCLUSION_STOP` and `_EXCLUSION_SKIP` cannot disagree about ``and``.
     """
     out: list[str] = []
-    for m in re.finditer(
-        r"\b(?:ignor(?:e|ing)|exclud(?:e|ing)|remov(?:e|ing)|drop(?:ping)?|without|except)\s+(?:the\s+)?(.+)",
-        q,
-        flags=re.I,
-    ):
-        clause = m.group(1)
-        stop = _EXCLUSION_STOP.search(clause)
-        if stop:
-            clause = clause[: stop.start()]
-        for token in re.split(r"\s*(?:,|/|\band\b|\bor\b)\s*", clause, flags=re.I):
+    for clause in _exclusion_clauses(q):
+        for token in _EXCLUSION_JOINER_RE.split(clause):
             t = token.strip().strip("'\"")
             tm = re.match(r"^([A-Za-z0-9][\w-]*)$", t)
             if not tm:
@@ -455,12 +547,15 @@ def undefined_subject(question: str) -> str | None:
     return subject
 
 
+_SKU_SUBJECTS = frozenset({"sku", "skus", "item", "items", "product", "products"})
+
+
 def _subject_allows_sales_rank(q: str) -> bool:
-    """Sales rank is SKUs. A named non-SKU subject must not become a SKU list."""
+    """Sales rank is SKUs. Category/supplier/etc. must not become a SKU list."""
     subject = _named_subject(q)
     if subject is None:
         return True
-    return _known_subject_map().get(subject) == "SKUs"
+    return subject in _SKU_SUBJECTS
 
 
 def _wants_sales_rank(q: str, q_raw: str) -> bool:
@@ -475,6 +570,77 @@ def _wants_sales_rank(q: str, q_raw: str) -> bool:
     if _rank_window(q_raw) and re.search(r"\b(sku|skus|revenue|sales|sell)\b", q):
         return True
     return False
+
+
+#: "i mean ...", "you meant ..." - a repair phrase, not an average.
+_DISCOURSE_LEADIN = re.compile(r"^\W*(?:i|we|you)\s+mean(?:t)?\b[\s,:-]*", re.I)
+
+#: Words that aggregate *values*. Narrower than `_wants_aggregate`, which also
+#: carries counting words: counting a ranking of five is five; summing one has
+#: no governed metric.
+_VALUE_AGGREGATE = re.compile(
+    r"\b(sum|summed|summing|total|totals|totalled|totalling|average|averaged|avg|"
+    r"mean|median|combined|altogether|aggregate|cumulative|overall|added up)\b",
+    re.I,
+)
+_CARDINAL = r"(?:\d+|one|two|three|four|five|six|seven|eight|nine|ten)"
+#: A ranking must say how many, or continue into a participle. That is what
+#: separates "top 5" / "highest selling" from "bottom line" / "top-level".
+_RANKING = re.compile(
+    r"\b(top|bottom|highest|lowest|largest|smallest|biggest|best|worst|leading|"
+    rf"foremost|poorest)\b(?:\W{{0,3}}{_CARDINAL}\b|\s+\w+ing\b)",
+    re.I,
+)
+
+
+def _aggregate_over_ranking(question: str) -> str | None:
+    """Reason this question aggregates over a ranking, or None if it does not.
+
+    ANS-02. Every metric either ranks or aggregates. None does both, so
+    "the sum of the top 5 selling SKUs" has no plan. The router used to answer
+    with the ranking, badged governed_metric. Order decides it, not membership:
+    an aggregate *before* the ranking applies to it; an aggregate *after* is
+    the sort key. This is a mitigation (word lists), not Cortex#14 step 1.
+    """
+    question = _DISCOURSE_LEADIN.sub("", question)
+    agg = _VALUE_AGGREGATE.search(question)
+    if agg is None:
+        return None
+    rank = _RANKING.search(question)
+    if rank is None or agg.start() > rank.start():
+        return None
+    return (
+        f"no governed metric computes a {agg.group(0).lower()} over a ranking - "
+        f"ask for the ranking on its own first, then 'sum of them'"
+    )
+
+
+def _grouped_ranking_unanswerable(question: str) -> str | None:
+    """Reason this ranking asks for a grouping no metric returns, or None.
+
+    ANS-03. "top 3 categories by total revenue" used to hit ``revenue_total``
+    and return one warehouse-wide row under governed_metric. Unknown subjects
+    stay with ANS-04. SKU rankings stay answerable (R-0005).
+    """
+    from packs.dms.semantic.vocabulary import normalize_for_routing
+
+    q = _DISCOURSE_LEADIN.sub("", normalize_for_routing(question))
+    if _RANKING.search(q) is None:
+        return None
+    subject = _named_subject(q)
+    if subject is None or subject in _SKU_SUBJECTS:
+        return None
+    if subject not in _known_subject_map():
+        return None
+    return (
+        f"no governed metric ranks {subject} by the requested measure - "
+        f"it would collapse the grouping into one population row"
+    )
+
+
+def _shape_refusal(question: str) -> str | None:
+    """Plan-shape mismatch the router must not paper over with an adjacent metric."""
+    return _aggregate_over_ranking(question) or _grouped_ranking_unanswerable(question)
 
 
 # ── L1 metric router (ordered; specific rules before generic) ────────────────
@@ -495,6 +661,9 @@ def route_to_metric(question: str) -> MetricPlan | None:
     q_raw = question.lower()
     q = normalize_for_routing(question)
 
+    if _shape_refusal(question):
+        return None
+
     # scalars first — "how many X" must not fall through to a listing
     if re.search(r"\b(how many|number of|count of|count)\b", q) and "cold storage" in q:
         return _metric_plan("cold_storage_count", {}, "count of cold-storage locations")
@@ -514,8 +683,13 @@ def route_to_metric(question: str) -> MetricPlan | None:
         return _metric_plan("revenue_last_month", {}, "revenue in the previous calendar month")
     if re.search(r"\b(revenue|sales|sold)\b", q) and re.search(r"\b(last|past|within|previous)\b.*\bday", q):
         return _metric_plan("revenue_windowed", {"days": _days(q_raw, 30)}, "revenue over a rolling window")
-    # G6 — bare total revenue (no month/window); must not fall through to abstain
-    if re.search(r"\btotal\b", q) and re.search(r"\b(revenue|sales)\b", q):
+    # G6 — bare total revenue (no month/window); must not fall through to abstain.
+    # A ranking that happens to say "total revenue" as its sort key is not this.
+    if (
+        re.search(r"\btotal\b", q)
+        and re.search(r"\b(revenue|sales)\b", q)
+        and _RANKING.search(_DISCOURSE_LEADIN.sub("", q)) is None
+    ):
         return _metric_plan("revenue_total", {}, "total outbound revenue")
     if re.search(r"\b(revenue|sales)\b", q) and not re.search(
         r"\b(top|best|highest|most|sku|skus|rank|per|by|each)\b", q
@@ -1011,6 +1185,7 @@ def _aggregate_prior(
     """
     q = question.lower()
     wants_avg = bool(re.search(r"\b(average|avg|mean)\b", q))
+    wants_sum = bool(re.search(r"\b(sum|sums|total|altogether|combined)\b", q)) and not wants_avg
     scale = _scale_factor(q)
     nums = _numeric_columns(rows)
     measure = _pick_measure(nums)
@@ -1057,6 +1232,22 @@ def _aggregate_prior(
             # Literal SELECT — no unknown column vs warehouse allowlist.
             sql = f"SELECT CAST({avg_val} AS DOUBLE) AS {col}"
             return sql, [{col: avg_val}]
+
+    if wants_sum and measure and rows:
+        vals = []
+        for row in rows:
+            raw = row.get(measure)
+            if raw is None:
+                continue
+            try:
+                vals.append(float(raw))
+            except (TypeError, ValueError):
+                continue
+        if vals:
+            total = round(sum(vals), 2)
+            col = f"sum_{measure}"
+            sql = f"SELECT CAST({total} AS DOUBLE) AS {col}"
+            return sql, [{col: total}]
 
     tree = sqlglot.parse_one(prior_sql, read="duckdb")
     tree.set("limit", None)
@@ -1203,6 +1394,9 @@ def answer(
 
         if is_catalog_intent(question):
             return _done(_catalog_response(question, audit_id))
+        refused = _shape_refusal(question)
+        if refused:
+            return _abs(refused)
         unknown = undefined_subject(question)
         if unknown:
             named = ", ".join(_answerable_entities())

--- a/bench/golden/dms_adversarial_v1.yaml
+++ b/bench/golden/dms_adversarial_v1.yaml
@@ -22,6 +22,13 @@ categories:
       assert_sql_contains: ["SKU-BETA"]
       assert_rows_exclude: ["SKU-BETA"]
       assert_answer_excludes: ["SKU-BETA"]
+    # ANS-01: trailing skip token after "and" must not force a confirm chip.
+    - id: exclude_exact_sku_conjunction
+      question: "ignore SKU-BETA and also show the top 5 SKUs by revenue"
+      expect: correct_rows
+      assert_sql_contains: ["SKU-BETA"]
+      assert_rows_exclude: ["SKU-BETA"]
+      assert_answer_excludes: ["SKU-BETA"]
 
   ambiguous_entity:
     - id: exclude_nonexistent_sku
@@ -88,6 +95,14 @@ categories:
     - id: gen_no_silent_template
       # Outside L0/L1 templates; without FreeRoute L2 must abstain (never invent).
       question: "rank carriers by on-time percentage for hazmat only"
+      expect: abstain
+    # ANS-02: a sum over a ranking is adjacent to the ranking itself.
+    - id: sum_of_ranking
+      question: "i mean the sum of top 5 selling skus"
+      expect: abstain
+    # ANS-03: category ranking must not leak the warehouse-wide total.
+    - id: category_ranking
+      question: "top 3 categories by total revenue"
       expect: abstain
 
   # Covered primarily by paraphrase_benchmark + accuracy_benchmark;

--- a/bench/golden/dms_golden_v1.yaml
+++ b/bench/golden/dms_golden_v1.yaml
@@ -62,6 +62,20 @@ items:
     tags: [sales, rank, value_normalization]
     category: value_normalization
 
+  # ANS-01: exact SKU + conjunction + trailing skip token must exclude and answer.
+  - id: exclude_exact_sku_conjunction
+    tier: core
+    question: "ignore SKU-BETA and also show the top 5 SKUs by revenue"
+    match: resultset
+    canonical_sql: >
+      SELECT sku, ROUND(SUM(quantity_kg * unit_cost_myr), 2) AS sales_value_myr
+      FROM transactions WHERE txn_type = 'OUT' AND sku NOT IN ('SKU-BETA')
+      GROUP BY sku ORDER BY sales_value_myr DESC, sku ASC LIMIT 5
+    key_columns: [sku, sales_value_myr]
+    round: 2
+    tags: [sales, rank, value_normalization, ans-01]
+    category: value_normalization
+
   - id: sales_top3_volume
     tier: core
     question: "Top 3 SKUs by quantity sold"
@@ -394,3 +408,17 @@ items:
     question: "top 3 customers by amount"
     match: abstain
     tags: [abstain, unknown-subject]
+
+  # ANS-02: aggregate-over-ranking has no governed metric.
+  - id: abstain_sum_of_ranking
+    tier: safety
+    question: "i mean the sum of top 5 selling skus"
+    match: abstain
+    tags: [abstain, ans-02]
+
+  # ANS-03: grouped ranking must not return the warehouse as one row.
+  - id: abstain_category_ranking
+    tier: safety
+    question: "top 3 categories by total revenue"
+    match: abstain
+    tags: [abstain, ans-03]

--- a/tests/dms/test_ans02_aggregate_over_ranking.py
+++ b/tests/dms/test_ans02_aggregate_over_ranking.py
@@ -1,0 +1,107 @@
+"""ANS-02 — an aggregate over a ranking has no governed metric, so it abstains.
+
+The router used to answer "sum of top 5 selling skus" with the five-row
+ranking, badged governed_metric. Assertions are on rendered text and rows.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from CortexOS.dms.answer_engine import _aggregate_over_ranking, answer, route_to_metric
+
+AGGREGATE_OVER_RANKING = [
+    "i mean the sum of top 5 selling skus",
+    "sum of top 5 selling skus",
+    "total revenue of the top 3 suppliers",
+    "average of the top 5 skus by revenue",
+    "combined revenue of the top 10 skus",
+]
+
+STILL_ANSWERABLE = [
+    "top 5 selling skus by revenue",
+    "what is the total revenue",
+    "total cold storage locations",
+    "how many delayed shipments",
+    "i mean top 5 skus",
+]
+
+ESCAPES = [
+    "total revenue of the leading 3 suppliers",
+    "cumulative revenue of the top 3 suppliers",
+    "overall revenue of the top 3 suppliers",
+]
+
+
+@pytest.fixture(scope="module", autouse=True)
+def ensure_db():
+    from bench.accuracy import _ensure_db_loaded
+    from packs.dms.semantic.loader import reload
+
+    _ensure_db_loaded()
+    reload()
+    yield
+
+
+@pytest.mark.parametrize("question", AGGREGATE_OVER_RANKING)
+def test_an_aggregate_over_a_ranking_abstains(question: str) -> None:
+    body = answer(question)
+    assert body["badge"] == "abstain", (
+        f"{question!r} answered under {body['badge']!r} with {body.get('rows')!r}"
+    )
+    assert body["rows"] == []
+    assert body.get("sql_used") is None
+    rendered = (body.get("answer") or "").lower()
+    assert "ranking" in rendered
+    assert "sum of them" in rendered
+    assert route_to_metric(question) is None
+
+
+def test_the_warehouse_total_is_never_offered_as_the_answer() -> None:
+    body = answer("total revenue of the top 3 suppliers")
+    blob = str(body.get("rows")) + (body.get("answer") or "").replace(",", "")
+    assert body["rows"] == []
+    assert "80375993" not in blob
+
+
+@pytest.mark.parametrize("question", STILL_ANSWERABLE)
+def test_legitimate_questions_still_answer(question: str) -> None:
+    body = answer(question)
+    assert body["badge"] != "abstain", (
+        f"{question!r} became an abstain: {body.get('answer')!r}"
+    )
+    assert body["rows"]
+    rendered = body.get("answer") or ""
+    assert rendered.strip()
+    if "top 5" in question:
+        assert len(body["rows"]) == 5, body["rows"]
+        assert "sku" in body["rows"][0]
+
+
+def test_discourse_leadin_does_not_rename_the_reason() -> None:
+    rendered = answer("i mean the sum of top 5 selling skus")["answer"].lower()
+    assert "computes a sum over a ranking" in rendered
+    assert "mean over a ranking" not in rendered
+
+
+@pytest.mark.parametrize("question", ESCAPES)
+def test_synonyms_do_not_walk_past_the_guard(question: str) -> None:
+    body = answer(question)
+    assert body["badge"] == "abstain"
+    assert "80375993" not in str(body.get("rows")).replace(",", "")
+
+
+def test_the_two_step_path_still_computes_the_sum() -> None:
+    answer("Top 5 selling SKUs by revenue", session_id="ans02-followup")
+    body = answer("Sum of them", session_id="ans02-followup")
+    assert body["rows"]
+    value = next(iter(body["rows"][0].values()))
+    assert float(value) > 0
+    assert "sum" in (body.get("answer") or "").lower()
+
+
+def test_order_decides_it_not_membership() -> None:
+    assert _aggregate_over_ranking("sum of the top 5 skus") is not None
+    assert _aggregate_over_ranking("top 5 skus by total revenue") is None
+    assert _aggregate_over_ranking("total revenue of the top 3") is not None
+    assert _aggregate_over_ranking("top 3 by total revenue") is None

--- a/tests/dms/test_ans03_grouped_ranking.py
+++ b/tests/dms/test_ans03_grouped_ranking.py
@@ -1,0 +1,90 @@
+"""ANS-03 — a ranking grouped by a dimension must not return one warehouse row.
+
+"top 3 categories by total revenue" used to compile ``revenue_total`` and
+return [{"revenue_myr": 80375993.99}] under governed_metric. No metric ranks
+categories by sales, so the honest outcome is to abstain and say why.
+Assertions are on rendered text and returned rows, not SQL.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from CortexOS.dms.answer_engine import answer, route_to_metric
+from CortexOS.dms.query_service import answer_question
+
+GROUPED_RANKINGS = [
+    "top 3 categories by total revenue",
+    "top 5 categories by total revenue",
+]
+
+
+@pytest.fixture(scope="module", autouse=True)
+def ensure_db():
+    from bench.accuracy import _ensure_db_loaded
+    from packs.dms.semantic.loader import reload
+
+    _ensure_db_loaded()
+    reload()
+    yield
+
+
+def _warehouse_total_leaked(body: dict) -> bool:
+    blob = str(body.get("rows")) + (body.get("answer") or "").replace(",", "")
+    return "80375993" in blob
+
+
+@pytest.mark.parametrize("question", GROUPED_RANKINGS)
+def test_grouped_ranking_does_not_return_the_warehouse_as_one_row(
+    question: str,
+) -> None:
+    body = answer(question)
+    rows = body.get("rows") or []
+    rendered = body.get("answer") or ""
+
+    assert not _warehouse_total_leaked(body), (
+        f"{question!r} returned the warehouse total under {body.get('badge')!r}: "
+        f"{rows!r} / {rendered!r}"
+    )
+    if body.get("badge") == "abstain":
+        assert rows == []
+        assert body.get("sql_used") is None
+        low = rendered.lower()
+        assert "categor" in low
+        assert "can't answer" in low or "no governed metric" in low
+        assert route_to_metric(question) is None
+        return
+
+    assert len(rows) >= 2, (
+        f"{question!r} answered with {len(rows)} row(s), not one row per group: "
+        f"{rows!r}"
+    )
+    assert "category" in {str(k).lower() for k in rows[0]}
+    asked = 3 if "top 3" in question else 5
+    assert len(rows) <= asked
+
+
+def test_sku_rank_that_names_total_revenue_still_ranks() -> None:
+    """R-0005 — "top 5 SKUs by total revenue" ranks SKUs; it is not a scalar."""
+    body = answer("top 5 SKUs by total revenue")
+    assert body["badge"] != "abstain", body.get("answer")
+    assert len(body.get("rows") or []) == 5
+    assert "sku" in body["rows"][0]
+    assert not _warehouse_total_leaked(body)
+    rendered = body.get("answer") or ""
+    assert "SKU-" in rendered
+
+
+def test_bare_total_revenue_still_answers() -> None:
+    body = answer_question("what is our total revenue")
+    assert body["badge"] == "governed_metric"
+    assert body["rows"]
+    assert float(body["rows"][0]["revenue_myr"]) > 0
+    assert any(ch.isdigit() for ch in (body.get("answer") or ""))
+
+
+def test_unknown_subject_still_belongs_to_ans04() -> None:
+    body = answer("top 3 customers by amount")
+    assert body["badge"] == "abstain"
+    assert body["rows"] == []
+    assert "customer" in (body.get("answer") or "").lower()

--- a/tests/dms/test_exclusion_clause_funnel.py
+++ b/tests/dms/test_exclusion_clause_funnel.py
@@ -1,0 +1,109 @@
+"""ANS-01 — an exact SKU plus a conjunction must exclude and answer.
+
+Two lists used to disagree about ``and`` / ``dan``. The clause now ends at
+the entities that resolve, so a trailing conjunction or adverb cannot force
+a confirm chip. Assertions are on rendered text and returned rows, not SQL.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from CortexOS.dms.answer_engine import _excluded_skus, answer, route_to_metric
+from CortexOS.dms.query_service import answer_question
+
+TICKET_PHRASINGS = [
+    "ignore SKU-BETA and show the top 5 SKUs by revenue",
+    "ignore BETA and show the top 5 SKUs by revenue",
+    "keluarkan BETA dari top 5 sku revenue",
+]
+
+ADVERB_PHRASINGS = [
+    "ignore SKU-BETA and also show the top 5 SKUs by revenue",
+    "exclude SKU-BETA and just show the top 5 SKUs by revenue",
+    "buang BETA dan tunjukkan top 5 sku revenue",
+]
+
+
+@pytest.fixture(scope="module", autouse=True)
+def ensure_db():
+    from bench.accuracy import _ensure_db_loaded
+    from packs.dms.semantic.loader import reload
+
+    _ensure_db_loaded()
+    reload()
+    yield
+
+
+@pytest.mark.parametrize("question", TICKET_PHRASINGS + ADVERB_PHRASINGS)
+def test_exact_sku_plus_conjunction_excludes_and_answers(question: str) -> None:
+    body = answer_question(question)
+    rows = body.get("rows") or []
+    assert rows, (
+        f"{question!r} abstained instead of applying the exclusion - "
+        f"badge={body.get('badge')!r} answer={body.get('answer')!r}"
+    )
+    assert body["badge"] != "abstain"
+    assert body["route"] == "sql"
+    rendered = str(body.get("answer") or "")
+    assert rendered.strip(), "rendered answer was empty"
+    assert "SKU-BETA" not in rendered.upper()
+    assert all("BETA" not in str(row.get("sku", "")).upper() for row in rows)
+    assert "?" not in rendered
+
+
+def test_exclusion_slot_strips_trailing_skip_tokens() -> None:
+    assert _excluded_skus("ignore SKU-BETA and show the top 5 SKUs by revenue") == [
+        "SKU-BETA"
+    ]
+    assert _excluded_skus("ignore SKU-BETA and also show the top 5 SKUs by revenue") == [
+        "SKU-BETA"
+    ]
+    assert _excluded_skus("keluarkan BETA dari top 5 sku revenue") == ["BETA"]
+    assert "ALSO" not in _excluded_skus(
+        "ignore SKU-00397 and also show the top 5 SKUs by revenue"
+    )
+
+
+def test_dropping_rank_one_changes_the_rank_one_row() -> None:
+    baseline = answer("show the top 5 SKUs by revenue")
+    leaders = [row.get("sku") for row in (baseline.get("rows") or [])]
+    assert leaders, "baseline ranking is empty"
+    leader = leaders[0]
+
+    body = answer(f"ignore {leader} and also show the top 5 SKUs by revenue")
+    rows = body.get("rows") or []
+    assert rows, f"excluding {leader} abstained: {body.get('answer')!r}"
+    got = [row.get("sku") for row in rows]
+    assert leader not in got
+    assert leader not in str(body.get("answer") or "")
+    assert body["badge"] != "abstain"
+
+
+def test_two_named_skus_are_both_excluded() -> None:
+    baseline = answer("show the top 5 SKUs by revenue")
+    leaders = [row.get("sku") for row in (baseline.get("rows") or [])]
+    assert len(leaders) >= 2
+    first, second = leaders[0], leaders[1]
+
+    body = answer(f"exclude {first} and {second} and show top 5")
+    rows = body.get("rows") or []
+    assert rows, f"two-SKU exclusion abstained: {body.get('answer')!r}"
+    got = [row.get("sku") for row in rows]
+    assert first not in got and second not in got
+    rendered = str(body.get("answer") or "")
+    assert first not in rendered and second not in rendered
+
+
+def test_unknown_sku_shaped_token_abstains_rather_than_half_applying() -> None:
+    body = answer("exclude SKU-BETA and SKU-GAMMA and SKU-00397 and show top 5")
+    assert body["badge"] == "abstain"
+    assert body["rows"] == []
+    assert "SKU-GAMMA" in str(body.get("answer") or "")
+
+
+def test_route_still_compiles_sales_rank() -> None:
+    plan = route_to_metric("ignore SKU-BETA and show the top 5 SKUs by revenue")
+    assert plan is not None
+    assert plan.metric_id == "sales_by_value"
+    assert plan.slots.get("exclude_skus") == ["SKU-BETA"]


### PR DESCRIPTION
## Summary
- Rebase of ANS-01/02/03 onto current main (supersedes draft PR #48, which is 23 behind and dirty).
- ANS-01: exclusion clause ends at resolved entities.
- ANS-02: aggregate-over-ranking abstains.
- ANS-03: grouped ranking abstains instead of warehouse-wide total.
- Golden pins keep the main ANS-04 customers case and add ANS-02/03.

## Test plan
- [ ] `pytest tests/dms/test_exclusion_clause_funnel.py tests/dms/test_ans02_aggregate_over_ranking.py tests/dms/test_ans03_grouped_ranking.py -q`
- [ ] CI lint-type-test / base-install / protected-paths / secrets-scan / rls-proof

Closes #8, #36, #38