### PR TITLE
test(answer): gate exclusion, low-stock, catalog on rendered text and rows

### DIFF
--- a/tests/dms/test_certified_synonyms.py
+++ b/tests/dms/test_certified_synonyms.py
@@ -35,15 +35,34 @@ def test_certified_synonym_hits_l0():
     assert r["layer"] == "certified"
     assert r["badge"] == "certified"
     assert r["route"] == "sql"
-    assert r.get("rows") is not None
-    text = (r.get("answer") or "").lower()
-    assert "sku" in text or r["rows"]
+    rows = r.get("rows") or []
+    assert rows, f"certified sku-count returned no rows: {r.get('answer')!r}"
+    text = r.get("answer") or ""
+    assert text.strip(), "certified sku-count rendered no answer text"
+    assert "sku" in text.lower()
+    assert any(ch.isdigit() for ch in text)
+    assert "sku_count" in rows[0]
+    assert int(rows[0]["sku_count"]) > 0
 
 
 def test_certified_sales_synonym_hits_l0():
     cq = match_certified("Top 5 SKUs by revenue")
     assert cq is not None
     assert cq.id == "cq_sales_top5_value"
+
+    from CortexOS.dms.answer_engine import answer
+
+    r = answer("Top 5 SKUs by revenue")
+    assert r["layer"] == "certified"
+    assert r["badge"] == "certified"
+    assert r["route"] == "sql"
+    rows = r.get("rows") or []
+    assert len(rows) == 5, f"certified top-5 returned {len(rows)} rows: {r.get('answer')!r}"
+    text = r.get("answer") or ""
+    assert text.strip(), "certified top-5 rendered no answer text"
+    for row in rows:
+        assert str(row["sku"]) in text
+        assert "sales_value_myr" in row
 
 
 def test_rewrite_beta_to_sku_beta():

--- a/tests/dms/test_meta01_catalog.py
+++ b/tests/dms/test_meta01_catalog.py
@@ -7,6 +7,17 @@ from CortexOS.dms.answer_engine import answer as engine_answer
 from packs.dms.semantic.catalog_answer import is_catalog_intent
 from packs.dms.semantic.loader import load_all
 
+
+@pytest.fixture(scope="module", autouse=True)
+def ensure_db():
+    from bench.accuracy import _ensure_db_loaded
+    from packs.dms.semantic.loader import reload
+
+    _ensure_db_loaded()
+    reload()
+    yield
+
+
 # Phrasings that used to split: two routed, two abstained. Also a couple of
 # same-class wordings so the matcher is an intent, not a remembered list.
 CATALOG_PHRASES = (
@@ -24,12 +35,16 @@ CATALOG_PHRASES = (
 def _assert_catalog_payload(r: dict) -> None:
     assert r["route"] != "needs_clarification"
     assert r["layer"] == "catalog"
+    # Catalog prose is never a green session grant.
     assert r["badge"] == "catalog"
+    assert r["badge"] != "session"
     assert r["sql_used"] is None
     assert r["rows"] == []
-    answer = (r.get("answer") or "").lower()
-    assert "certified" in answer
-    assert "table" in answer
+    answer = r.get("answer") or ""
+    assert answer.strip(), "catalog rendered no customer-visible text"
+    low = answer.lower()
+    assert "certified" in low
+    assert "table" in low
     suggestions = r.get("suggestions") or []
     assert suggestions
     model = load_all()
@@ -56,3 +71,14 @@ def test_meta01_revenue_still_governed():
     plan = route_to_metric(q)
     assert plan is not None
     assert plan.metric_id == "revenue_total"
+
+    r = engine_answer(q)
+    assert r["badge"] != "session"
+    assert r["badge"] != "catalog"
+    assert r["layer"] == "governed_metric"
+    rows = r.get("rows") or []
+    assert rows, f"revenue returned no rows: {r.get('answer')!r}"
+    text = r.get("answer") or ""
+    assert text.strip(), "revenue rendered no answer text"
+    assert any(ch.isdigit() for ch in text)
+    assert float(rows[0]["revenue_myr"]) > 0

--- a/tests/dms/test_q2_answer_engine.py
+++ b/tests/dms/test_q2_answer_engine.py
@@ -238,6 +238,23 @@ def test_l2_disabled_by_default(monkeypatch):
     assert r["route"] == "needs_clarification"  # no L2 model wired → abstain, not guess
 
 
+def _assert_exclusion_visible(r: dict, excluded: list[str], *, n: int = 5) -> None:
+    """Customer-visible exclusion: non-empty ranking rows, text lists them, omitted SKUs stay out."""
+    rows = r.get("rows") or []
+    assert rows, f"exclusion returned zero rows: {r.get('answer')!r}"
+    assert 1 <= len(rows) <= n
+    skus = [str(row["sku"]).upper() for row in rows]
+    rendered = r.get("answer") or ""
+    assert rendered.strip(), "rendered answer was empty"
+    for token in excluded:
+        assert token.upper() not in skus
+        assert token.upper() not in rendered.upper()
+    for sku in skus:
+        assert sku in rendered.upper()
+    assert "None" not in rendered
+    assert "?" not in rendered
+
+
 def test_top_sku_excludes_named_sku():
     r = answer_question("ignoring SKU-00173 what is the top 5 sku by revenue")
     assert r["route"] == "sql"
@@ -245,13 +262,7 @@ def test_top_sku_excludes_named_sku():
     sql = (r["sql_used"] or "").upper()
     assert "SKU-00173" in sql
     assert "NOT" in sql and "IN" in sql
-    skus = [row["sku"].upper() for row in (r.get("rows") or [])]
-    assert "SKU-00173" not in skus
-    assert len(skus) <= 5
-    answer = r.get("answer") or ""
-    assert "SKU-00173" not in answer.upper()
-    assert "None" not in answer
-    assert "?" not in answer
+    _assert_exclusion_visible(r, ["SKU-00173"])
 
 
 def test_top_sku_excludes_bare_beta_token():
@@ -261,10 +272,7 @@ def test_top_sku_excludes_bare_beta_token():
     assert r["layer"] == "governed_metric"
     sql = (r["sql_used"] or "").upper()
     assert "SKU-BETA" in sql
-    skus = [str(row["sku"]).upper() for row in (r.get("rows") or [])]
-    assert "SKU-BETA" not in skus
-    answer = (r.get("answer") or "").upper()
-    assert "SKU-BETA" not in answer
+    _assert_exclusion_visible(r, ["SKU-BETA"])
 
 
 def test_top_sku_excludes_multiple_and_bare_token():
@@ -275,19 +283,13 @@ def test_top_sku_excludes_multiple_and_bare_token():
     assert r["layer"] == "governed_metric"
     sql = (r["sql_used"] or "").upper()
     assert "SKU-00173" in sql and "SKU-00241" in sql
-    skus = [row["sku"].upper() for row in (r.get("rows") or [])]
-    assert "SKU-00173" not in skus
-    assert "SKU-00241" not in skus
-    answer = (r.get("answer") or "").upper()
-    assert "SKU-00173" not in answer
-    assert "SKU-00241" not in answer
+    _assert_exclusion_visible(r, ["SKU-00173", "SKU-00241"])
 
     bare = answer_question("ignoring 00173 what is the top 5 sku by revenue")
     assert bare["route"] == "sql"
     bare_sql = (bare["sql_used"] or "").upper()
     assert "SKU-00173" in bare_sql
-    bare_skus = [row["sku"].upper() for row in (bare.get("rows") or [])]
-    assert "SKU-00173" not in bare_skus
+    _assert_exclusion_visible(bare, ["SKU-00173"])
 
 
 def test_query_skill_does_not_replay_stale_exclusions(tmp_path, monkeypatch):
@@ -311,6 +313,14 @@ def test_query_skill_does_not_replay_stale_exclusions(tmp_path, monkeypatch):
     sql = (r["sql_used"] or "").upper()
     assert "SKU-00173" not in sql
     assert "NOT IN" not in sql
+    rows = r.get("rows") or []
+    assert rows, f"stale-replay returned zero rows: {r.get('answer')!r}"
+    rendered = r.get("answer") or ""
+    assert rendered.strip(), "stale-replay rendered no answer text"
+    low = rendered.lower()
+    assert "sales" in low or "ranked" in low or "myr" in low
+    for row in rows:
+        assert str(row["sku"]) in rendered
 
 
 def test_low_stock_followup_uses_inventory_not_placeholders():

--- a/tests/test_dms/test_dms_pipeline.py
+++ b/tests/test_dms/test_dms_pipeline.py
@@ -103,7 +103,21 @@ def test_query_low_stock(loaded_db, monkeypatch):
     result = query_service.answer_question("Which SKUs are below reorder level?")
     assert result["violations_blocked"] == []
     assert result["sql_used"]
-    assert result.get("row_count", 0) >= 0
+    rows = result.get("rows") or []
+    assert rows, f"low-stock listing empty: {result.get('answer')!r}"
+    for row in rows:
+        assert row.get("sku")
+        qty = float(row["quantity_kg"])
+        assert qty >= 0
+        reorder = row.get("reorder_level_kg", row.get("reorder_level"))
+        if reorder is not None:
+            assert qty < float(reorder)
+    rendered = result.get("answer") or ""
+    assert rendered.strip(), "low-stock rendered no answer text"
+    low = rendered.lower()
+    assert "below reorder" in low or "reorder level" in low
+    for row in rows[:8]:
+        assert str(row["sku"]) in rendered
 
 
 def test_query_top_sales_respects_top_n(loaded_db, monkeypatch):


### PR DESCRIPTION
## Summary
- Q2 exclusion and stale-replay gates now require non-empty rows and rendered text (CLAUDE.md section 8).
- Low-stock pipeline gate no longer passes on `row_count >= 0`; asserts qty vs reorder plus rendered SKUs.
- Certified synonym and catalog/revenue tests assert the customer-visible artifact; catalog stays badge=catalog, never SESSION.

## Test plan
- [x] `PACK=dms python -m pytest tests/dms/test_q2_answer_engine.py tests/test_dms/test_dms_pipeline.py tests/dms/test_certified_synonyms.py tests/dms/test_meta01_catalog.py -q` (47 passed)
- [ ] Independent of Cortex #72/#73 file set (tests only)
- [ ] Do not merge while Netie-AI Actions is billing-blocked (red checks are not a code signal)
