### PR TITLE
fix(dms-ui): declare @babel/runtime, which the .babelrc build depends on

### DIFF
--- a/demo/dms-ui/package-lock.json
+++ b/demo/dms-ui/package-lock.json
@@ -16,6 +16,7 @@
       },
       "devDependencies": {
         "@babel/core": "^7.29.7",
+        "@babel/runtime": "^7.29.7",
         "@playwright/test": "^1.49.0"
       }
     },

--- a/demo/dms-ui/package.json
+++ b/demo/dms-ui/package.json
@@ -18,6 +18,7 @@
   },
   "devDependencies": {
     "@babel/core": "^7.29.7",
+    "@babel/runtime": "^7.29.7",
     "@playwright/test": "^1.49.0"
   },
   "overrides": {


### PR DESCRIPTION
`demo/dms-ui/.babelrc` pins `{"presets": ["next/babel"]}` — the deliberate SWC-skew mitigation from #84. `next/babel` needs `@babel/runtime` at build time, but #84 declared only `@babel/core`. The build works today **by accident**: `@babel/runtime` is hoisted transitively through recharts 2 → react-smooth.

That makes it a latent break rather than a theoretical one. Any dependency change that drops the recharts→react-smooth chain takes out both `next build` and `next dev` (`demo/run_demo.ps1` runs `npm run dev`, same Babel path).

## Why this matters right now

Dependabot [#79](https://github.com/Netie-AI/Cortex/pull/79) (recharts 3.10.1) does exactly that. It fails the build on three routes — including `app/chat/page.jsx`, which imports no recharts at all. The failure therefore points at the wrong file, which is why an earlier audit recorded "next build breaks" against recharts itself and recommended closing #79.

With `@babel/runtime` declared, recharts 3.10.1 builds clean and all five chart paths render. So this PR is a prerequisite for deciding #79 on its actual merits, and it should land whether or not #79 ever does.

## Verification

```
npm ci && npm run build   ->  exit 0, 11/11 static pages prerendered
```

Two files, two lines. No source changes.

## Related finding

No workflow builds `demo/dms-ui` at all. `grep -rniE "npm|node|yarn|pnpm|dms-ui|setup-node|playwright" .github/workflows/` returns zero matches across all five workflows, while `.github/dependabot.yml` opens npm PRs against that directory with `open-pull-requests-limit: 5`. Every one of #77–#81 would go green on a gate that never ran — which is how two provably broken bumps (#78 and #81, whose own lockfiles violate a peer internally) sat open. A single job running `npm ci && npm run build` there would have caught #79 automatically. Worth adding, though it proves nothing until Actions billing is restored.

🤖 Generated with [Claude Code](https://claude.com/claude-code)