### PR TITLE
test(packaging): built cortex-contract wheel reproduces the frozen canonical vectors (EPIC-002)

### DIFF
--- a/tests/packaging/test_contract_wheel.py
+++ b/tests/packaging/test_contract_wheel.py
@@ -1,0 +1,115 @@
+"""EPIC-002 — the built cortex-contract wheel is the same contract.
+
+DMS pins ``cortex-contract`` as a dependency so the models and the
+canonicalisation rule are *the same code* as the engine's. That promise is
+only real if the artifact we hand out reproduces ``canonical_manifest_bytes``
+byte-for-byte — a wheel that drifts from the repo would present as a
+signature bug on every manifest DMS signs.
+
+This test builds the wheel with pip, imports it in a clean subprocess whose
+``cortex_contract`` resolves from the unpacked artifact (asserted, not
+assumed — the repo may also be importable via an editable install), and
+replays every frozen vector in ``contract/testvectors/manifest_canonical.jsonl``
+against it. PyPI publishing stays a founder step; this proves the artifact is
+publishable.
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+import zipfile
+from pathlib import Path
+
+import pytest
+from cortex_contract.version import CONTRACT_VERSION
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+PKG_DIR = REPO_ROOT / "packages" / "cortex_contract"
+VECTORS_PATH = REPO_ROOT / "contract" / "testvectors" / "manifest_canonical.jsonl"
+
+# Runs inside the built artifact only: argv[1] = unpacked wheel dir,
+# argv[2] = vectors path, argv[3] = expected contract version.
+_SUBPROCESS_PROBE = """
+import hashlib, json, sys
+from pathlib import Path
+
+site = Path(sys.argv[1]).resolve()
+import cortex_contract
+got = Path(cortex_contract.__file__).resolve()
+assert str(got).startswith(str(site)), (
+    f"cortex_contract resolved from {got}, not the built wheel at {site}"
+)
+
+from cortex_contract.version import CONTRACT_VERSION
+assert CONTRACT_VERSION == sys.argv[3], (CONTRACT_VERSION, sys.argv[3])
+
+from cortex_contract.execution import Manifest, canonical_manifest_bytes
+
+checked = 0
+for line in Path(sys.argv[2]).read_text(encoding="utf-8").splitlines():
+    if not line.strip():
+        continue
+    vector = json.loads(line)
+    produced = canonical_manifest_bytes(Manifest.model_validate(vector["manifest"]))
+    assert produced.decode("utf-8") == vector["canonical_utf8"], vector["name"]
+    assert hashlib.sha256(produced).hexdigest() == vector["canonical_sha256"], vector["name"]
+    assert len(produced) == vector["canonical_length"], vector["name"]
+    checked += 1
+assert checked >= 20, f"only {checked} vectors replayed"
+print(f"wheel-ok {checked}")
+"""
+
+
+@pytest.fixture(scope="module")
+def built_wheel(tmp_path_factory: pytest.TempPathFactory) -> Path:
+    out = tmp_path_factory.mktemp("contract_wheel")
+    proc = subprocess.run(
+        [sys.executable, "-m", "pip", "wheel", str(PKG_DIR), "--no-deps", "-w", str(out)],
+        capture_output=True,
+        text=True,
+        timeout=600,
+    )
+    assert proc.returncode == 0, f"pip wheel failed:\n{proc.stdout}\n{proc.stderr}"
+    wheels = sorted(out.glob("cortex_contract-*.whl"))
+    assert len(wheels) == 1, [w.name for w in wheels]
+    return wheels[0]
+
+
+def test_wheel_filename_carries_the_contract_version(built_wheel: Path) -> None:
+    """Artifact-level twin of scripts/check_versions.py."""
+    assert built_wheel.name.startswith(f"cortex_contract-{CONTRACT_VERSION}-")
+
+
+def test_wheel_ships_the_module_not_the_repo_layout(built_wheel: Path) -> None:
+    with zipfile.ZipFile(built_wheel) as zf:
+        names = zf.namelist()
+    assert any(n == "cortex_contract/__init__.py" for n in names), names[:10]
+    assert not any(n.startswith("packages/") for n in names), (
+        "wheel must ship top-level cortex_contract, never the packages/ spelling"
+    )
+
+
+def test_artifact_reproduces_every_canonical_vector(
+    built_wheel: Path, tmp_path: Path
+) -> None:
+    site = tmp_path / "site"
+    with zipfile.ZipFile(built_wheel) as zf:
+        zf.extractall(site)
+    probe = tmp_path / "probe.py"
+    probe.write_text(_SUBPROCESS_PROBE, encoding="utf-8")
+    proc = subprocess.run(
+        [sys.executable, str(probe), str(site), str(VECTORS_PATH), CONTRACT_VERSION],
+        capture_output=True,
+        text=True,
+        timeout=120,
+        cwd=tmp_path,  # repo root must not be importable via cwd
+        env={
+            **os.environ,
+            "PYTHONPATH": str(site),
+            "PYTHONSAFEPATH": "1",  # no cwd/script-dir on sys.path (3.11+)
+        },
+    )
+    assert proc.returncode == 0, f"probe failed:\n{proc.stdout}\n{proc.stderr}"
+    assert "wheel-ok" in proc.stdout


### PR DESCRIPTION
First startable EPIC-002 slice, per the survey in `docs/subagents_findings/2026-08-23_epic002-contract-wheel-blocked.md`: it was blocked until CONTRACT-01's one-identity fix reached main — that landed yesterday as #69 (verified: 0 `packages.cortex_contract` imports on main, name-binding refusal live, `tests/contract/test_contract_module_identity.py` present).

## What this adds

`tests/packaging/test_contract_wheel.py` — three assertions that the artifact we would hand a consumer *is* the contract:

1. **Builds the real wheel** with `pip wheel packages/cortex_contract --no-deps` and pins the filename to `CONTRACT_VERSION` (artifact-level twin of `scripts/check_versions.py`).
2. **Refuses the wrong layout** — the wheel must ship top-level `cortex_contract/`, never the `packages/` spelling (the CONTRACT-01 bug class).
3. **Replays all 25 frozen canonicalisation vectors against the artifact** in a clean subprocess: `cortex_contract` is asserted to resolve from the unpacked wheel (not the repo's editable install — `PYTHONSAFEPATH`, cwd off-repo, resolution asserted on `__file__`), then every vector in `contract/testvectors/manifest_canonical.jsonl` must reproduce byte-for-byte, sha256 and length included. A wheel that drifts from the repo would present as a signature bug on every manifest DMS signs; this catches it at build time.

PyPI publishing stays a founder step (no twine/PYPI_TOKEN workflow exists); this proves the artifact is publishable. Advances #16 — does not close it.

## Verification

```
python -m pytest tests/packaging/test_contract_wheel.py -q   → 3 passed in 37.22s
ruff check tests/packaging/test_contract_wheel.py            → clean
```

No protected paths touched (`tests/packaging/` is not in the guard set).

## CI note

Org GitHub Actions is billing-blocked right now, so checks will insta-fail until Billing & plans is fixed; re-run checks after unblocking.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
