### PR TITLE
Accept Constructor enhance nodes as DOCUMENT_REF

### DIFF
--- a/CortexOS/constructor_graph.py
+++ b/CortexOS/constructor_graph.py
@@ -19,6 +19,7 @@ _KINDS = frozenset(
         "agent",
         "hypothesize",
         "improve",
+        "enhance",
         "audit",
         "tool_call",
     }
@@ -34,6 +35,7 @@ _KIND_TO_TYPE = {
     "agent": NodeType.AGENT_TASK,
     "hypothesize": NodeType.DOCUMENT_REF,
     "improve": NodeType.DOCUMENT_REF,
+    "enhance": NodeType.DOCUMENT_REF,
     "audit": NodeType.DOCUMENT_REF,
     "tool_call": NodeType.TOOL_CALL,
 }

--- a/tests/dms/test_constructor_graph.py
+++ b/tests/dms/test_constructor_graph.py
@@ -61,6 +61,30 @@ def test_compile_rejects_unknown_kind():
         compile_constructor_graph({"nodes": [{"id": "x", "kind": "n8n"}], "edges": []})
 
 
+def test_compile_enhance_kind_is_document_ref():
+    from netie.fabrication.dsl_parser import NodeType
+
+    program = compile_constructor_graph(
+        {
+            "nodes": [
+                {
+                    "id": "e1",
+                    "kind": "enhance",
+                    "object_type": "images",
+                    "action_type": "image.enhance",
+                    "fetch_from": "local.model",
+                },
+                {"id": "a1", "kind": "app"},
+            ],
+            "edges": [{"from": "e1", "to": "a1"}],
+        }
+    )
+    by_id = {n.id: n for n in program.nodes}
+    assert by_id["e1"].type == NodeType.DOCUMENT_REF
+    assert by_id["e1"].annotations["constructor_kind"] == "enhance"
+    assert by_id["a1"].type == NodeType.EMIT
+
+
 def test_compile_ontology_fields_land_on_the_dag():
     program = compile_constructor_graph(
         {


### PR DESCRIPTION
## Summary
- Suspect-desk graphs use kind `enhance` (Comfy-style, ghost on Pages).
- Compile maps it to DOCUMENT_REF so ghost/run no longer 400 unknown kind.

## Test plan
- [ ] pytest tests/dms/test_constructor_graph.py::test_compile_enhance_kind_is_document_ref
- [ ] Local ghost a police-suspect-desk graph after issuing ov_
