### PR TITLE
C7-01: L2 shadow mode + route_to_metric replacement design (Cortex#17, Cortex#100)

### DIFF
--- a/CortexOS/dms/answer_engine.py
+++ b/CortexOS/dms/answer_engine.py
@@ -1318,10 +1318,14 @@ def answer(
             return _abstain_unbound(question, audit_id, reason=str(exc))
 
     def _done(result: dict[str, Any]) -> dict[str, Any]:
-        if not require_grounding:
-            return result
-        if "grant_kind" not in result:
-            return _stamp_grant(result, kind=grant_kind, sources=granted_sources)
+        if require_grounding and "grant_kind" not in result:
+            result = _stamp_grant(result, kind=grant_kind, sources=granted_sources)
+        try:
+            from CortexOS.dms.l2_generation import maybe_record_l2_shadow
+
+            maybe_record_l2_shadow(question, result, verified=verified)
+        except Exception:  # noqa: BLE001 — shadow must never affect served
+            pass
         return result
 
     def _abs(reason: str) -> dict[str, Any]:

--- a/CortexOS/dms/l2_generation.py
+++ b/CortexOS/dms/l2_generation.py
@@ -9,8 +9,11 @@ declares this port, the active pack registers an implementation, and
 from __future__ import annotations
 
 import importlib
+import json
 import os
+import time
 from dataclasses import dataclass
+from pathlib import Path
 from typing import Any, Protocol
 
 
@@ -87,12 +90,24 @@ class L2Attempt:
     violations: list[str] | None = None
 
 
-def attempt_l2(question: str, *, verified: Any = None) -> L2Attempt | None:
+def _env_on(name: str) -> bool:
+    return os.environ.get(name, "").lower() in ("1", "true", "yes")
+
+
+def attempt_l2(
+    question: str,
+    *,
+    verified: Any = None,
+    force: bool = False,
+    promote: bool = True,
+) -> L2Attempt | None:
     """Run L2 through the registered port. ``None`` when the L2 flag is off.
 
+    ``force=True`` runs even when ``DMS_L2_ENABLED`` is unset (shadow).
+    ``promote=False`` skips steward recording so shadow cannot mutate L0.
     Lives here so ``answer_engine`` never names pack generation modules.
     """
-    if os.environ.get("DMS_L2_ENABLED", "").lower() not in ("1", "true", "yes"):
+    if not force and not _env_on("DMS_L2_ENABLED"):
         return None
 
     from CortexOS.dms.sql_validate_gate import SqlGateAbstain, gate_with_retry
@@ -151,15 +166,140 @@ def attempt_l2(question: str, *, verified: Any = None) -> L2Attempt | None:
         )
 
     sql = gate.safe_sql
-    try:
-        l2.record_validated(question, sql)
-    except Exception:  # noqa: BLE001 — promotion signal must not block answers
-        pass
+    if promote:
+        try:
+            l2.record_validated(question, sql)
+        except Exception:  # noqa: BLE001 — promotion signal must not block answers
+            pass
     tables = list((reduced.get("tables") or {}).keys())
     return L2Attempt(
         sql=sql,
         assumptions=f"L2 FreeRoute SQL over reduced schema tables={tables}",
     )
+
+
+_SKIP_SHADOW_LAYERS = frozenset({"generated", "blocked", "rag", "catalog"})
+
+
+def _shadow_path() -> Path:
+    override = (os.environ.get("DMS_L2_SHADOW_PATH") or "").strip()
+    if override:
+        return Path(override)
+    from CortexOS.paths import data_path
+
+    return data_path("engine", "l2_shadow.jsonl")
+
+
+def _compact_values(rows: list[Any] | None) -> list[Any] | None:
+    if not rows or len(rows) > 3:
+        return None
+    return json.loads(json.dumps(rows, default=str))
+
+
+def _l2_execute(sql: str, verified: Any) -> tuple[list[Any] | None, str | None]:
+    if verified is not None:
+        from CortexOS.execution.manifest import ManifestError
+        from CortexOS.execution.submit import execute_sql
+
+        try:
+            rows, _, _ = execute_sql(verified, sql)
+            return list(rows), None
+        except ManifestError as exc:
+            return None, type(exc).__name__
+        except Exception as exc:  # noqa: BLE001
+            return None, type(exc).__name__
+    from CortexOS.dms.sql_guardrail import guard_and_execute
+    from CortexOS.dms.warehouse_db import (
+        DEFAULT_DB,
+        get_connection,
+        load_semantic_layer,
+        read_only_queries_enabled,
+    )
+
+    con = get_connection(DEFAULT_DB, read_only=read_only_queries_enabled())
+    try:
+        gate, rows, _ = guard_and_execute(sql, load_semantic_layer(), con)
+        if not gate.passed:
+            return None, "guardrail"
+        return list(rows), None
+    finally:
+        con.close()
+
+
+def _write_l2_shadow(
+    question: str,
+    served: dict[str, Any],
+    *,
+    verified: Any,
+) -> None:
+    started = time.perf_counter()
+    refusal: str | None = None
+    l2_sql: str | None = None
+    l2_rows: list[Any] | None = None
+    try:
+        out = attempt_l2(question, verified=verified, force=True, promote=False)
+        if out is None:
+            refusal = "not_enabled"
+        elif not out.sql:
+            refusal = (out.reason or "l2_refused")[:240]
+        else:
+            l2_sql = out.sql
+            l2_rows, exec_ref = _l2_execute(out.sql, verified)
+            if exec_ref:
+                refusal = exec_ref
+                l2_sql = out.sql
+    except Exception as exc:  # noqa: BLE001
+        refusal = f"exception:{type(exc).__name__}"
+    latency_ms = round((time.perf_counter() - started) * 1000.0, 3)
+    served_rows = list(served.get("rows") or [])
+    served_n = served.get("row_count")
+    if served_n is None:
+        served_n = served.get("total_count")
+    if served_n is None:
+        served_n = len(served_rows)
+    l2_n = len(l2_rows) if l2_rows is not None else None
+    served_empty = served.get("layer") in ("abstain", "refused") or not served_rows
+    l2_empty = l2_rows is None
+    if served_empty and l2_empty:
+        agree = True
+    elif served_empty or l2_empty:
+        agree = False
+    else:
+        agree = int(served_n) == int(l2_n or 0)
+    rec = {
+        "question": question,
+        "served_layer": served.get("layer"),
+        "served_badge": served.get("badge"),
+        "served_row_count": served_n,
+        "served_values": _compact_values(served_rows),
+        "l2_sql": l2_sql,
+        "l2_refusal_type": refusal,
+        "l2_row_count": l2_n,
+        "l2_values": _compact_values(l2_rows),
+        "agree": agree,
+        "latency_ms": latency_ms,
+    }
+    path = _shadow_path()
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("a", encoding="utf-8") as fh:
+        fh.write(json.dumps(rec, default=str) + "\n")
+
+
+def maybe_record_l2_shadow(
+    question: str,
+    served: dict[str, Any],
+    *,
+    verified: Any = None,
+) -> None:
+    """Compare L2 to a served envelope. Never raises; never mutates ``served``."""
+    if not _env_on("DMS_L2_SHADOW"):
+        return
+    if served.get("layer") in _SKIP_SHADOW_LAYERS:
+        return
+    try:
+        _write_l2_shadow(question, served, verified=verified)
+    except Exception:  # noqa: BLE001
+        return
 
 
 __all__ = [
@@ -168,6 +308,7 @@ __all__ = [
     "L2NotRegistered",
     "attempt_l2",
     "clear_l2_generation",
+    "maybe_record_l2_shadow",
     "register_l2_generation",
     "resolve_l2_generation",
 ]

--- a/docs/design/2026-09-04_C7_ROUTE_TO_METRIC_REPLACEMENT.md
+++ b/docs/design/2026-09-04_C7_ROUTE_TO_METRIC_REPLACEMENT.md
@@ -1,0 +1,202 @@
+# C7 — replace `route_to_metric` keyword cascade
+
+**Date:** 2026-09-04  
+**Epic:** Netie-AI/Cortex#17 EPIC-006 (founder override superseding #12)  
+**Branch / worktree:** `cursor/c7-design-epic-006` at `D:\Cortex-wt\c7-design`  
+**This ticket ships:** design + C7-01 shadow mode only. Do not rewrite the cascade here.
+
+C7 in CLAUDE.md: replace the keyword cascade in `answer_engine.route_to_metric` with schema retrieval → generation → sqlglot → EXPLAIN → bounded retry → plausibility. L2 already exists as an env-gated port. The serve path stays L0/L1 until numeric gates pass.
+
+---
+
+## (a) Current state (measured 2026-09-04 against `bf4ecee`)
+
+### Router 2 order
+
+`docs/dms/ROUTER_STATES.md` (established 2026-07-27): session → certified L0 → governed_metric L1 (`route_to_metric`) → query_skill → L2 freeform (`DMS_L2_ENABLED`, default OFF) → L3 abstain. First match wins.
+
+### File:line anchors
+
+| Piece | Path | Lines |
+|---|---|---|
+| L0/L1/L2 docstring | `CortexOS/dms/answer_engine.py` | 6–13 |
+| Slot regex helpers used by L1 | same | `_explicit_limit` 141–161, `_direction` 164–165, `_threshold` 168–170, `_threshold_op` 173–176, `_days` 179–186, `_wants_aggregate` 189–196, `_calendar_month` 199–205, `_pct` 208–210, `_rank_window` 351–380, `_wants_sales_rank` 561–572 |
+| Shape refusal (not a metric) | same | `_shape_refusal` 641–643, called 664–665 and again in `answer` 1397–1399 |
+| **L1 cascade** | same | `route_to_metric` **647–776** |
+| Serve path L0 then L1 then skill then L2 | same | `answer` 1388–1485 |
+| L2 port + `attempt_l2` | `CortexOS/dms/l2_generation.py` | port 17–30, register 40–61, `attempt_l2` 90–162 |
+| sqlglot + EXPLAIN + retry | `CortexOS/dms/sql_validate_gate.py` | `run_gate` 58–100, `gate_with_retry` 103–134 |
+| Manifest enforcer | `CortexOS/execution/manifest.py` | `enforce_manifest` 960+ |
+| Enforce then EXPLAIN then fetch | `CortexOS/execution/submit.py` | `execute_sql` 174–228 |
+| Schema retrieval | `packs/dms/generative/schema_retrieval.py` | `retrieve` 99+ |
+| FreeRoute generator | `packs/dms/generative/sql_generator.py` | `is_configured` 23–32, `generate_candidates` 139–169 |
+| Literal normalize (G4) | `packs/dms/generative/literal_normalize.py` | `normalize_sql_literals` 48+ |
+| Pack adapter (C2 inversion) | `packs/dms/generative/l2_adapter.py` | 8–37 |
+| Pack registers port | `packs/dms/__init__.py` | `register_engine_seams` 17–30 |
+| Existing L2 tests | `tests/dms/test_c7_full_generation.py`, `tests/dms/test_sql_validate_gate.py` | — |
+| `test_l2_pipelines.py` | lakehouse pipelines, **not** NL→SQL L2 | — |
+
+`DMS_L2_ENABLED` default OFF: `l2_generation.py:95`, `sql_generator.py:25`. When ON and no model, `attempt_l2` returns reason `no verified answer path (L2 not wired)` (`l2_generation.py:111–112`). `ROUTER_STATES.md:67` still says the flag only changes the abstain reason; that is stale — `test_c7_full_generation.py:87–107` already mocks a generator and can serve `layer=generated` / `badge=L2_VALIDATED`.
+
+### Measured counts (`route_to_metric` body 647–776)
+
+| Metric | Count | Notes |
+|---|---|---|
+| `re.search(` call sites | **27** | One site in the status loop (729–733) runs per token |
+| `return _metric_plan(...)` branches | **25** | 23 unique `metric_id`s; `revenue_total` and `revenue_last_month` each have two return sites |
+| `return None` | **2** | shape refusal 664–665; fallthrough 776 |
+| File-wide `re.search(` in `answer_engine.py` | **65** | includes slot extractors, session anaphora, subject parse; not all are L1 |
+
+Unique L1 metric ids (23): `active_alerts`, `arriving_window`, `avg_lead_time_by_country`, `capacity_above`, `capacity_utilisation`, `cold_storage_count`, `cold_storage_list`, `count_by_carrier`, `count_by_destination`, `expired_count`, `expired_items`, `expired_last_month`, `free_capacity`, `low_stock`, `revenue_last_month`, `revenue_total`, `revenue_windowed`, `sales_by_value`, `sales_by_volume`, `shipments_by_status`, `sku_count`, `stale_restock`, `suppliers_by_risk`.
+
+### What already exists vs what C7 still lacks
+
+Present (gated, not the serve default): reduced-schema retrieval, FreeRoute generation, literal normalize, sqlglot `validate_sql`, optional DuckDB EXPLAIN, bounded retry (`max_retries=2` → 3 attempts), promotion after 5 validated uses.
+
+Missing on the **serve** path: plausibility / abstain-confidence; held-out (non-team) corpus; shadow comparison vs L1; **manifest enforcer inside the L2 generate gate**.
+
+### Gap the replacement must close
+
+`attempt_l2` (`l2_generation.py:126–137`) opens a warehouse connection for EXPLAIN only when `verified is None`. When a session manifest is present, `gate_with_retry(..., con=None)` is parse-only (`sql_validate_gate.py:75–81` sets `explain_ok=True` without EXPLAIN). Manifest runs later in `answer` via `execute_sql` → `enforce_manifest` then EXPLAIN (`submit.py:194–213`). The generate/retry loop can therefore accept SQL the enforcer will later refuse, and it can EXPLAIN SQL the enforcer has not rewritten. C7-02 must put `enforce_manifest` on **every** generated candidate **before** EXPLAIN. No stage may weaken `manifest.py` refusals.
+
+C2: `l2_generation.py` must not statically import `packs.*` (already tested). `answer_engine.route_to_metric` and `_tables_stated_by_metric` still import `packs.dms.semantic` — pre-C2 debt. The replacement must call L2 only through `CortexOS.dms.l2_generation`.
+
+---
+
+## (b) Target pipeline
+
+Every generated SQL is a candidate, not an answer, until the enforcer and EXPLAIN pass. Stages are fail-closed. Served customer envelope fields that gates assert on: `answer` text, `rows`, `layer`, `badge`, `route`, `sql_used`, `assumptions` / reason, `suggestions` (abstain), and when grounded: `grant_kind` / refused vs abstain (F40).
+
+| # | Stage | Input | Output | Refusal type (envelope) | May weaken manifest? |
+|---|---|---|---|---|---|
+| 1 | Schema retrieval | question | reduced `{tables, columns, joins}` top-k | `schema_empty` / `schema_retrieval_failed` → L3 abstain | no (no SQL yet) |
+| 2 | Generation | question + reduced schema + prior violations | 1 candidate SELECT (literal-normalized) | `not_wired`, `leave_machine_denied`, `no_candidate`, `unresolved_literal` (G4) | no — empty list, never a guessed filter |
+| 3 | sqlglot allowlist | candidate SQL + semantic layer | `safe_sql` or violations | `PARSE_ERROR`, `MULTI_STATEMENT`, unknown table/column, DDL/DML | no |
+| 4 | **Manifest enforcer** | `safe_sql` + same `VerifiedManifest` / grant as the served turn | rewritten SQL or `ManifestError.code` | `refused` + code (`statement_not_allowed`, `path_not_allowed`, `sql_not_analyzable`, …) — **not** Badge.SESSION | **MUST run. MUST NOT be skipped when `verified` is set. MUST NOT be narrowed to make a candidate pass.** |
+| 5 | EXPLAIN | post-enforce SQL + read-only con | ok / `EXPLAIN_FAILED:…` | feed violation to retry; exhaust → `SqlGateAbstain` | no — EXPLAIN is after enforce so it sees the rewritten statement |
+| 6 | Bounded retry | prior violations | new candidate or exhaust | same as 2–5; `max_retries=2` (3 attempts) stays | no |
+| 7 | Execute (C4 submit) | post-enforce SQL | rows | execute `SqlGateAbstain` / `ManifestError` → abstain / refused | no |
+| 8 | Plausibility (c) | question + rows + SQL + schema | pass or abstain | `implausible_empty`, `implausible_shape`, `low_confidence` | no — abstain, never rewrite SQL around the enforcer |
+
+L0 certified and L1 governed templates remain the high-trust serve path until (f) passes. Pipeline is the L2 path, then the L1 replacement.
+
+---
+
+## (c) Abstain-confidence / plausibility
+
+After execute, before synthesize. Does **not** generate SQL. Does **not** call the enforcer. Can only pass through or abstain.
+
+Signals (all fail-closed; any trip → abstain, badge `abstain`, no rows):
+
+1. **Empty-success:** 0 rows and the question asserted existence / ranking / threshold. Prefer abstain over a green empty table (G4 class).
+2. **Shape:** scalar question (`how many` / `average`) with a listing, or listing with a single unlabeled number and no group key.
+3. **Retrieval miss:** generated SQL's tables disjoint from retrieval top-k (wrong-table valid SQL — the BIRD-width failure).
+4. **Literal leftover:** a filter literal that value-dict would have rewritten (`BETA` vs `SKU-BETA`) slipped through.
+5. **Numeric gate:** optional score in `[0,1]`; default cut **0.55**. Below → `low_confidence`. Score is diagnostic; it must not override 1–4.
+
+Calibration lives on the held-out corpus (d/e), not on team paraphrases of `metrics.yaml`.
+
+---
+
+## (d) Shadow mode (`DMS_L2_SHADOW=1`) — C7-01
+
+After `_done` stamps the **served** envelope, if `DMS_L2_SHADOW` is on:
+
+1. Do not mutate the served dict. Do not change `answer` / `rows` / `layer` / `badge` / `route`.
+2. Skip `generated` / `blocked` / `rag` / `catalog` (L2 already served, or not the cascade).
+3. Call `attempt_l2(question, verified=verified, force=True, promote=False)` — same manifest/grant as the turn; **never** write promotion / steward rows.
+4. If L2 returns SQL, execute with the same grant (`execute_sql` when `verified` else legacy `guard_and_execute`).
+5. Append one JSONL line. Path: `DMS_L2_SHADOW_PATH` or `data/engine/l2_shadow.jsonl` via `CortexOS.paths.data_path`. Create parents. `data/engine/` is gitignored.
+6. Outer `try/except`: disk, L2, execute — never raise into the serve path.
+
+`DMS_L2_SHADOW` does **not** set `DMS_L2_ENABLED`. Serve L2 still requires `DMS_L2_ENABLED`. Pack `is_configured()` treats SHADOW as configured so a wired model can run in shadow without serving.
+
+Fields: `question`, `served_layer`, `served_badge`, `served_row_count`, `served_values` (≤3 rows or null), `l2_sql` or `l2_refusal_type`, `l2_row_count`, `l2_values`, `agree` (bool), `latency_ms`.
+
+`agree`: both empty/abstain → true; one empty → false; else row counts equal.
+
+Shadow is **sync** and adds latency to the request. Flag is opt-in. Do not enable on the S1 watcher hot path (`docs/research/findings/S1_TOKEN_BUDGET.md`).
+
+---
+
+## (e) Held-out corpus (not team paraphrases)
+
+`bench/accuracy` (36 gold) and `bench/paraphrase` (85) are **development** sets. They were written next to the 23 metrics. They must not be the cutover corpus.
+
+| Split | Source | Use |
+|---|---|---|
+| Dev | existing golden + paraphrase | keep L1 from regressing while shadowing |
+| Held-out SQL | BIRD-SQL + Spider 2.0 style questions over **this** warehouse schema (or a frozen dump), gold SQL from a **different** model/lab than FreeRoute, then human-checked | execution accuracy |
+| Must-abstain | adversarial + false-premise from a **different** model (not the serve generator): unknown entities, 1997 Berlin, ESG+weather, destructive phrasing, unanswerable joins | 100% abstain |
+| Width | same questions at 20 / 100 / 500 table catalogs (synthetic wide schema) | retrieval miss |
+
+Scoring buckets (`docs/dms/DMS_EVAL_AND_STRESS_PLAN.md` §3.2): correct / abstained / incorrect. Incorrect is the number that must approach zero. A third party writes must-abstain items; the team only reviews, does not author the paraphrases.
+
+---
+
+## (f) Decision procedure (numeric)
+
+All gates are on the **customer envelope** (rendered `answer` + `rows` + badge), not on generated SQL alone.
+
+| Gate | Number | Fail action |
+|---|---|---|
+| G-abs | must-abstain recall **= 100%** (0 served rows on that split) | no serve-path swap |
+| G-err | held-out **incorrect < 2%** and **≤** current L1 incorrect on the same items | no swap |
+| G-env | 0 G4-class: success badge + empty/wrong encoding (`BETA` vs `SKU-BETA`) | no swap |
+| G-man | `tests/test_execution` green; **0** hostile-corpus reclassifications to `allow_but_predicate_must_apply` | no swap; never weaken `manifest.py` |
+| G-sh | ≥ **500** shadow lines on live/dev traffic; report L2-only-correct vs L1-only-correct; no silent serve change | needed before C7-05 |
+| G-lat | serve p95 with SHADOW off **unchanged**; SHADOW-on extra latency documented, not a serve gate | ops only |
+
+Cutover (C7-05): `DMS_L2_ENABLED=1` may serve when L0/L1 miss **after** G-abs, G-err, G-env, G-man, G-sh. Retire `route_to_metric` (C7-06) only when L2-as-L1-replacement beats L1 on G-err **and** G-abs still holds. Until then the 27-regex cascade stays.
+
+---
+
+## (g) Sub-tickets (paste-ready)
+
+### C7-01 — L2 shadow JSONL (`DMS_L2_SHADOW=1`)
+
+**WHEN** an operator sets `DMS_L2_SHADOW=1`  
+**SHALL** the engine leave the served envelope byte-identical to SHADOW off (same `answer`, `rows`, `layer`, `badge`, `route`) and append one JSONL record under `data/engine/` (path overridable) comparing served vs L2; L2 exceptions SHALL NOT change the envelope.  
+**Appetite:** S  
+**Files:** `CortexOS/dms/l2_generation.py`, `CortexOS/dms/answer_engine.py`, `packs/dms/generative/sql_generator.py`, `tests/dms/test_c7_l2_shadow.py`  
+**Blocked-by:** none (this ticket)
+
+### C7-02 — Manifest before EXPLAIN on every L2 candidate
+
+**WHEN** L2 generates SQL for a grounded session  
+**SHALL** `enforce_manifest` run on that SQL before EXPLAIN; a `ManifestError` SHALL surface as customer `route/layer/badge=refused` (not SESSION) and SHALL abort retry of that candidate; EXPLAIN SHALL see only post-enforce SQL. No refusal in `manifest.py` may be narrowed to pass a candidate.  
+**Appetite:** S  
+**Files:** `CortexOS/dms/sql_validate_gate.py`, `CortexOS/dms/l2_generation.py`, `CortexOS/execution/submit.py`, `tests/dms/test_sql_validate_gate.py`, `tests/test_execution/`  
+**Blocked-by:** none (parallel with C7-01)
+
+### C7-03 — Plausibility / abstain-confidence stage
+
+**WHEN** L2 execute returns rows  
+**SHALL** a plausibility stage run before synthesize; trips SHALL abstain (`badge=abstain`, empty `rows`, reason in `assumptions`) and SHALL NOT rewrite SQL or skip the enforcer. Empty-success and wrong-table-vs-retrieval SHALL abstain.  
+**Appetite:** M  
+**Files:** new `CortexOS/dms/l2_plausibility.py` (engine), tests under `tests/dms/`  
+**Blocked-by:** C7-02 (stage order: enforce → EXPLAIN → execute → plausibility)
+
+### C7-04 — Held-out corpus + eval harness
+
+**WHEN** C7 cutover is proposed  
+**SHALL** a frozen held-out set exist that is not team-written paraphrases of `metrics.yaml`: BIRD/Spider-style items + must-abstain from a different model; the harness SHALL score correct / abstained / incorrect on the customer envelope.  
+**Appetite:** M  
+**Files:** `bench/` (new split), `docs/dms/DMS_EVAL_AND_STRESS_PLAN.md` (pointer only if needed — do not edit STATUS/CHANGELOG/INDEX in this epic's first ticket)  
+**Blocked-by:** none (parallel). Required before C7-05.
+
+### C7-05 — Serve L2 on L0/L1 miss after numeric gates
+
+**WHEN** G-abs, G-err, G-env, G-man, G-sh all pass on the held-out report  
+**SHALL** `DMS_L2_ENABLED=1` serve `layer=generated` / `badge=L2_VALIDATED` only after the full pipeline including plausibility; SHADOW-off serve p95 SHALL not regress.  
+**Appetite:** L  
+**Files:** `CortexOS/dms/answer_engine.py` (call site already exists), pack generator, eval report  
+**Blocked-by:** C7-01, C7-02, C7-03, C7-04
+
+### C7-06 — Retire `route_to_metric` cascade
+
+**WHEN** the pipeline as L1 replacement beats L1 on G-err and still holds G-abs  
+**SHALL** `route_to_metric` stop being the serve chooser; keyword helpers may remain as slot extractors only if still needed for L0. A commit that deletes the 25 `_metric_plan` branches SHALL include the held-out numbers in the body.  
+**Appetite:** L  
+**Files:** `CortexOS/dms/answer_engine.py` 647–776, `tests/dms/test_q2_answer_engine.py`  
+**Blocked-by:** C7-05

--- a/docs/subagents_findings/2026-09-04_c7-design-and-shadow-mode.md
+++ b/docs/subagents_findings/2026-09-04_c7-design-and-shadow-mode.md
@@ -1,0 +1,26 @@
+# C7 route_to_metric replacement design + L2 shadow
+
+- Date: 2026-09-04
+- Keywords: C7, EPIC-006, route_to_metric, DMS_L2_SHADOW, L2, manifest, EXPLAIN, abstain-confidence, held-out, Spider, BIRD
+- Main idea: L1 is a 27-`re.search` / 25-`MetricPlan` cascade. L2 pipeline already exists behind `DMS_L2_ENABLED` (default OFF) on an engine port. Do not swap serve yet. C7-01 shadows L2 after the served envelope (`DMS_L2_SHADOW=1`); never mutates the answer. Manifest must run on every generated SQL before EXPLAIN (C7-02). Cutover needs a non-team held-out corpus plus numeric gates.
+- Path: this file
+
+## PREFLIGHT
+
+PARTIAL. reuse: `docs/dms/ROUTER_STATES.md`, `docs/dms/packets/CORTEX_TO_DMS_C7_KICKOFF.md`, `docs/dms/DMS_EVAL_AND_STRESS_PLAN.md` §3, `docs/subagents_findings/2026-08-25_dms-handoff-f40-ff03.md`. spawn: skip (executor).
+
+## Golden rules
+
+1. CortexOS must not statically import `packs.*`. Call L2 only via `CortexOS.dms.l2_generation`.
+2. Never weaken `CortexOS/execution/manifest.py` refusals. Enforcer before EXPLAIN.
+3. Shadow (`DMS_L2_SHADOW`) must not set `DMS_L2_ENABLED` and must not promote to L0.
+4. Held-out items are not team paraphrases of `metrics.yaml`. Must-abstain comes from a different model.
+5. Customer-envelope assertions (answer text + rows + badge), not SQL-only gates.
+
+## Verify
+
+```
+D:\Cortex\.venv\Scripts\python.exe -m pytest tests/dms/test_c7_l2_shadow.py tests/dms/test_c7_full_generation.py tests/dms/test_sql_validate_gate.py -q
+```
+
+Does not prove: live FreeRoute quality, held-out accuracy, or that L1 can be deleted.

--- a/packs/dms/generative/sql_generator.py
+++ b/packs/dms/generative/sql_generator.py
@@ -21,8 +21,10 @@ _SELECT = re.compile(r"(SELECT\b.+)", re.I | re.S)
 
 
 def is_configured() -> bool:
-    """True when L2 is enabled and OpenVault answers (FreeRoute path exists)."""
-    if os.environ.get("DMS_L2_ENABLED", "").lower() not in ("1", "true", "yes"):
+    """True when L2 is enabled or shadowed, and OpenVault answers."""
+    enabled = os.environ.get("DMS_L2_ENABLED", "").lower() in ("1", "true", "yes")
+    shadow = os.environ.get("DMS_L2_SHADOW", "").lower() in ("1", "true", "yes")
+    if not (enabled or shadow):
         return False
     try:
         from CortexOS.integrations.openvault_client import ping

--- a/tests/dms/test_c7_full_generation.py
+++ b/tests/dms/test_c7_full_generation.py
@@ -68,6 +68,7 @@ def test_promotion_surfaces_after_five(tmp_path: Path):
 
 def test_generator_unconfigured_without_l2_flag(monkeypatch):
     monkeypatch.delenv("DMS_L2_ENABLED", raising=False)
+    monkeypatch.delenv("DMS_L2_SHADOW", raising=False)
     assert sql_generator.is_configured() is False
     assert sql_generator.generate_candidates("top skus", {}) == []
 

--- a/tests/dms/test_c7_l2_shadow.py
+++ b/tests/dms/test_c7_l2_shadow.py
@@ -1,0 +1,120 @@
+"""C7-01 — DMS_L2_SHADOW records L2 without changing the served envelope."""
+
+from __future__ import annotations
+
+import json
+import uuid
+from datetime import datetime, timezone
+from pathlib import Path
+
+import pytest
+
+from CortexOS.dms import l2_generation
+
+
+@pytest.fixture(scope="module", autouse=True)
+def ensure_db():
+    from bench.accuracy import _ensure_db_loaded
+
+    _ensure_db_loaded()
+    yield
+
+
+class _OkPort:
+    def is_configured(self) -> bool:
+        return True
+
+    def retrieve_schema(self, question: str) -> dict:
+        return {"tables": {"inventory": {}}}
+
+    def generate_candidates(self, question, schema, *, prior_violations=None):
+        return ["SELECT sku FROM inventory LIMIT 5"]
+
+    def record_validated(self, question, sql):
+        raise AssertionError("shadow must not promote")
+
+
+class _BoomPort(_OkPort):
+    def generate_candidates(self, question, schema, *, prior_violations=None):
+        raise RuntimeError("l2 boom")
+
+
+class _FrozenDateTime:
+    @staticmethod
+    def now(tz=None):
+        return datetime(2026, 9, 4, 1, 2, 3, tzinfo=timezone.utc)
+
+
+def _freeze(monkeypatch) -> None:
+    monkeypatch.setattr(
+        "CortexOS.dms.answer_engine.uuid.uuid4",
+        lambda: uuid.UUID("00000000-0000-4000-8000-000000000099"),
+    )
+    monkeypatch.setattr("CortexOS.dms.sql_guardrail.datetime", _FrozenDateTime)
+
+
+def _dump(envelope: dict) -> bytes:
+    return json.dumps(envelope, sort_keys=True, default=str).encode("utf-8")
+
+
+def _ask():
+    from CortexOS.dms.answer_engine import answer
+
+    return answer("Which suppliers have a risk score above 0.7?")
+
+
+def test_shadow_off_vs_on_envelope_identical(monkeypatch, tmp_path: Path):
+    _freeze(monkeypatch)
+    monkeypatch.delenv("DMS_L2_ENABLED", raising=False)
+    monkeypatch.delenv("DMS_L2_SHADOW", raising=False)
+    monkeypatch.setattr(l2_generation, "resolve_l2_generation", lambda: _OkPort())
+    off = _ask()
+
+    monkeypatch.setenv("DMS_L2_SHADOW", "1")
+    monkeypatch.setenv("DMS_L2_SHADOW_PATH", str(tmp_path / "l2_shadow.jsonl"))
+    on = _ask()
+
+    assert _dump(on) == _dump(off)
+    assert on["layer"] == "governed_metric"
+    assert on["badge"] == off["badge"]
+    assert on["answer"] == off["answer"]
+    assert on["rows"] == off["rows"]
+
+
+def test_shadow_writes_one_jsonl_record(monkeypatch, tmp_path: Path):
+    _freeze(monkeypatch)
+    path = tmp_path / "nested" / "l2_shadow.jsonl"
+    monkeypatch.delenv("DMS_L2_ENABLED", raising=False)
+    monkeypatch.setenv("DMS_L2_SHADOW", "1")
+    monkeypatch.setenv("DMS_L2_SHADOW_PATH", str(path))
+    monkeypatch.setattr(l2_generation, "resolve_l2_generation", lambda: _OkPort())
+    served = _ask()
+    assert served["layer"] == "governed_metric"
+    lines = path.read_text(encoding="utf-8").strip().splitlines()
+    assert len(lines) == 1
+    rec = json.loads(lines[0])
+    assert rec["question"].startswith("Which suppliers")
+    assert rec["served_layer"] == "governed_metric"
+    assert rec["served_badge"] == "governed_metric"
+    assert rec["served_row_count"] == 8
+    assert rec["l2_sql"]
+    assert rec["l2_refusal_type"] is None
+    assert rec["l2_row_count"] == 5
+    assert isinstance(rec["agree"], bool)
+    assert rec["latency_ms"] >= 0
+
+
+def test_shadow_l2_exception_does_not_change_envelope(monkeypatch, tmp_path: Path):
+    _freeze(monkeypatch)
+    monkeypatch.delenv("DMS_L2_ENABLED", raising=False)
+    monkeypatch.delenv("DMS_L2_SHADOW", raising=False)
+    off = _ask()
+
+    monkeypatch.setenv("DMS_L2_SHADOW", "1")
+    monkeypatch.setenv("DMS_L2_SHADOW_PATH", str(tmp_path / "l2_shadow.jsonl"))
+    monkeypatch.setattr(l2_generation, "resolve_l2_generation", lambda: _BoomPort())
+    on = _ask()
+    assert _dump(on) == _dump(off)
+    rec = json.loads((tmp_path / "l2_shadow.jsonl").read_text(encoding="utf-8"))
+    assert rec["l2_refusal_type"] == "exception:RuntimeError"
+    assert rec["agree"] is False


### PR DESCRIPTION
## Summary
- Design for replacing the L1 keyword cascade (27 re.search sites, 25 MetricPlan returns) without serving L2.
- C7-01: `DMS_L2_SHADOW=1` runs L2 after the served envelope, writes JSONL, never changes answer/rows/badge.
- Does not rewrite `route_to_metric`. C7-02..06 remain separate tickets (#101-#105).

## Test plan
- [x] `pytest tests/dms/test_c7_l2_shadow.py` (3 passed locally)
- [ ] CI lint-type-test / base-install / protected-paths / rls-proof / secrets-scan
- [ ] Served envelope identical with SHADOW on vs off

Made with [Cursor](https://cursor.com)