### PR TITLE
Return 400 for broken JSON on /cortex/session

### DIFF
--- a/packs/dms/constructor_routes.py
+++ b/packs/dms/constructor_routes.py
@@ -168,7 +168,11 @@ def constructor_issue_key(request: Request, body: IssueKeyBody = IssueKeyBody())
 async def cortex_session(request: Request) -> RedirectResponse:
     content_type = request.headers.get("content-type", "")
     if "application/json" in content_type:
-        body = SessionBody.model_validate(await request.json())
+        try:
+            payload = await request.json()
+        except Exception as exc:
+            raise HTTPException(status_code=400, detail="Send JSON {key: ...}") from exc
+        body = SessionBody.model_validate(payload)
         key = body.key.strip()
     else:
         try:

--- a/tests/dms/test_constructor_graph.py
+++ b/tests/dms/test_constructor_graph.py
@@ -326,6 +326,25 @@ def test_run_seeds_fetch_onto_document_ref(dms_client, api_keys_env):
     assert out["rows"]
 
 
+def test_session_rejects_broken_json_with_400(dms_client):
+    res = dms_client.post(
+        "/cortex/session",
+        content="{key:no-quotes}",
+        headers={"Content-Type": "application/json"},
+    )
+    assert res.status_code == 400
+
+
+def test_session_sets_cookie_for_viewer_key(dms_client, api_keys_env):
+    res = dms_client.post(
+        "/cortex/session",
+        json={"key": api_keys_env["viewer"]},
+        follow_redirects=False,
+    )
+    assert res.status_code == 303
+    assert "cortex_api_key" in res.cookies
+
+
 def test_issue_key_uses_openvault_token(dms_client, monkeypatch):
     monkeypatch.setattr(
         "CortexOS.integrations.openvault_client.post_json",


### PR DESCRIPTION
## Summary
- Bad JSON on POST /cortex/session was a 500 traceback.
- Now 400 with `Send JSON {key: ...}`. Valid viewer key still 303 + cookie.

## Test plan
- [ ] pytest tests/dms/test_constructor_graph.py::test_session_rejects_broken_json_with_400
- [ ] pytest tests/dms/test_constructor_graph.py::test_session_sets_cookie_for_viewer_key
