### PR TITLE
test: make main green again after #87 (three self-inflicted red tests)

### DIFF
--- a/tests/dms/test_memory_persist_stress.py
+++ b/tests/dms/test_memory_persist_stress.py
@@ -125,7 +125,9 @@ def test_memory_api_survives_store_reopen(tmp_path, monkeypatch):
     from CortexOS.api import memory_routes
     from CortexOS.memory.factory import get_store as fresh_store
 
-    memory_routes._STORE = fresh_store()
+    # setattr, not plain assignment: this rebinds a module global that other
+    # suites read, and monkeypatch puts the original store back on teardown.
+    monkeypatch.setattr(memory_routes, "_STORE", fresh_store())
     from CortexOS.api.app import create_app
 
     client = TestClient(create_app())
@@ -137,7 +139,7 @@ def test_memory_api_survives_store_reopen(tmp_path, monkeypatch):
     assert up.status_code == 200, up.text
     assert up.json()["upserted"] == 1
     memory_routes._STORE.close()
-    memory_routes._STORE = fresh_store()
+    monkeypatch.setattr(memory_routes, "_STORE", fresh_store())
     q = client.post("/api/memory/query", json={"vector": vec, "k": 1})
     assert q.status_code == 200, q.text
     hits = q.json()["hits"]

--- a/tests/test_api/test_memory_assemble.py
+++ b/tests/test_api/test_memory_assemble.py
@@ -15,6 +15,10 @@ def test_memory_assemble_endpoint(monkeypatch):
     import CortexOS.api.memory_routes as memory_routes
     from CortexOS.api.app import create_app
 
+    # Own the store outright. The module-level `memory_routes._STORE` is a global
+    # other suites rebind (tests/dms/test_memory_persist_stress.py swaps in a
+    # 64-dim RawKnnStore and closes it), so reading it here instead of replacing
+    # it would make this test order-dependent under pytest-randomly.
     store = InMemoryStore()
     store.upsert([MemoryRecord(id="m1", text="warehouse aisle 3", vector=[1.0, 0.0])])
     monkeypatch.setattr(memory_routes, "_STORE", store)

--- a/tests/test_execution/test_cost_ledger_and_executor.py
+++ b/tests/test_execution/test_cost_ledger_and_executor.py
@@ -1,3 +1,5 @@
+import sys
+import types
 from dataclasses import replace
 
 import pytest
@@ -238,7 +240,19 @@ async def test_ensure_node_record_skips_when_llm_already_wrote():
 
 @pytest.mark.asyncio
 async def test_fetch_records_for_run_merges_db_and_memory(monkeypatch):
+    # `CostLedger._load_records_from_db` imports `sqlalchemy.text` lazily, inside
+    # the function. sqlalchemy is only in the .[full] extra, so on a default
+    # install the import is the one thing standing between this test and the
+    # merge logic it exists to cover. Standing in the single symbol it needs
+    # keeps the DB-merge path exercised on every install rather than skipped on
+    # most of them; `text()` is an inert SQL marker here, since the engine, the
+    # connection and the result set below are all fakes anyway.
+    sqlalchemy_stub = types.ModuleType("sqlalchemy")
+    sqlalchemy_stub.text = lambda sql: sql  # type: ignore[attr-defined]
+    monkeypatch.setitem(sys.modules, "sqlalchemy", sqlalchemy_stub)
+
     ledger = CostLedger()
+    issued: list[tuple[str, dict]] = []
 
     class FakeResult:
         def mappings(self):
@@ -265,7 +279,8 @@ async def test_fetch_records_for_run_merges_db_and_memory(monkeypatch):
             ]
 
     class FakeConn:
-        async def execute(self, *_a, **_k):
+        async def execute(self, sql, params=None, **_k):
+            issued.append((str(sql), dict(params or {})))
             return FakeResult()
 
         async def __aenter__(self):
@@ -300,3 +315,14 @@ async def test_fetch_records_for_run_merges_db_and_memory(monkeypatch):
     merged = await ledger.fetch_records_for_run("db_run")
     node_ids = {r.node_id for r in merged}
     assert node_ids == {"from_db", "local_only"}
+
+    # The DB leg really ran: one scoped SELECT against node_executions.
+    assert len(issued) == 1
+    sql, params = issued[0]
+    assert "FROM node_executions" in sql
+    assert params == {"r": "db_run"}
+    # The row the fake DB returned was hydrated, not just counted.
+    from_db = next(r for r in merged if r.node_id == "from_db")
+    assert from_db.tier == "T1"
+    assert from_db.cost_myr == 0.03
+    assert from_db.ceiling_myr == 1.0

--- a/tests/test_execution/test_dag_runner.py
+++ b/tests/test_execution/test_dag_runner.py
@@ -261,11 +261,14 @@ async def test_parallel_layer_runs_siblings_concurrently(monkeypatch):
 
     from netie.execution.dag_runner import NodeResult
 
-    start_times: dict[str, float] = {}
+    # (start, end) per node, so concurrency is asserted as window overlap rather
+    # than against a fixed wall-clock budget (which flakes on a loaded machine).
+    windows: dict[str, tuple[float, float]] = {}
 
     async def slow_execute_node(node, context, router, ledger, workflow_cost_ceiling_myr=None):
-        start_times[node.id] = time.monotonic()
+        started_at = time.monotonic()
         await asyncio.sleep(0.08)
+        windows[node.id] = (started_at, time.monotonic())
         return NodeResult(node_id=node.id, output={"content": node.id}, tier="stub", cost_myr=0.0)
 
     monkeypatch.setattr("netie.execution.dag_runner.execute_node", slow_execute_node)
@@ -310,13 +313,22 @@ async def test_parallel_layer_runs_siblings_concurrently(monkeypatch):
     ledger = CostLedger()
     ctx = ExecutionContext("run_parallel")
 
-    started = time.monotonic()
     res = await run_dag(dag, ctx, router, ledger, workflow_cost_ceiling_myr=None, parallel=True)
-    elapsed = time.monotonic() - started
 
     assert "a" in res.outputs and "b" in res.outputs
-    assert abs(start_times["a"] - start_times["b"]) < 0.05
-    assert elapsed < 0.2
+
+    start_a, end_a = windows["a"]
+    start_b, end_b = windows["b"]
+    # The two siblings were in flight at the same instant. A serial runner gives
+    # overlap <= 0 no matter how fast or slow the host is.
+    overlap = min(end_a, end_b) - max(start_a, start_b)
+    assert overlap > 0, f"siblings did not overlap: {windows}"
+    # The layer finished faster than running the same two nodes back to back.
+    # Both sides are measured from this run, so a slow or loaded host stretches
+    # them together and the comparison holds.
+    layer_span = max(end_a, end_b) - min(start_a, start_b)
+    serial_total = (end_a - start_a) + (end_b - start_b)
+    assert layer_span < serial_total, f"layer_span {layer_span} >= serial {serial_total}"
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
`origin/main` is red. #87 merged carrying three tests it added that fail. This fixes them. Tests only — no production code changes, no protected paths.

## What was failing

**`test_fetch_records_for_run_merges_db_and_memory`** — `ModuleNotFoundError: No module named 'sqlalchemy'`. `CortexOS/routing/cost_ledger.py:164` does `from sqlalchemy import text`, and sqlalchemy is not in the default (non-`.[full]`) install. This is the *only* test covering the new DB-merge path, so that path currently ships untested on a normal install.

Deliberately **not** fixed with `pytest.importorskip` — that would make the test skip silently on every default install, which is the "gate that cannot fail" problem CLAUDE.md §7 warns about. Instead the test injects a one-symbol `sqlalchemy` stub via `monkeypatch.setitem`, so the real `_load_records_from_db` and the real merge logic execute everywhere. `text()` is inert here because the engine, connection and result set in that test were already fakes. The test is also strengthened while open: it now asserts exactly one scoped `SELECT ... FROM node_executions` was issued with params `{"r": "db_run"}`, and that the DB row was actually hydrated (tier T1, cost 0.03, ceiling 1.0) rather than merely counted.

**`test_parallel_layer_runs_siblings_concurrently`** — `assert elapsed < 0.2` measured 0.26–0.55 depending on machine load. The real concurrency assertion (`abs(start_a - start_b) < 0.05`) passed, so parallelism genuinely works; only the arbitrary wall-clock budget was wrong. Raising the number would just move the flake, so the test now asserts the sibling execution windows actually **overlap** instead of racing a stopwatch.

Negative control, to prove the new assertion is a real gate and not a tautology — forcing serial execution (`max_parallel=1`, `parallel=True`) makes it fail as it should:

```
E   AssertionError: siblings did not overlap: {'a': (35275.2522, 35275.3378), 'b': (35275.4070, 35275.4986)}
E   assert -0.0692 > 0
```

**`test_memory_assemble_endpoint`** — order-dependent. `tests/dms/test_memory_persist_stress.py` rebinds the module-global `memory_routes._STORE` to a 64-dim store and closes it, so this test failed with `ValueError: vector dim (2,) != store dim (64,)` whenever it ran second. `pytest-randomly` is installed, so this was a permanent intermittent red. Main had already half-fixed this; this adds the comment explaining *why* the store must be owned outright, so it does not regress.

## Verification

```
pytest tests/test_execution/ tests/test_api/ tests/contract/ tests/invariants/ -q   323 passed, 1 skipped
pytest tests/dms/test_memory_persist_stress.py tests/test_api/test_memory_assemble.py -q -p no:randomly   6 passed
pytest tests/ -q   1485 passed, 11 skipped   (run twice under different pytest-randomly orders)
ruff check CortexOS packages/cortex_contract scripts tests/packaging tests/contract   All checks passed!
lint-imports   Contracts: 2 kept, 0 broken.
```

CI is billing-blocked (jobs fail in 2–4s with `steps: 0`), so these local gates are the only real signal here.

## Two follow-ups found, deliberately not fixed here

1. **`GET /api/engine/runs/{run_id}/cost` has no auth.** It is unauthenticated while its siblings in `memory_routes.py` all carry `Depends(require_role("viewer"))`, and `create_app` adds no auth middleware. An unauthenticated caller who can guess a `run_id` gets that run's total MYR spend plus per-node model, tier, latency and token counts. The obvious one-line fix is **wrong**: `require_role` lives in `packs.dms.security.api_auth`, and `CortexOS/api/dag_run.py` is in neither `.importlinter`'s ignore list nor `_C2_ALLOWLIST`, so copying the neighbour's import would breach the C2 boundary — and CLAUDE.md forbids adding new allowlist entries. This needs an engine-side auth port with the pack registering an implementation, like `CortexOS/audit/ledger_registry.py`. That is a design change, not a drive-by.

2. **The cost GET mutates ceiling state.** `hydrate_run_total` writes `_run_totals[run_id]`, the exact value `enforce_ceiling` reads. `add()` commits its DB row before incrementing `_run_totals`, so a GET landing in that window recomputes from a SUM that already contains the row and then double-counts it. Fails closed (throttles early, never overspends), so it is a correctness defect rather than a spend-control hole — but combined with (1) it means an unauthenticated request can perturb a run's ceiling accounting.

🤖 Generated with [Claude Code](https://claude.com/claude-code)