### PR TITLE
fix(bench): empty correct_rows is wrong, not correct

### DIFF
--- a/bench/adversarial.py
+++ b/bench/adversarial.py
@@ -121,6 +121,13 @@ def _score(item: AdvItem, resp: dict[str, Any]) -> str:
     if route != "sql":
         return "wrong"
 
+    # Negative assertions are vacuous on an empty result set. A predicate that
+    # matched nothing (SKU-BETA / NOT IN ('BETA')) is wrong, not correct.
+    if not rows:
+        return "wrong"
+    if not str(answer).strip():
+        return "wrong"
+
     for needle in item.assert_sql_contains:
         if needle.upper() not in sql:
             return "wrong"

--- a/tests/dms/test_adversarial_benchmark.py
+++ b/tests/dms/test_adversarial_benchmark.py
@@ -89,3 +89,42 @@ def test_eleven_categories_declared():
 
 def test_holding_pids_hint_parses_pid_token():
     assert "28008" in _holding_pids_hint(RuntimeError("File locked (PID 28008)"))
+
+
+def _sku_beta_correct_rows_item():
+    from bench.adversarial import AdvItem
+
+    return AdvItem(
+        id="exclude_bare_beta",
+        category="value_normalization",
+        question="excluding BETA, top 5 sku by revenue",
+        expect="correct_rows",
+        assert_sql_contains=["SKU-BETA"],
+        assert_rows_exclude=["SKU-BETA"],
+        assert_answer_excludes=["SKU-BETA"],
+    )
+
+
+def test_score_correct_rows_rejects_vacuous_empty_rows():
+    """NOT IN ('SKU-BETA') that matches nothing must not score correct."""
+    from bench.adversarial import _score
+
+    resp = {
+        "route": "sql",
+        "sql_used": "SELECT sku FROM fact_sales WHERE sku NOT IN ('SKU-BETA') LIMIT 5",
+        "rows": [],
+        "answer": "No matching SKUs.",
+    }
+    assert _score(_sku_beta_correct_rows_item(), resp) == "wrong"
+
+
+def test_score_correct_rows_rejects_empty_answer_text():
+    from bench.adversarial import _score
+
+    resp = {
+        "route": "sql",
+        "sql_used": "SELECT sku FROM fact_sales WHERE sku NOT IN ('SKU-BETA') LIMIT 5",
+        "rows": [{"sku": "SKU-ALPHA"}],
+        "answer": "   ",
+    }
+    assert _score(_sku_beta_correct_rows_item(), resp) == "wrong"


### PR DESCRIPTION
## Summary
- `bench.adversarial._score` on `expect=correct_rows` now requires non-empty rows and non-empty rendered answer text, then keeps the existing SQL/exclude assertions.
- A `NOT IN ('SKU-BETA')` predicate that matches nothing can no longer score `correct` (CLAUDE.md section 8 / SKU-BETA false-green class).
- Unit tests in `tests/dms/test_adversarial_benchmark.py` cover empty rows and empty answer text.

## Test plan
- [x] `PACK=dms python -m pytest tests/dms/test_adversarial_benchmark.py -q` (6 passed)
- [ ] Confirm value_normalization still gates at `wrong_max: 0` once this lands