### PR TITLE
fix(ask): ground contract ask and fill Sources panel

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,12 @@
+version: 2
+updates:
+  - package-ecosystem: pip
+    directory: "/"
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 5
+  - package-ecosystem: npm
+    directory: "/demo/dms-ui"
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 5

--- a/CHANGELOG_DMS.md
+++ b/CHANGELOG_DMS.md
@@ -2,6 +2,16 @@
 
 Agents append one section per shipped feature. Sequential build log.
 
+## CONTRACT-01 one module identity — 2026-08-26
+
+`cortex_contract` is one package. Consumers pin it; they do not import `CortexOS`.
+Merged as #69.
+
+## DOC-01 stop claiming Wasm sandboxing — 2026-08-26
+
+README / ARCHITECTURE no longer claim an in-process Wasm sandbox the engine
+never ran. Merged as #68.
+
 ## GitHub PAT still cannot see private Netie-AI — 2026-08-25
 
 Used the operator fine-grained PAT as `jian-hong`. It authenticates and still

--- a/CLAUDE_HANDOFF.md
+++ b/CLAUDE_HANDOFF.md
@@ -28,8 +28,9 @@ External supervisor. Verify F7 remainder against `docs/dms/BUILD_PLAN.md` § FEA
 
 ## Test snapshot
 ```
-pytest tests/dms/test_f7_rbac.py -q → 8 passed
-pytest -q → 153 passed, 4 skipped
+Not a live count. This file is a role template. Run `python -m pytest tests/ -q`
+and treat STATUS.md / the last gate log as the count, not the 153-test snapshot
+that used to live here.
 ```
 
 ## Reference

--- a/CURSOR_HANDOFF.md
+++ b/CURSOR_HANDOFF.md
@@ -18,7 +18,7 @@ Builder. **F7 remainder in progress** — F6 PASS (2026-07-03). F8 blocked.
 |---|---|
 | F6 skill capture | PASS |
 | F7 remainder | RBAC on `/dms/skills/*` + rate limit shipped; RLS/SOPS next |
-| Tests | **153 passed, 4 skipped** |
+| Tests | See STATUS.md / last gate log. This file is not a live count. |
 
 ## F7 remainder — done this slice
 - `packs/dms/security/api_auth.py` — API-key → viewer/steward/admin

--- a/CortexOS/api/contract_routes.py
+++ b/CortexOS/api/contract_routes.py
@@ -160,6 +160,35 @@ def _provenance_from_flat(data: dict[str, Any]) -> Provenance:
     )
 
 
+def _contributing_sources(data: dict[str, Any]) -> list[dict[str, Any]]:
+    """Sources panel cards from granted tables. Never invent on abstain."""
+    if _is_abstain_signal(data):
+        return []
+    names: list[str] = []
+    granted = data.get("granted_sources")
+    if isinstance(granted, list):
+        names.extend(str(x) for x in granted if x)
+    table = data.get("source_table")
+    if isinstance(table, str) and table.strip() and table.strip() not in names:
+        names.append(table.strip())
+    if not names:
+        return []
+    rows = data.get("rows") if isinstance(data.get("rows"), list) else []
+    n_rows = len(rows) if rows else None
+    share = round(1.0 / len(names), 4)
+    return [
+        {
+            "ref_id": name,
+            "container": "warehouse",
+            "member": name,
+            "kind": "table",
+            "row_count": n_rows if len(names) == 1 else None,
+            "contribution": share,
+        }
+        for name in names
+    ]
+
+
 def _enrich_answer(data: dict[str, Any], *, session_id: str, verified: Any) -> dict[str, Any]:
     """Attach T7 answer_id + drillthrough_token when SQL is present.
 
@@ -183,7 +212,10 @@ def _enrich_answer(data: dict[str, Any], *, session_id: str, verified: Any) -> d
         data["assumptions"] = [assumptions.strip()]
     elif not isinstance(assumptions, list):
         data["assumptions"] = []
-    data.setdefault("contributing_sources", [])
+    if _is_abstain_signal(data):
+        data["contributing_sources"] = []
+    elif not data.get("contributing_sources"):
+        data["contributing_sources"] = _contributing_sources(data)
     sql = data.get("sql_used")
     # Never mint drillthrough for abstain/blocked answers.
     if _is_abstain_signal(data):
@@ -232,6 +264,7 @@ async def contract_ask(body: AskRequest) -> Answer:
             session_id=body.session_id,
             space_id=body.space_id,
             verified=verified,
+            require_grounding=True,
         )
     except ManifestError as exc:
         code = getattr(exc, "code", "manifest_error")

--- a/PRODUCT_ROLES.md
+++ b/PRODUCT_ROLES.md
@@ -13,7 +13,7 @@ Shared across Cortex · OpenVault · AirGPT · OpenIDE. Keep this file identical
 | **OpenVault** | Safe manager + final shipper — where things live, model keys, **FreeRoute** (best-route + budget, OmniRoute-class), one-click connect APIs + local ground models, gating, one-click deploy/host | Running the agent loop itself; picking DAG vs LangGraph |
 | **OpenIDE** | Standalone coding app — activates coding expert slice of brain (TSX/canvas, tools, web search, FS, PRs) | Being the host/deploy console |
 | **AirGPT** | Standalone host shell / control plane — phone, settings, pairing, apps hub; thin bridge to Cortex + OpenVault | Owning orchestration forever; second key vault |
-| **DMS / Spaces** | Reference + product consumer — ChatGPT-for-Excel/DB; Spaces = ACL-scoped sandboxes on Cortex lake/query | Being the engine; Pointer Act UI |
+| **DMS / Spaces** | Reference + product consumer — ChatGPT-for-Excel/DB; Spaces are a planned ACL-scoped sandbox on Cortex lake/query, not a shipped surface | Being the engine; Pointer Act UI |
 | **Pointer** | External Act / computer-control client → Cortex engine | DMS Spaces demo surface; custody/deploy |
 
 ---

--- a/README.md
+++ b/README.md
@@ -39,10 +39,9 @@ python scripts/handoff.py --claude   # supervisor
 .\demo\run_demo.ps1 -Fast    # restart in ~30s
 ```
 
-- UI: http://localhost:3000
-- Warehouse: http://localhost:3000/warehouse
-- Chat: http://localhost:3000/chat
-- API: http://localhost:8000/health
+- Demo UI: http://localhost:3000
+- Demo API (``demo/run_demo.ps1``): http://localhost:8000/health
+- Engine launcher (``scripts/start_cortex_engine.ps1``): http://localhost:8010/health
 
 **Show script:** [docs/DEMO.md](docs/DEMO.md)
 

--- a/scripts/handoff.py
+++ b/scripts/handoff.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 
 import argparse
 import re
-import subprocess
 import sys
 from datetime import datetime, timezone
 from pathlib import Path
@@ -24,18 +23,8 @@ def _read(path: Path) -> str:
 
 
 def _pytest_summary() -> str:
-    try:
-        r = subprocess.run(
-            [sys.executable, "-m", "pytest", "tests/", "-q", "--tb=no"],
-            cwd=ROOT,
-            capture_output=True,
-            text=True,
-            timeout=180,
-        )
-        lines = (r.stdout or r.stderr or "").strip().splitlines()
-        return lines[-1] if lines else "pytest: no output"
-    except Exception as exc:
-        return f"pytest: skipped ({exc})"
+    """Do not run the suite. A stamped count here is not a gate."""
+    return "not a live count; run `python -m pytest tests/ -q`"
 
 
 def _patch_test_snapshot(content: str, summary: str) -> str:

--- a/tests/dms/test_enrich_answer_provenance.py
+++ b/tests/dms/test_enrich_answer_provenance.py
@@ -134,3 +134,51 @@ def test_provenance_unknown_badge_is_abstain_not_session():
 def test_provenance_mapped_certified_stays_certified():
     prov = _provenance_from_flat({"badge": "certified", "route": "sql", "layer": "engine"})
     assert prov.badge == Badge.CERTIFIED
+
+
+def test_enrich_answer_fills_contributing_sources_from_granted_tables():
+    verified = SimpleNamespace(manifest={"tables": {}})
+    data = _enrich_answer(
+        {
+            "answer": "Revenue is 10",
+            "route": "sql",
+            "badge": "governed_metric",
+            "layer": "engine",
+            "audit_id": "aud_src",
+            "sql_used": "SELECT 1",
+            "granted_sources": ["transactions"],
+            "rows": [{"revenue_myr": 10}],
+        },
+        session_id="ses_1",
+        verified=verified,
+    )
+    srcs = data["contributing_sources"]
+    assert srcs
+    assert srcs[0]["ref_id"] == "transactions"
+    assert srcs[0]["kind"] == "table"
+    assert srcs[0]["row_count"] == 1
+
+
+def test_enrich_answer_sources_empty_on_abstain():
+    verified = SimpleNamespace(manifest={"tables": {}})
+    data = _enrich_answer(
+        {
+            "answer": "I can't answer that",
+            "route": "abstain",
+            "badge": "abstain",
+            "granted_sources": ["transactions"],
+            "audit_id": "aud_abs",
+        },
+        session_id="ses_1",
+        verified=verified,
+    )
+    assert data["contributing_sources"] == []
+
+
+def test_contract_ask_requires_grounding():
+    import inspect
+
+    from CortexOS.api import contract_routes
+
+    src = inspect.getsource(contract_routes.contract_ask)
+    assert "require_grounding=True" in src


### PR DESCRIPTION
## Summary
- `/v1/contract/ask` now sets `require_grounding=True` (parity with `/dms/query`).
- Sources panel is filled from granted tables instead of hardcoded `[]`; abstain still returns empty sources.
- Handoff files no longer claim a 153-test snapshot. Dependabot covers pip and demo npm.

## Test plan
- [x] `pytest tests/dms/test_enrich_answer_provenance.py tests/security/test_readme_claims.py` — 16 passed
- [ ] CI is billing-blocked on Netie-AI; treat red checks as non-signal
