### PR TITLE
fix(sdk): require a session manifest for warehouse reads

### DIFF
--- a/CortexOS/agent_sdk/backends.py
+++ b/CortexOS/agent_sdk/backends.py
@@ -15,6 +15,8 @@ import re
 from pathlib import Path
 from typing import Any, Protocol
 
+from CortexOS.execution.manifest import VerifiedManifest
+
 _IDENT = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*$")
 
 
@@ -26,6 +28,7 @@ class QueryBackend(Protocol):
         filters: dict[str, Any],
         limit: int,
         *,
+        verified: VerifiedManifest,
         db_path: Path | str | None = None,
     ) -> list[dict[str, Any]]: ...
 
@@ -61,15 +64,20 @@ def _dms_duckdb_backend(
     filters: dict[str, Any],
     limit: int,
     *,
+    verified: VerifiedManifest | None = None,
     db_path: Path | str | None = None,
 ) -> list[dict[str, Any]]:
     """Reference backend: the DMS DuckDB warehouse (object type id == table name).
 
-    Opens via ``CortexOS.execution.warehouse`` only — no direct ``duckdb`` import
-    (C4). Ungoverned agent reads remain a C4.follow concern relative to
-    ``enforce_manifest``; the AST invariant is what this change closes.
+    Every read goes through ``execute_sql`` -> ``enforce_manifest``. Missing
+    verified is a hard refuse — this backend never opens an ungoverned connection.
     """
-    from CortexOS.execution.warehouse import get_connection, warehouse_path
+    from CortexOS.execution.session_manifests import SessionUnbound
+    from CortexOS.execution.submit import execute_sql
+    from CortexOS.execution.warehouse import warehouse_path
+
+    if verified is None:
+        raise SessionUnbound("manifest is required for warehouse reads")
 
     root = Path(__file__).resolve().parents[2]
     path = (
@@ -89,10 +97,7 @@ def _dms_duckdb_backend(
             values.append(value)
         where_sql = " WHERE " + " AND ".join(parts)
     sql = f"SELECT {cols_sql} FROM {_quote(object_type)}{where_sql} LIMIT {int(limit)}"
-    con = get_connection(path, read_only=True)
-    try:
-        rel = con.execute(sql, values)
-        names = [d[0] for d in rel.description]
-        return [dict(zip(names, row, strict=False)) for row in rel.fetchall()]
-    finally:
-        con.close()
+    rows, _, _ = execute_sql(
+        verified, sql, params=values or None, db_path=path
+    )
+    return rows

--- a/CortexOS/agent_sdk/sdk.py
+++ b/CortexOS/agent_sdk/sdk.py
@@ -4,8 +4,9 @@ Every function takes ``pack`` (name) or ``pack_dir`` (explicit path — wins whe
 given) so the engine serves any pack; defaults resolve from the PACK env var.
 
 Read path (``query_objects``): only ``agent_visible`` properties are ever
-selected or filterable — for every role. The SDK is the *agent* surface; PII
-kept out of prompts is the point, so there is no privileged bypass here.
+selected or filterable — for every role. A bound session/manifest is required;
+the backend executes through ``enforce_manifest``. The SDK is the *agent*
+surface; PII kept out of prompts is the point, so there is no privileged bypass.
 
 Write path (``call_action``): registry lookup → role gate → confirm gate →
 F8 runner (allowlist → sanitize → compliance → sandbox → F1 ledger). SDK-level
@@ -118,6 +119,10 @@ def list_functions(
 
 # -- reads -------------------------------------------------------------------
 
+# Self-issued grants are not a session binding (answer_engine.resolve_product_grant).
+_LOCAL_ISSUER_KID = "local-self-issued"
+
+
 def query_objects(
     object_type: str,
     filters: dict[str, Any] | None = None,
@@ -127,8 +132,21 @@ def query_objects(
     pack: str | None = None,
     pack_dir: Path | str | None = None,
     db_path: Path | str | None = None,
+    session_id: str | None = None,
+    verified: Any | None = None,
 ) -> list[dict[str, Any]]:
-    """Rows of one object type — agent-visible columns only, equality filters."""
+    """Rows of one object type — agent-visible columns only, equality filters.
+
+    Reads require a bound session/manifest. Missing or self-issued grants refuse;
+    there is no ungoverned warehouse fallback.
+    """
+    from CortexOS.execution.manifest import ManifestError
+    from CortexOS.execution.session_manifests import (
+        SessionExpired,
+        SessionUnbound,
+        get_session_registry,
+    )
+
     _identity(actor)  # any known role may read visible data
     resolved = _resolve_pack_dir(pack, pack_dir)
     objects = {o.id: o for o in load_object_types(resolved)}
@@ -145,7 +163,32 @@ def query_objects(
             raise SdkDenied(f"unknown property {key!r}", verdict="not_found")
 
     backend = get_query_backend(pack or ("dms" if pack_dir is None else _missing_pack(resolved)))
-    return backend(object_type, visible, dict(filters or {}), max(1, min(int(limit), 500)), db_path=db_path)
+    bound = verified
+    if bound is None:
+        try:
+            bound = get_session_registry().resolve(session_id)
+        except SessionUnbound as exc:
+            raise SdkDenied(str(exc), verdict="session_unbound") from exc
+        except SessionExpired as exc:
+            raise SdkDenied(str(exc), verdict="session_expired") from exc
+    if (getattr(bound, "issuer_kid", None) or "").strip() == _LOCAL_ISSUER_KID:
+        raise SdkDenied(
+            "self-issued grant is not a session binding",
+            verdict="session_unbound",
+        )
+    try:
+        return backend(
+            object_type,
+            visible,
+            dict(filters or {}),
+            max(1, min(int(limit), 500)),
+            verified=bound,
+            db_path=db_path,
+        )
+    except SessionUnbound as exc:
+        raise SdkDenied(str(exc), verdict="session_unbound") from exc
+    except ManifestError as exc:
+        raise SdkDenied(str(exc), verdict=getattr(exc, "code", "manifest_error")) from exc
 
 
 def _missing_pack(pack_dir: Path) -> str:

--- a/CortexOS/api/sidecar_routes.py
+++ b/CortexOS/api/sidecar_routes.py
@@ -107,6 +107,7 @@ class QueryObjectsRequest(BaseModel):
     object_type: str
     filters: dict[str, Any] = Field(default_factory=dict)
     limit: int = 50
+    session_id: str | None = None
 
 
 class CallActionRequest(BaseModel):
@@ -121,7 +122,9 @@ _DENIAL_STATUS = {
     "unregistered": 404,
     "confirm_required": 409,
     "not_invocable": 400,
-    # rbac / filter_hidden / bad_actor and anything new default to 403
+    "session_unbound": 409,
+    "session_expired": 409,
+    # rbac / filter_hidden / bad_actor / path_not_allowed default to 403
 }
 
 
@@ -139,7 +142,12 @@ def sidecar_query_objects(
 
     try:
         rows = query_objects(
-            req.object_type, req.filters, actor=caller, limit=req.limit, pack="dms"
+            req.object_type,
+            req.filters,
+            actor=caller,
+            limit=req.limit,
+            pack="dms",
+            session_id=req.session_id,
         )
     except SdkDenied as exc:
         raise _sdk_http_error(exc) from exc

--- a/CortexOS/dms/sql_validate_gate.py
+++ b/CortexOS/dms/sql_validate_gate.py
@@ -7,7 +7,7 @@ answer engine still abstains.
 
 from __future__ import annotations
 
-from collections.abc import Callable
+from collections.abc import Callable, Sequence
 from dataclasses import dataclass, field
 from typing import Any
 
@@ -41,10 +41,15 @@ class SqlGateAbstain(Exception):
         return f"{base}: {', '.join(self.violations)}"
 
 
-def explain_dry_run(con: Any, sql: str) -> tuple[bool, str]:
+def explain_dry_run(
+    con: Any, sql: str, params: Sequence[Any] | None = None
+) -> tuple[bool, str]:
     """Run EXPLAIN without executing the query body. Returns (ok, detail)."""
     try:
-        con.execute(f"EXPLAIN {sql}")
+        if params is not None:
+            con.execute(f"EXPLAIN {sql}", params)
+        else:
+            con.execute(f"EXPLAIN {sql}")
         return True, "ok"
     except Exception as exc:  # noqa: BLE001
         return False, str(exc)[:400]

--- a/CortexOS/execution/submit.py
+++ b/CortexOS/execution/submit.py
@@ -8,6 +8,7 @@ through this module.
 from __future__ import annotations
 
 import time
+from collections.abc import Sequence
 from typing import Any
 
 from cortex_contract.execution import Manifest, QueryResult, SubmitRequest
@@ -177,11 +178,14 @@ def execute_sql(
     pool_id: str | None = None,
     db_path: Any = None,
     explain_gate: bool | None = None,
+    params: Sequence[Any] | None = None,
 ) -> tuple[list[dict[str, Any]], float, float]:
     """Enforce + execute rewritten SQL. Returns (rows, queue_ms, exec_ms).
 
     When ``explain_gate`` is True (default: env ``DMS_EXPLAIN_GATE`` unset or
     truthy), run DuckDB EXPLAIN after manifest enforce and before fetch.
+    ``params`` are forwarded to both EXPLAIN and the fetch execute so bind
+    placeholders in caller SQL survive predicate wrapping.
     """
     import os
 
@@ -201,7 +205,7 @@ def execute_sql(
         con = get_connection(path, read_only=read_only_queries_enabled() or True)
         try:
             if use_explain:
-                ok, detail = explain_dry_run(con, safe_sql)
+                ok, detail = explain_dry_run(con, safe_sql, params=params)
                 if not ok:
                     raise SqlGateAbstain(
                         f"EXPLAIN rejected SQL: {detail}",
@@ -214,7 +218,7 @@ def execute_sql(
                     con.execute(f"SET statement_timeout='{int(timeout_s * 1000)}ms'")
                 except Exception:  # noqa: BLE001
                     pass
-            rel = con.execute(safe_sql)
+            rel = con.execute(safe_sql, params) if params is not None else con.execute(safe_sql)
             rows_raw = rel.fetchall()
             columns = [d[0] for d in rel.description] if rel.description else []
             rows = [dict(zip(columns, row, strict=False)) for row in rows_raw]

--- a/packs/dms/agents/sdk.py
+++ b/packs/dms/agents/sdk.py
@@ -49,9 +49,18 @@ def query_objects(
     actor: Any,
     limit: int = 50,
     db_path: Path | str | None = None,
+    session_id: str | None = None,
+    verified: Any | None = None,
 ):
     return _engine.query_objects(
-        object_type, filters, actor=actor, limit=limit, pack=PACK, db_path=db_path
+        object_type,
+        filters,
+        actor=actor,
+        limit=limit,
+        pack=PACK,
+        db_path=db_path,
+        session_id=session_id,
+        verified=verified,
     )
 
 

--- a/tests/dms/test_agent_sdk.py
+++ b/tests/dms/test_agent_sdk.py
@@ -37,6 +37,47 @@ def ledger_db(tmp_path, monkeypatch):
     return db
 
 
+@pytest.fixture
+def granted_session():
+    """Wide in-process grant so visibility tests still read through enforce_manifest."""
+    from datetime import datetime, timedelta, timezone
+
+    from cortex_contract.execution import Manifest
+
+    from CortexOS.execution.manifest import VerifiedManifest
+    from CortexOS.execution.pool import PoolConfig, reset_read_pool_for_tests
+    from CortexOS.execution.session_manifests import (
+        get_session_registry,
+        reset_session_registry_for_tests,
+    )
+
+    reset_session_registry_for_tests()
+    reset_read_pool_for_tests(PoolConfig("default", 4, 5.0, 30.0))
+    now = datetime.now(timezone.utc)
+    verified = VerifiedManifest(
+        manifest=Manifest(
+            session_id="sdk-wide",
+            org_id="acme",
+            pool_id="default",
+            issuer_key_id="int-1",
+            allowed_paths=["/data/pool/acme/**"],
+            row_predicates={
+                "inventory": "1=1",
+                "suppliers": "1=1",
+                "locations": "1=1",
+            },
+            issued_at=now.isoformat(),
+            expires_at=(now + timedelta(minutes=5)).isoformat(),
+            signature="not-checked-here",
+        ),
+        issuer_kid="int-1",
+        verified_at=now,
+    )
+    get_session_registry().bind(verified)
+    yield "sdk-wide"
+    reset_session_registry_for_tests()
+
+
 # -- 1. visibility ----------------------------------------------------------
 
 def test_schema_listing_strips_hidden_properties():
@@ -46,19 +87,28 @@ def test_schema_listing_strips_hidden_properties():
     assert "supplier_name" in names
 
 
-def test_query_returns_only_visible_columns(warehouse):
-    rows = dms_sdk.query_objects("suppliers", actor=VIEWER, limit=5, db_path=warehouse)
+def test_query_returns_only_visible_columns(warehouse, granted_session):
+    rows = dms_sdk.query_objects(
+        "suppliers", actor=VIEWER, limit=5, db_path=warehouse, session_id=granted_session
+    )
     assert rows, "sample warehouse should have suppliers"
     for row in rows:
         assert {"email", "phone", "contact_person"}.isdisjoint(row)
         assert "supplier_name" in row
 
 
-def test_filters_work_and_hidden_filter_is_refused(warehouse):
-    all_rows = dms_sdk.query_objects("inventory", actor=VIEWER, limit=500, db_path=warehouse)
+def test_filters_work_and_hidden_filter_is_refused(warehouse, granted_session):
+    all_rows = dms_sdk.query_objects(
+        "inventory", actor=VIEWER, limit=500, db_path=warehouse, session_id=granted_session
+    )
     category = all_rows[0]["category"]
     filtered = dms_sdk.query_objects(
-        "inventory", {"category": category}, actor=VIEWER, limit=500, db_path=warehouse
+        "inventory",
+        {"category": category},
+        actor=VIEWER,
+        limit=500,
+        db_path=warehouse,
+        session_id=granted_session,
     )
     assert filtered and all(r["category"] == category for r in filtered)
     assert len(filtered) <= len(all_rows)
@@ -125,11 +175,15 @@ def test_event_kind_not_invocable_and_unregistered(ledger_db):
 
 # -- 3. identity ------------------------------------------------------------
 
-def test_api_auth_caller_duck_types(warehouse):
+def test_api_auth_caller_duck_types(warehouse, granted_session):
     from packs.dms.security.api_auth import Caller
 
     rows = dms_sdk.query_objects(
-        "locations", actor=Caller(role="viewer", actor="api_viewer"), limit=3, db_path=warehouse
+        "locations",
+        actor=Caller(role="viewer", actor="api_viewer"),
+        limit=3,
+        db_path=warehouse,
+        session_id=granted_session,
     )
     assert rows and "location_code" in rows[0]
 

--- a/tests/dms/test_o5_sidecar_sdk.py
+++ b/tests/dms/test_o5_sidecar_sdk.py
@@ -37,6 +37,42 @@ def env(tmp_path, monkeypatch, warehouse_db):
 
 
 @pytest.fixture
+def granted_session():
+    from datetime import datetime, timedelta, timezone
+
+    from cortex_contract.execution import Manifest
+
+    from CortexOS.execution.manifest import VerifiedManifest
+    from CortexOS.execution.pool import PoolConfig, reset_read_pool_for_tests
+    from CortexOS.execution.session_manifests import (
+        get_session_registry,
+        reset_session_registry_for_tests,
+    )
+
+    reset_session_registry_for_tests()
+    reset_read_pool_for_tests(PoolConfig("default", 4, 5.0, 30.0))
+    now = datetime.now(timezone.utc)
+    verified = VerifiedManifest(
+        manifest=Manifest(
+            session_id="sidecar-wide",
+            org_id="acme",
+            pool_id="default",
+            issuer_key_id="int-1",
+            allowed_paths=["/data/pool/acme/**"],
+            row_predicates={"inventory": "1=1", "suppliers": "1=1", "locations": "1=1"},
+            issued_at=now.isoformat(),
+            expires_at=(now + timedelta(minutes=5)).isoformat(),
+            signature="not-checked-here",
+        ),
+        issuer_kid="int-1",
+        verified_at=now,
+    )
+    get_session_registry().bind(verified)
+    yield "sidecar-wide"
+    reset_session_registry_for_tests()
+
+
+@pytest.fixture
 def client(env):
     reset_limiter(per_minute=240)
     from CortexOS.api.app import create_app
@@ -48,10 +84,10 @@ VIEWER = {"X-API-Key": "sk-viewer-test"}
 STEWARD = {"X-API-Key": "sk-steward-test"}
 
 
-def test_query_objects_hides_pii_columns(client):
+def test_query_objects_hides_pii_columns(client, granted_session):
     res = client.post(
         "/dms/sidecar/query-objects",
-        json={"object_type": "suppliers", "limit": 5},
+        json={"object_type": "suppliers", "limit": 5, "session_id": granted_session},
         headers=VIEWER,
     )
     assert res.status_code == 200, res.text

--- a/tests/test_execution/hostile_sql_corpus.json
+++ b/tests/test_execution/hostile_sql_corpus.json
@@ -644,6 +644,20 @@
       "expected": "reject_predicate_bypass",
       "why_it_might_slip": "The outer query references 'orders', so a name-based injector believes the predicate landed. But 'orders' here is a derived-table alias over an in-manifest glob read, never the base table. An injector that dedupes by name will mark 'orders' handled and skip it, and one that rewrites the alias only filters an already-materialized unfiltered scan.",
       "sql": "SELECT orders.tenant_id, count(*) AS n\nFROM (\n    SELECT * FROM read_parquet('/data/pool/tenant_a/*.parquet')\n) AS orders\nGROUP BY orders.tenant_id"
+    },
+    {
+      "name": "sdk_shaped_read_of_ungranted_table",
+      "sql": "SELECT \"id\" FROM \"secrets\" LIMIT 3",
+      "technique": "ungranted_table_via_quoted_identifier",
+      "why_it_might_slip": "The Agent SDK emits double-quoted identifiers. A quoted bare name is not a file path, so the path screen does not fire, and grant checking is the only remaining control. If the table-name walk dropped quotes or treated the identifier as a path it had already cleared, an SDK read of a table the manifest never named would pass.",
+      "expected": "reject_path"
+    },
+    {
+      "name": "sdk_shaped_read_keeps_predicate_under_bind_params",
+      "sql": "SELECT \"id\", \"tenant_id\" FROM \"orders\" WHERE \"tenant_id\" = ? AND \"region\" = ? LIMIT 3",
+      "technique": "predicate_injection_with_bind_parameters",
+      "why_it_might_slip": "The SDK wraps filters as positional ? placeholders. Predicate wrapping moves the table into a FROM subquery. If the injected predicate ever carried a placeholder, or the rewrite reordered the tree, every positional bind would silently attach to the wrong column and the caller would get rows it did not ask for under a manifest that looked enforced.",
+      "expected": "allow_but_predicate_must_apply"
     }
   ],
   "_expected_values": {

--- a/tests/test_execution/test_sdk_manifest.py
+++ b/tests/test_execution/test_sdk_manifest.py
@@ -1,0 +1,172 @@
+"""P22 — Agent SDK warehouse reads must go through enforce_manifest.
+
+Ungranted tables refuse. Granted tables return rows and the row predicate
+is actually applied to those rows (not only to generated SQL).
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+import pytest
+from cortex_contract.execution import Manifest
+
+from CortexOS.agent_sdk import AgentActor, SdkDenied, query_objects
+from CortexOS.agent_sdk.backends import get_query_backend
+from CortexOS.execution.manifest import VerifiedManifest
+from CortexOS.execution.pool import PoolConfig, reset_read_pool_for_tests
+from CortexOS.execution.session_manifests import (
+    SessionUnbound,
+    get_session_registry,
+    reset_session_registry_for_tests,
+)
+
+VIEWER = AgentActor(actor="sdk_manifest_viewer", role="viewer")
+INVENTORY_ONLY = {"inventory": "location_id = 'LOC-001'"}
+
+
+@pytest.fixture(scope="module")
+def warehouse(tmp_path_factory: pytest.TempPathFactory) -> Path:
+    from CortexOS.dms.warehouse_db import load_inventory_csv
+
+    db = tmp_path_factory.mktemp("wh") / "wh.duckdb"
+    load_inventory_csv(db_path=db)
+    return db
+
+
+@pytest.fixture()
+def pool() -> None:
+    reset_read_pool_for_tests(PoolConfig("default", 4, 5.0, 30.0))
+    yield
+    reset_read_pool_for_tests()
+
+
+def _verified(
+    predicates: dict[str, str],
+    *,
+    session_id: str = "sdk-sess",
+    issuer_kid: str = "int-1",
+) -> VerifiedManifest:
+    now = datetime.now(timezone.utc)
+    manifest = Manifest(
+        session_id=session_id,
+        org_id="acme",
+        pool_id="default",
+        issuer_key_id=issuer_kid,
+        allowed_paths=["/data/pool/acme/**"],
+        row_predicates=predicates,
+        issued_at=now.isoformat(),
+        expires_at=(now + timedelta(minutes=5)).isoformat(),
+        signature="not-checked-here",
+    )
+    return VerifiedManifest(manifest=manifest, issuer_kid=issuer_kid, verified_at=now)
+
+
+def test_sdk_read_refuses_without_session_or_manifest(warehouse: Path, pool: None) -> None:
+    reset_session_registry_for_tests()
+    with pytest.raises(SdkDenied) as caught:
+        query_objects("inventory", actor=VIEWER, pack="dms", db_path=warehouse)
+    assert caught.value.verdict == "session_unbound"
+
+
+def test_sdk_read_of_ungranted_table_is_refused(warehouse: Path, pool: None) -> None:
+    verified = _verified(INVENTORY_ONLY)
+    with pytest.raises(SdkDenied) as caught:
+        query_objects(
+            "suppliers",
+            actor=VIEWER,
+            pack="dms",
+            db_path=warehouse,
+            verified=verified,
+        )
+    assert caught.value.verdict == "path_not_allowed"
+    assert "suppliers" in str(caught.value).lower()
+
+
+def test_sdk_read_of_granted_table_applies_predicate(warehouse: Path, pool: None) -> None:
+    verified = _verified(INVENTORY_ONLY)
+    rows = query_objects(
+        "inventory",
+        actor=VIEWER,
+        pack="dms",
+        limit=500,
+        db_path=warehouse,
+        verified=verified,
+    )
+    assert rows, "LOC-001 inventory must exist in the sample warehouse"
+    assert all(r["location_id"] == "LOC-001" for r in rows)
+    assert {r["location_id"] for r in rows} == {"LOC-001"}
+
+
+def test_sdk_granted_read_keeps_bind_params_under_predicate(
+    warehouse: Path, pool: None
+) -> None:
+    verified = _verified(INVENTORY_ONLY)
+    rows = query_objects(
+        "inventory",
+        actor=VIEWER,
+        pack="dms",
+        limit=500,
+        db_path=warehouse,
+        verified=verified,
+    )
+    category = rows[0]["category"]
+    filtered = query_objects(
+        "inventory",
+        {"category": category},
+        actor=VIEWER,
+        pack="dms",
+        limit=500,
+        db_path=warehouse,
+        verified=verified,
+    )
+    assert filtered
+    assert all(r["location_id"] == "LOC-001" and r["category"] == category for r in filtered)
+
+
+def test_sdk_read_via_bound_session_id(warehouse: Path, pool: None) -> None:
+    reset_session_registry_for_tests()
+    verified = _verified(INVENTORY_ONLY, session_id="bound-sdk")
+    get_session_registry().bind(verified)
+    try:
+        rows = query_objects(
+            "inventory",
+            actor=VIEWER,
+            pack="dms",
+            limit=50,
+            db_path=warehouse,
+            session_id="bound-sdk",
+        )
+        assert rows and all(r["location_id"] == "LOC-001" for r in rows)
+        with pytest.raises(SdkDenied) as caught:
+            query_objects(
+                "suppliers",
+                actor=VIEWER,
+                pack="dms",
+                db_path=warehouse,
+                session_id="bound-sdk",
+            )
+        assert caught.value.verdict == "path_not_allowed"
+    finally:
+        reset_session_registry_for_tests()
+
+
+def test_sdk_backend_refuses_missing_manifest_without_opening(warehouse: Path) -> None:
+    backend = get_query_backend("dms")
+    with pytest.raises(SessionUnbound):
+        backend("inventory", ["sku"], {}, 3, verified=None, db_path=warehouse)
+
+
+def test_sdk_self_issued_grant_is_refused(warehouse: Path, pool: None) -> None:
+    verified = _verified(INVENTORY_ONLY, issuer_kid="local-self-issued")
+    with pytest.raises(SdkDenied) as caught:
+        query_objects(
+            "inventory",
+            actor=VIEWER,
+            pack="dms",
+            db_path=warehouse,
+            verified=verified,
+        )
+    assert caught.value.verdict == "session_unbound"
+    assert "self-issued" in str(caught.value)


### PR DESCRIPTION
## Summary
- Agent-SDK `query_objects` no longer opens DuckDB without a bound session/manifest (PARKING_LOT P22).
- Missing grant refuses; granted tables still go through `enforce_manifest` (predicates applied). `manifest.py` refusals unchanged.
- Two hostile-corpus cases added for the SDK statement shape; existing cases not reclassified.

## Test plan
- [x] `PACK=dms pytest tests/test_execution/test_sdk_manifest.py tests/test_execution/test_manifest_enforcement.py -q` (145 passed)
- [x] Did not touch `CortexOS/api/dms_query.py` (held PR #44)
- [ ] Do not merge while Netie-AI Actions is billing-blocked (red checks are not a code signal)
