### PR TITLE
fix(release): verify the cortex-contract wheel we actually ship (EPIC-002)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -59,6 +59,23 @@ jobs:
           mkdir -p dist_release
           cp packages/cortex_contract/dist/cortex_contract-*.whl dist_release/
 
+      - name: Verify the contract wheel we are about to ship
+        # DMS pins cortex-contract so the canonicalisation rule is the SAME CODE
+        # as the engine's. A wheel that drifts from the repo makes every manifest
+        # DMS signs fail verification, and it presents as a signature bug, not a
+        # packaging bug. Replay the frozen vectors against THIS artifact - the
+        # exact file attached below - rather than against a rebuild of the tree.
+        run: |
+          set -euo pipefail
+          shopt -s nullglob
+          wheels=(dist_release/cortex_contract-*.whl)
+          if [ "${#wheels[@]}" -ne 1 ]; then
+            echo "::error::expected exactly one cortex-contract wheel, found ${#wheels[@]}"
+            exit 1
+          fi
+          echo "verifying ${wheels[0]}"
+          CORTEX_CONTRACT_WHEEL="${wheels[0]}" python -m pytest tests/packaging/test_contract_wheel.py -q
+
       - name: Changelog since previous tag
         id: changelog
         run: |

--- a/tests/packaging/test_contract_wheel.py
+++ b/tests/packaging/test_contract_wheel.py
@@ -64,6 +64,19 @@ print(f"wheel-ok {checked}")
 
 @pytest.fixture(scope="module")
 def built_wheel(tmp_path_factory: pytest.TempPathFactory) -> Path:
+    """The wheel these assertions run against.
+
+    ``CORTEX_CONTRACT_WHEEL`` points them at an ALREADY-BUILT artifact instead
+    of a fresh one. The release workflow sets it to the exact file it is about
+    to attach to the GitHub Release, so the wheel a consumer downloads is the
+    wheel that was proved - not a rebuild that merely came from the same tree.
+    """
+    prebuilt = (os.environ.get("CORTEX_CONTRACT_WHEEL") or "").strip()
+    if prebuilt:
+        wheel = Path(prebuilt)
+        assert wheel.is_file(), f"CORTEX_CONTRACT_WHEEL={prebuilt!r} is not a file"
+        assert wheel.suffix == ".whl", f"CORTEX_CONTRACT_WHEEL={prebuilt!r} is not a wheel"
+        return wheel
     out = tmp_path_factory.mktemp("contract_wheel")
     proc = subprocess.run(
         [sys.executable, "-m", "pip", "wheel", str(PKG_DIR), "--no-deps", "-w", str(out)],
@@ -113,3 +126,22 @@ def test_artifact_reproduces_every_canonical_vector(
     )
     assert proc.returncode == 0, f"probe failed:\n{proc.stdout}\n{proc.stderr}"
     assert "wheel-ok" in proc.stdout
+
+
+def test_release_workflow_verifies_the_wheel_it_attaches() -> None:
+    """The proof is only worth having if the release actually runs it.
+
+    release.yml builds the cortex-contract wheel into dist_release/ and attaches
+    it to the GitHub Release. Without this step that artifact ships unproved, so
+    deleting the step must fail here rather than silently in a consumer's build.
+    """
+    workflow = (REPO_ROOT / ".github" / "workflows" / "release.yml").read_text(encoding="utf-8")
+    assert "CORTEX_CONTRACT_WHEEL" in workflow, (
+        "release.yml no longer points the canonical-vector proof at the wheel it ships"
+    )
+    assert "tests/packaging/test_contract_wheel.py" in workflow, (
+        "release.yml no longer runs the contract-wheel proof"
+    )
+    build_at = workflow.index("python -m build --wheel packages/cortex_contract")
+    verify_at = workflow.index("CORTEX_CONTRACT_WHEEL")
+    assert build_at < verify_at, "the wheel must be verified after it is built, not before"


### PR DESCRIPTION
Follow-through on #71. That PR proved a *rebuilt* wheel reproduces the frozen canonicalisation vectors. `release.yml` never ran that proof — it built `cortex_contract-*.whl` into `dist_release/` and attached it to the GitHub Release unverified. The artifact a consumer pins was shipping unproved.

## What changed

- **`tests/packaging/test_contract_wheel.py`** — the `built_wheel` fixture now honours `CORTEX_CONTRACT_WHEEL`. When set, the 25 frozen vectors replay against that **already-built** artifact instead of a fresh one, so the file attached to the Release is the file that got proved, not a rebuild that merely came from the same tree.
- **`.github/workflows/release.yml`** — a `Verify the contract wheel we are about to ship` step runs immediately after the build, pointed at the exact wheel in `dist_release/`. It refuses if the glob does not resolve to exactly one wheel.
- **New regression guard** — `test_release_workflow_verifies_the_wheel_it_attaches` asserts release.yml still wires the proof *and* that the verify comes after the build. Deleting the step now fails here, in CI, rather than silently in a consumer's build.

## Why it matters

DMS pins `cortex-contract` so the canonicalisation rule is *the same code* as the engine's. A wheel that drifts from the repo makes every manifest DMS signs fail verification — and it presents as a signature bug, not a packaging bug.

## Verification (local — see CI note)

| check | result |
|---|---|
| `pytest tests/packaging/test_contract_wheel.py` (builds its own wheel) | 4 passed |
| same, with `CORTEX_CONTRACT_WHEEL` set to a prebuilt artifact | 4 passed in 3.5s |
| **proof the guard can fail (R-0007)** — delete the verify step | RED: *"release.yml no longer points the canonical-vector proof at the wheel it ships"* |
| restore the step | green |
| `ruff check` | clean |
| `release.yml` YAML parse + step order | valid, 12 steps |

No protected paths touched (`tests/packaging/` is outside the guard set), no contract version change, no spec regeneration needed.

## CI note

Org GitHub Actions is still billing-blocked — runs fail in 4–5s with zero steps and the annotation *"recent account payments have failed or your spending limit needs to be increased"*. Checks here will be red for that reason alone until Billing & plans is fixed; re-run them afterwards.

🤖 Generated with [Claude Code](https://claude.com/claude-code)