### PR TITLE
fix(deps): clear demo/dms-ui critical + transitive CVEs without a React 19 migration

### DIFF
--- a/demo/dms-ui/package-lock.json
+++ b/demo/dms-ui/package-lock.json
@@ -8,14 +8,15 @@
       "name": "dms-demo-ui",
       "version": "0.1.0",
       "dependencies": {
-        "next": "14.2.0",
+        "next": "14.2.35",
         "react": "^18.3.0",
         "react-dom": "^18.3.0",
         "recharts": "^2.12.0",
         "swr": "^2.2.5"
       },
       "devDependencies": {
-        "@babel/core": "^7.29.7"
+        "@babel/core": "^7.29.7",
+        "@playwright/test": "^1.49.0"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -295,17 +296,19 @@
       }
     },
     "node_modules/@next/env": {
-      "version": "14.2.0",
-      "resolved": "https://registry.npmjs.org/@next/env/-/env-14.2.0.tgz",
-      "integrity": "sha512-4+70ELtSbRtYUuyRpAJmKC8NHBW2x1HMje9KO2Xd7IkoyucmV9SjgO+qeWMC0JWkRQXgydv1O7yKOK8nu/rITQ=="
+      "version": "14.2.35",
+      "resolved": "https://registry.npmjs.org/@next/env/-/env-14.2.35.tgz",
+      "integrity": "sha512-DuhvCtj4t9Gwrx80dmz2F4t/zKQ4ktN8WrMwOuVzkJfBilwAwGr6v16M5eI8yCuZ63H9TTuEU09Iu2HqkzFPVQ==",
+      "license": "MIT"
     },
     "node_modules/@next/swc-darwin-arm64": {
-      "version": "14.2.0",
-      "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-14.2.0.tgz",
-      "integrity": "sha512-kHktLlw0AceuDnkVljJ/4lTJagLzDiO3klR1Fzl2APDFZ8r+aTxNaNcPmpp0xLMkgRwwk6sggYeqq0Rz9K4zzA==",
+      "version": "14.2.33",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-14.2.33.tgz",
+      "integrity": "sha512-HqYnb6pxlsshoSTubdXKu15g3iivcbsMXg4bYpjL2iS/V6aQot+iyF4BUc2qA/J/n55YtvE4PHMKWBKGCF/+wA==",
       "cpu": [
         "arm64"
       ],
+      "license": "MIT",
       "optional": true,
       "os": [
         "darwin"
@@ -315,12 +318,13 @@
       }
     },
     "node_modules/@next/swc-darwin-x64": {
-      "version": "14.2.0",
-      "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-14.2.0.tgz",
-      "integrity": "sha512-HFSDu7lb1U3RDxXNeKH3NGRR5KyTPBSUTuIOr9jXoAso7i76gNYvnTjbuzGVWt2X5izpH908gmOYWtI7un+JrA==",
+      "version": "14.2.33",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-14.2.33.tgz",
+      "integrity": "sha512-8HGBeAE5rX3jzKvF593XTTFg3gxeU4f+UWnswa6JPhzaR6+zblO5+fjltJWIZc4aUalqTclvN2QtTC37LxvZAA==",
       "cpu": [
         "x64"
       ],
+      "license": "MIT",
       "optional": true,
       "os": [
         "darwin"
@@ -330,12 +334,13 @@
       }
     },
     "node_modules/@next/swc-linux-arm64-gnu": {
-      "version": "14.2.0",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-14.2.0.tgz",
-      "integrity": "sha512-iQsoWziO5ZMxDWZ4ZTCAc7hbJ1C9UDj/gATSqTaMjW2bJFwAsvf9UM79AKnljBl73uPZ+V0kH4rvnHTco4Ps2w==",
+      "version": "14.2.33",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-14.2.33.tgz",
+      "integrity": "sha512-JXMBka6lNNmqbkvcTtaX8Gu5by9547bukHQvPoLe9VRBx1gHwzf5tdt4AaezW85HAB3pikcvyqBToRTDA4DeLw==",
       "cpu": [
         "arm64"
       ],
+      "license": "MIT",
       "optional": true,
       "os": [
         "linux"
@@ -345,12 +350,13 @@
       }
     },
     "node_modules/@next/swc-linux-arm64-musl": {
-      "version": "14.2.0",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-14.2.0.tgz",
-      "integrity": "sha512-0JOk2uzLUt8fJK5LpsKKZa74zAch7bJjjgJzR9aOMs231AlE4gPYzsSm430ckZitjPGKeH5bgDZjqwqJQKIS2w==",
+      "version": "14.2.33",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-14.2.33.tgz",
+      "integrity": "sha512-Bm+QulsAItD/x6Ih8wGIMfRJy4G73tu1HJsrccPW6AfqdZd0Sfm5Imhgkgq2+kly065rYMnCOxTBvmvFY1BKfg==",
       "cpu": [
         "arm64"
       ],
+      "license": "MIT",
       "optional": true,
       "os": [
         "linux"
@@ -360,12 +366,13 @@
       }
     },
     "node_modules/@next/swc-linux-x64-gnu": {
-      "version": "14.2.0",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-14.2.0.tgz",
-      "integrity": "sha512-uYHkuTzX0NM6biKNp7hdKTf+BF0iMV254SxO0B8PgrQkxUBKGmk5ysHKB+FYBfdf9xei/t8OIKlXJs9ckD943A==",
+      "version": "14.2.33",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-14.2.33.tgz",
+      "integrity": "sha512-FnFn+ZBgsVMbGDsTqo8zsnRzydvsGV8vfiWwUo1LD8FTmPTdV+otGSWKc4LJec0oSexFnCYVO4hX8P8qQKaSlg==",
       "cpu": [
         "x64"
       ],
+      "license": "MIT",
       "optional": true,
       "os": [
         "linux"
@@ -375,12 +382,13 @@
       }
     },
     "node_modules/@next/swc-linux-x64-musl": {
-      "version": "14.2.0",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-14.2.0.tgz",
-      "integrity": "sha512-paN89nLs2dTBDtfXWty1/NVPit+q6ldwdktixYSVwiiAz647QDCd+EIYqoiS+/rPG3oXs/A7rWcJK9HVqfnMVg==",
+      "version": "14.2.33",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-14.2.33.tgz",
+      "integrity": "sha512-345tsIWMzoXaQndUTDv1qypDRiebFxGYx9pYkhwY4hBRaOLt8UGfiWKr9FSSHs25dFIf8ZqIFaPdy5MljdoawA==",
       "cpu": [
         "x64"
       ],
+      "license": "MIT",
       "optional": true,
       "os": [
         "linux"
@@ -390,12 +398,13 @@
       }
     },
     "node_modules/@next/swc-win32-arm64-msvc": {
-      "version": "14.2.0",
-      "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-14.2.0.tgz",
-      "integrity": "sha512-j1oiidZisnymYjawFqEfeGNcE22ZQ7lGUaa4pGOCVWrWeIDkPSj8zYgS9TzMNlg17Q3wSWCQC/F5uJAhSh7qcA==",
+      "version": "14.2.33",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-14.2.33.tgz",
+      "integrity": "sha512-nscpt0G6UCTkrT2ppnJnFsYbPDQwmum4GNXYTeoTIdsmMydSKFz9Iny2jpaRupTb+Wl298+Rh82WKzt9LCcqSQ==",
       "cpu": [
         "arm64"
       ],
+      "license": "MIT",
       "optional": true,
       "os": [
         "win32"
@@ -405,12 +414,13 @@
       }
     },
     "node_modules/@next/swc-win32-ia32-msvc": {
-      "version": "14.2.0",
-      "resolved": "https://registry.npmjs.org/@next/swc-win32-ia32-msvc/-/swc-win32-ia32-msvc-14.2.0.tgz",
-      "integrity": "sha512-6ff6F4xb+QGD1jhx/dOT9Ot7PQ/GAYekV9ykwEh2EFS/cLTyU4Y3cXkX5cNtNIhpctS5NvyjW9gIksRNErYE0A==",
+      "version": "14.2.33",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-ia32-msvc/-/swc-win32-ia32-msvc-14.2.33.tgz",
+      "integrity": "sha512-pc9LpGNKhJ0dXQhZ5QMmYxtARwwmWLpeocFmVG5Z0DzWq5Uf0izcI8tLc+qOpqxO1PWqZ5A7J1blrUIKrIFc7Q==",
       "cpu": [
         "ia32"
       ],
+      "license": "MIT",
       "optional": true,
       "os": [
         "win32"
@@ -420,18 +430,35 @@
       }
     },
     "node_modules/@next/swc-win32-x64-msvc": {
-      "version": "14.2.0",
-      "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-14.2.0.tgz",
-      "integrity": "sha512-09DbG5vXAxz0eTFSf1uebWD36GF3D5toynRkgo2AlSrxwGZkWtJ1RhmrczRYQ17eD5bdo4FZ0ibiffdq5kc4vg==",
+      "version": "14.2.33",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-14.2.33.tgz",
+      "integrity": "sha512-nOjfZMy8B94MdisuzZo9/57xuFVLHJaDj5e/xrduJp9CV2/HrfxTRH2fbyLe+K9QT41WBLUd4iXX3R7jBp0EUg==",
       "cpu": [
         "x64"
       ],
+      "license": "MIT",
       "optional": true,
       "os": [
         "win32"
       ],
       "engines": {
         "node": ">= 10"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.62.1",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.62.1.tgz",
+      "integrity": "sha512-DTcUc8qii+cpHvtOwggMtBRMjKZHXYWdw8syRYu2vtzuq4Wxphqq4NfCs5Zt44L6mA8rfDfj+PHnxFc/FeK6mQ==",
+      "devOptional": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.62.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=20"
       }
     },
     "node_modules/@swc/counter": {
@@ -747,6 +774,21 @@
         "node": ">=6.0.0"
       }
     },
+    "node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
     "node_modules/gensync": {
       "version": "1.0.0-beta.2",
       "resolved": "https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.2.tgz",
@@ -821,7 +863,9 @@
       "dev": true
     },
     "node_modules/nanoid": {
-      "version": "3.3.12",
+      "version": "3.3.18",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.18.tgz",
+      "integrity": "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==",
       "funding": [
         {
           "type": "github",
@@ -837,12 +881,12 @@
       }
     },
     "node_modules/next": {
-      "version": "14.2.0",
-      "resolved": "https://registry.npmjs.org/next/-/next-14.2.0.tgz",
-      "integrity": "sha512-2T41HqJdKPqheR27ll7MFZ3gtTYvGew7cUc0PwPSyK9Ao5vvwpf9bYfP4V5YBGLckHF2kEGvrLte5BqLSv0s8g==",
-      "deprecated": "This version has a security vulnerability. Please upgrade to a patched version. See https://nextjs.org/blog/security-update-2025-12-11 for more details.",
+      "version": "14.2.35",
+      "resolved": "https://registry.npmjs.org/next/-/next-14.2.35.tgz",
+      "integrity": "sha512-KhYd2Hjt/O1/1aZVX3dCwGXM1QmOV4eNM2UTacK5gipDdPN/oHHK/4oVGy7X8GMfPMsUTUEmGlsy0EY1YGAkig==",
+      "license": "MIT",
       "dependencies": {
-        "@next/env": "14.2.0",
+        "@next/env": "14.2.35",
         "@swc/helpers": "0.5.5",
         "busboy": "1.6.0",
         "caniuse-lite": "^1.0.30001579",
@@ -857,15 +901,15 @@
         "node": ">=18.17.0"
       },
       "optionalDependencies": {
-        "@next/swc-darwin-arm64": "14.2.0",
-        "@next/swc-darwin-x64": "14.2.0",
-        "@next/swc-linux-arm64-gnu": "14.2.0",
-        "@next/swc-linux-arm64-musl": "14.2.0",
-        "@next/swc-linux-x64-gnu": "14.2.0",
-        "@next/swc-linux-x64-musl": "14.2.0",
-        "@next/swc-win32-arm64-msvc": "14.2.0",
-        "@next/swc-win32-ia32-msvc": "14.2.0",
-        "@next/swc-win32-x64-msvc": "14.2.0"
+        "@next/swc-darwin-arm64": "14.2.33",
+        "@next/swc-darwin-x64": "14.2.33",
+        "@next/swc-linux-arm64-gnu": "14.2.33",
+        "@next/swc-linux-arm64-musl": "14.2.33",
+        "@next/swc-linux-x64-gnu": "14.2.33",
+        "@next/swc-linux-x64-musl": "14.2.33",
+        "@next/swc-win32-arm64-msvc": "14.2.33",
+        "@next/swc-win32-ia32-msvc": "14.2.33",
+        "@next/swc-win32-x64-msvc": "14.2.33"
       },
       "peerDependencies": {
         "@opentelemetry/api": "^1.1.0",
@@ -906,8 +950,42 @@
       "version": "1.1.1",
       "license": "ISC"
     },
+    "node_modules/playwright": {
+      "version": "1.62.1",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.62.1.tgz",
+      "integrity": "sha512-0M+L3LAD8/nm554LOla9Ayx0j0tmFZ0FBcoQ7F1VuVHpM/XpiC8RcDzBQB8W5+hA8L22THxELzeF+2WcUzvcLg==",
+      "devOptional": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.62.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.62.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.62.1.tgz",
+      "integrity": "sha512-wPYSwEBJY9GHraISXqyqtx0na0LpO3XEX7jNDhntbex7tzUS7kLnZsOlFruFJB4Hi/rhDMjXGqHewDZ68nYZVw==",
+      "devOptional": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
     "node_modules/postcss": {
-      "version": "8.4.31",
+      "version": "8.5.26",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.26.tgz",
+      "integrity": "sha512-u82N74LFzG8ca+dD8puPnplTXoGH4fTPpVGuIbt36G3qvNlkvfD0lEAZSxaly3KX8TS/L1A1gsCEmvKmBcVbkQ==",
       "funding": [
         {
           "type": "opencollective",
@@ -924,9 +1002,9 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "nanoid": "^3.3.6",
-        "picocolors": "^1.0.0",
-        "source-map-js": "^1.0.2"
+        "nanoid": "^3.3.17",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
       },
       "engines": {
         "node": "^10 || ^12 || >=14"
@@ -1048,6 +1126,8 @@
     },
     "node_modules/source-map-js": {
       "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">=0.10.0"

--- a/demo/dms-ui/package.json
+++ b/demo/dms-ui/package.json
@@ -10,7 +10,7 @@
     "test:e2e:reliability": "playwright test e2e/reliability.spec.js"
   },
   "dependencies": {
-    "next": "14.2.0",
+    "next": "14.2.35",
     "react": "^18.3.0",
     "react-dom": "^18.3.0",
     "recharts": "^2.12.0",
@@ -19,5 +19,9 @@
   "devDependencies": {
     "@babel/core": "^7.29.7",
     "@playwright/test": "^1.49.0"
+  },
+  "overrides": {
+    "postcss": "^8.5.26",
+    "nanoid": "^3.3.18"
   }
 }


### PR DESCRIPTION
## What this does

Clears the JavaScript dependency vulnerabilities in `demo/dms-ui` **without** a framework migration.

| package | before | after | how |
|---|---|---|---|
| `next` | 14.2.0 | **14.2.35** | direct bump (highest 14.x) |
| `postcss` | 8.4.31 | **8.5.26** | npm `overrides` |
| `nanoid` | 3.3.12 | **3.3.18** | npm `overrides` |

## Before / after

Measured with `npm audit` in the `demo/dms-ui` directory, counting distinct GHSA advisories.

| | before | after |
|---|---|---|
| distinct advisories | **39** | **21** |
| critical | **1** | **0** |
| high | 2 | 1 |
| `npm audit` summary | `3 vulnerabilities (2 high, 1 critical)` | `1 high severity vulnerability` |

39 matches the 39 open Dependabot alerts exactly. **18 advisories cleared, including the only critical.** All 4 `postcss` advisories and the `nanoid` advisory are fully cleared.

## Why `next@14.2.35` and not the Dependabot majors

`demo/dms-ui` is a **pure App Router** app — `app/` is populated, `pages/` is empty, and 20 of 24 source files are `"use client"` components.

The [Next.js 15 upgrade guide](https://nextjs.org/docs/app/guides/upgrading/version-15) states under **React 19**:

> The minimum versions of `react` and `react-dom` is now 19.

The `^18.2.0` still present in `next@15`'s published peer range is a leftover from the React 19 RC transition, not a support statement — `npm` will happily *resolve* `next@15` against React 18, and it will then fail at runtime on the App Router. So `next@15.5.21` is not reachable without also taking React 18 → 19.

`npm audit` independently lands on the same target:

```
fixAvailable = { "name": "next", "version": "14.2.35", "isSemVerMajor": false }
```

### The overrides are required, not cosmetic

`next@14.2.35` **still pins `postcss: 8.4.31` exactly**, so bumping `next` alone leaves the postcss and nanoid alerts open. The overrides are what actually clears them.

`nanoid` is deliberately held at `^3.3.18` (major 3): `postcss@8.5.26` requires `nanoid: ^3.3.17`, the advisory covers `<=3.3.17`, and **nanoid 4+ is ESM-only**, which would break postcss's CommonJS `require`. 3.3.18 is the only correct target.

## Dependabot PRs — recommend closing #78, #80, #81

These propose major-version jumps this PR **deliberately does not take**:

- **#80 `next` 14 → 16** — would force React 19 (see above) and skips two majors of breaking changes.
- **#78 `react` 18 → 19** and **#81 `react-dom` 18 → 19** — a React major across 20 client components, for a hand-run demo, with no CI that builds it.
- **#79 `recharts` 2 → 3** and **#77 `swr`** — not security fixes; neither package has an open advisory here. `recharts` stays 2.15.4 and `swr` stays 2.4.1 in this PR.

I have **not** closed any of them — that call is yours.

## Residual risk (stated plainly)

The remaining **21 advisories are all in `next`**, and every one of them has its fix boundary in the **15.5.x** line (`<15.5.10` … `<15.5.21`). There is **no 14.x fix** for any of them — the 14.2.x branch no longer receives these backports. Clearing the last 21 requires `next >= 15.5.21`, which requires React 19.

So this PR is the *complete* conservative fix, not a partial one: it takes every advisory that can be cleared without a React major. The remaining 21 are a **React 19 migration decision**, and they are mostly SSRF / cache-poisoning / DoS classes that assume a server-rendered app exposed to untrusted traffic — this is a localhost demo launched by hand from `run_demo.ps1`.

## Verification / scope

- React major **unchanged**: `react` and `react-dom` stay **18.3.1**. `recharts` 2.15.4 and `swr` 2.4.1 unchanged.
- **No package dropped** from the resolved tree (107 → 111 packages).
- The 4 added packages are `@playwright/test`, `playwright`, `playwright-core`, `fsevents` — `@playwright/test` was already declared in `package.json` `devDependencies` but **missing from the lockfile**; regenerating fixes that pre-existing desync.
- Single hoisted copy of `postcss` and `nanoid` — no nested vulnerable duplicates.
- `@next/swc-*` binaries resolve to 14.2.33 while `next` is 14.2.35. This is **upstream**: `next@14.2.35` pins its own `optionalDependencies` to 14.2.33. Not a resolution bug.
- Only 2 files changed, both under `demo/dms-ui/`.

### Not done

Lockfile was regenerated with `npm install --package-lock-only` (no `node_modules`, no compile) on a memory-constrained box. **`next build` and the Playwright e2e suite were not run.** The dependency graph is verified; a runtime smoke test of the demo is not. Given `next` moved only 14.2.0 → 14.2.35 (patch line) and `postcss` within 8.x, the risk is low, but it is untested — worth one `npm run dev` before relying on it.

CI is expected to fail in seconds with zero steps — GitHub Actions is billing-blocked org-wide, unrelated to this change. Do not judge this PR by CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
