### PR TITLE
Constructor generate seeds keep ontology+insight+foundry+app (Cortex#110)

### DIFF
--- a/CortexOS/constructor_graph.py
+++ b/CortexOS/constructor_graph.py
@@ -135,14 +135,249 @@ def compile_constructor_graph(payload: dict[str, Any]) -> AgenticDSLProgram:
     return parsed.value
 
 
+FOUNDRY_KINDS = frozenset({"ontology", "insight", "foundry", "app"})
+
+# Palantir-shaped generate intents. Each seed keeps ontology+insight+foundry+app
+# even when the prompt sounds like "agents" or "data" alone.
+NAMED_GENERATE = (
+    "understand this company",
+    "define data",
+    "govern agents",
+    "business insights",
+)
+
+# DMS semantic_layer.yaml tables only. No extra object without a matching table.
+_OBJECT_POINTS: dict[str, tuple[str, str]] = {
+    "inventory": ("sku", "warehouse.inventory"),
+    "suppliers": ("supplier_id", "warehouse.suppliers"),
+    "locations": ("location_id", "warehouse.locations"),
+    "shipments": ("shipment_id", "warehouse.shipments"),
+    "transactions": ("txn_id", "warehouse.transactions"),
+    "alerts": ("alert_id", "warehouse.alerts"),
+}
+
+_REFUSE_HITS = (
+    "prostitut",
+    "escort",
+    "brothel",
+    "sex work",
+    "sexworker",
+    "stalk",
+    "doxx",
+    "scrape the internet",
+    "scrape internet",
+    "public webcam",
+    "scrape camera",
+)
+
+_KIND_NOTES = {
+    "ingest": "Hop 0. Load semantic_layer rows. Ghost compiles. No write.",
+    "connector": "First-party Cortex input. No n8n.",
+    "ontology": "Object/link/action types transcribed from semantic_layer.yaml.",
+    "insight": "Cite ontology + ledger. What you may claim from those objects.",
+    "foundry": "Compile insights into a governed Cortex app. Not an n8n clone.",
+    "app": "Runnable output. Hosted inside Cortex at /cortex/constructor/.",
+    "agent": "AGENT_TASK loop. Action types + required_role. One bounded worker.",
+    "tool_call": "F8 governed write. requires_confirm. Real tool is export_pptx.",
+    "hypothesize": "Surface a testable claim.",
+    "audit": "Why this node exists. DETERMINISTIC_RULE, not a second EMIT.",
+}
+
+
 def recommend_extras(kinds: list[str]) -> dict[str, Any] | None:
     """Signals so Cortex ranks the foundry path as orchestrator-subagent."""
     kindset = {str(k) for k in kinds}
-    if {"ontology", "insight", "foundry", "app"} <= kindset:
+    if FOUNDRY_KINDS <= kindset:
         return {"specialization_needed": True, "prefer_cheapest": False}
     if {"hypothesize", "audit"} <= kindset:
         return {"quality_critical": True, "explicit_criteria": True}
     return None
+
+
+def generate_constructor_graph(prompt: str) -> dict[str, Any]:
+    """Compile a prompt onto a Constructor canvas. Ghost only. No writes.
+
+    Named seeds (understand this company / define data / govern agents /
+    business insights) always include ontology+insight+foundry+app. Object
+    types are semantic_layer tables only.
+    """
+    text = str(prompt or "").strip()
+    if not text:
+        raise ConstructorGraphError("prompt required")
+    low = " ".join(text.lower().split())
+    if any(hit in low for hit in _REFUSE_HITS):
+        return {
+            "ok": False,
+            "refused": True,
+            "ghost": True,
+            "nodes": [],
+            "edges": [],
+            "summary": (
+                "Refused. Constructor will not compile internet stalking, "
+                "doxxing, public-webcam scrape, or sex-work targeting."
+            ),
+        }
+
+    spec = _named_spec(low) or _default_spec(low)
+    nodes, edges = _seed_graph(spec)
+    compile_constructor_graph({"nodes": nodes, "edges": edges})
+    assumed = bool(spec["assumed"])
+    objects = list(spec["objects"])
+    action = str(spec["action"])
+    return {
+        "ok": True,
+        "ghost": True,
+        "pattern": spec["pattern"],
+        "assumed_object": assumed,
+        "objects": objects,
+        "action": action,
+        "nodes": nodes,
+        "edges": edges,
+        "summary": (
+            f"Compiled {len(nodes)} Cortex nodes ({spec['pattern']}). "
+            + ("Assumed inventory. " if assumed else f"Objects {', '.join(objects)}. ")
+            + f"Action {action}. Ghost only. Live run is POST /cortex/constructor/run."
+        ),
+    }
+
+
+def _named_spec(low: str) -> dict[str, Any] | None:
+    if "understand this company" in low:
+        return {
+            "kinds": ("connector", "ontology", "insight", "foundry", "app"),
+            "objects": ("inventory", "suppliers", "locations"),
+            "action": "export_pptx",
+            "pattern": "orchestrator_subagent",
+            "assumed": False,
+            "notes": {
+                "connector": "Bind warehouse rows that describe this company.",
+                "ontology": "Company model = object/link/action types already on the pack.",
+                "insight": "Cite ontology + ledger. What this company may claim.",
+                "foundry": "Compile the company model into a governed Cortex app.",
+                "app": "Runnable output hosted at /cortex/constructor/.",
+            },
+        }
+    if "define data" in low:
+        return {
+            "kinds": ("ingest", "connector", "ontology", "insight", "foundry", "app"),
+            "objects": ("inventory",),
+            "action": "export_pptx",
+            "pattern": "orchestrator_subagent",
+            "assumed": False,
+            "notes": {
+                "ingest": "Hop 0. Load semantic_layer columns as properties. No write.",
+                "connector": "Bind warehouse.inventory. Data points are table columns.",
+                "ontology": "Properties must match semantic_layer.yaml columns exactly.",
+                "insight": "Cite defined properties + joins. No extra object types.",
+                "foundry": "Compile the defined data into a governed Cortex app.",
+                "app": "Runnable output hosted at /cortex/constructor/.",
+            },
+        }
+    if "govern agents" in low:
+        return {
+            "kinds": ("connector", "ontology", "agent", "insight", "foundry", "app"),
+            "objects": ("inventory",),
+            "action": "agent.checked",
+            "pattern": "orchestrator_subagent",
+            "assumed": False,
+            "notes": {
+                "connector": "Bind the objects an agent may read.",
+                "ontology": "Action types + required_role are the agent permission gate.",
+                "agent": "AGENT_TASK. agent.checked is a ledger event, not an F8 tool.",
+                "insight": "Cite what the agent may claim after a governed check.",
+                "foundry": "Compile governed agents into a Cortex app. Not AIP Agent Studio.",
+                "app": "Runnable output hosted at /cortex/constructor/.",
+            },
+        }
+    if "business insights" in low:
+        return {
+            "kinds": ("connector", "ontology", "insight", "foundry", "app", "tool_call"),
+            "objects": ("inventory", "alerts"),
+            "action": "export_pptx",
+            "pattern": "orchestrator_subagent",
+            "assumed": False,
+            "notes": {
+                "connector": "Bind inventory + alerts the insight may cite.",
+                "ontology": "Insights ride object types, not a second metrics store.",
+                "insight": "Cite ontology + ledger. Business claim from owned rows.",
+                "foundry": "Compile insights into a governed Cortex app.",
+                "app": "Runnable output hosted at /cortex/constructor/.",
+                "tool_call": "F8 governed write. requires_confirm. export_pptx only.",
+            },
+        }
+    return None
+
+
+def _default_spec(low: str) -> dict[str, Any]:
+    objects = tuple(oid for oid in _OBJECT_POINTS if oid in low or oid.rstrip("s") in low)
+    assumed = not objects
+    if assumed:
+        objects = ("inventory",)
+    action = "export_pptx"
+    if "intake" in low:
+        action = "item.intake"
+    elif "agent.checked" in low or ("agent" in low and "check" in low):
+        action = "agent.checked"
+    kinds: tuple[str, ...] = (
+        "ingest",
+        "connector",
+        "ontology",
+        "insight",
+        "foundry",
+        "app",
+        "tool_call",
+    )
+    return {
+        "kinds": kinds,
+        "objects": objects,
+        "action": action,
+        "pattern": "orchestrator_subagent",
+        "assumed": assumed,
+        "notes": {},
+    }
+
+
+def _seed_graph(spec: dict[str, Any]) -> tuple[list[dict[str, Any]], list[dict[str, str]]]:
+    kinds: tuple[str, ...] = spec["kinds"]
+    objects: tuple[str, ...] = spec["objects"]
+    action = str(spec["action"])
+    notes: dict[str, str] = spec.get("notes") or {}
+    bind = frozenset(
+        {"ingest", "connector", "ontology", "insight", "enhance", "tool_call"}
+    )
+    nodes: list[dict[str, Any]] = []
+    for i, kind in enumerate(kinds):
+        obj = objects[0]
+        if kind == "ontology" and len(objects) > 1:
+            obj = objects[1]
+        elif kind == "insight" and len(objects) > 2:
+            obj = objects[2]
+        elif kind in {"tool_call", "app"}:
+            obj = objects[-1]
+        point, place = _OBJECT_POINTS[obj]
+        node: dict[str, Any] = {
+            "id": f"g{i + 1}",
+            "kind": kind,
+            "x": 32 + (i % 4) * 208,
+            "y": 48 + (i // 4) * 168,
+            "note": notes.get(kind) or _KIND_NOTES.get(kind) or kind,
+            "tier": "T0",
+            "stream": False,
+        }
+        if kind in bind:
+            node["object_type"] = obj
+            node["data_point"] = point
+            node["data_type"] = "string"
+            node["fetch_from"] = place
+        if kind in {"tool_call", "foundry"}:
+            node["action_type"] = action
+        if kind == "agent":
+            node["action_type"] = action if action.startswith("agent.") else "agent.checked"
+        if kind == "app":
+            node["action_type"] = "emit"
+        nodes.append(node)
+    edges = [{"from": nodes[i]["id"], "to": nodes[i + 1]["id"]} for i in range(len(nodes) - 1)]
+    return nodes, edges
 
 
 def _envelope(program: AgenticDSLProgram) -> dict[str, Any]:

--- a/CortexOS/constructor_skin/app.js
+++ b/CortexOS/constructor_skin/app.js
@@ -475,6 +475,16 @@ function loadFoundryPath() {
   render();
 }
 
+function replaceGraph(nodes, edges) {
+  if (!Array.isArray(nodes) || !nodes.length) return false;
+  state.nodes = nodes;
+  state.edges = Array.isArray(edges) ? edges : [];
+  selectedId = state.nodes[0].id;
+  save();
+  render();
+  return true;
+}
+
 function ensureKinds(kinds) {
   for (const kind of kinds) {
     if (!state.nodes.some((n) => n.kind === kind)) addNode(kind);
@@ -508,6 +518,7 @@ window.Constructor = {
   showAudit,
   markGhostWalk,
   loadFoundryPath,
+  replaceGraph,
   ensureKinds,
   patchSelected,
   replaceCatalog,

--- a/CortexOS/constructor_skin/engine.js
+++ b/CortexOS/constructor_skin/engine.js
@@ -446,6 +446,36 @@ async function handleChat(raw) {
     applyWinner(ranked[0].id);
     return "Applied " + ranked[0].name + ". Graph compiled toward " + ranked[0].cortex_path + ".";
   }
+  if (
+    /understand this company/.test(t) ||
+    /define data/.test(t) ||
+    /govern agents/.test(t) ||
+    /business insights/.test(t)
+  ) {
+    C.setGhost(true);
+    if (cortexOrigin()) {
+      const remote = await cortexPost("/cortex/constructor/generate", { prompt: text });
+      if (remote && remote.ok && Array.isArray(remote.nodes) && C.replaceGraph) {
+        C.replaceGraph(remote.nodes, remote.edges);
+        const ranked = await rankApproaches();
+        return (
+          (remote.summary || "Generated foundry path.") +
+          " Winner: " +
+          ranked[0].name +
+          ". Ghost on. Live run stays POST /cortex/constructor/run."
+        );
+      }
+    }
+    C.loadFoundryPath();
+    if (/govern agents/.test(t)) C.ensureKinds(["agent"]);
+    if (/define data/.test(t)) C.ensureKinds(["ingest"]);
+    const ranked = await rankApproaches();
+    return (
+      "Loaded ontology -> insight -> foundry -> app. Pages never fetch. Winner: " +
+      ranked[0].name +
+      "."
+    );
+  }
   if (/foundry|ontology path|create app/.test(t)) {
     C.loadFoundryPath();
     C.setGhost(true);

--- a/packs/dms/constructor_routes.py
+++ b/packs/dms/constructor_routes.py
@@ -334,6 +334,31 @@ def constructor_recommend(
     return {"ok": True, "recommendation": rec.as_dict(), "approaches": approaches}
 
 
+@router.post("/cortex/constructor/generate")
+async def constructor_generate(
+    request: Request,
+    caller: Caller = Depends(require_constructor_viewer),
+) -> dict[str, Any]:
+    """Compile a prompt onto a canvas. Ghost only. No DuckDB fetch. No run_dag."""
+    from CortexOS.constructor_graph import ConstructorGraphError, generate_constructor_graph
+
+    try:
+        payload = await request.json()
+    except Exception as exc:
+        raise HTTPException(status_code=400, detail="Send JSON {prompt: ...}") from exc
+    if not isinstance(payload, dict):
+        raise HTTPException(status_code=400, detail="Send JSON {prompt: ...}")
+    prompt = str(payload.get("prompt") or "").strip()
+    if not prompt:
+        raise HTTPException(status_code=400, detail="prompt required")
+    try:
+        out = generate_constructor_graph(prompt)
+    except ConstructorGraphError as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
+    _ = caller
+    return out
+
+
 @router.post("/cortex/constructor/run")
 async def constructor_run(
     request: Request,

--- a/tests/dms/test_constructor_graph.py
+++ b/tests/dms/test_constructor_graph.py
@@ -5,7 +5,13 @@ from __future__ import annotations
 import pytest
 from fastapi.testclient import TestClient
 
-from CortexOS.constructor_graph import ConstructorGraphError, compile_constructor_graph
+from CortexOS.constructor_graph import (
+    ConstructorGraphError,
+    FOUNDRY_KINDS,
+    NAMED_GENERATE,
+    compile_constructor_graph,
+    generate_constructor_graph,
+)
 from packs.dms.security.rate_limit import reset_limiter
 
 SAMPLE = {
@@ -156,6 +162,9 @@ def test_vendored_skin_is_served_without_laptop_path(dms_client, api_keys_env):
     skin = constructor_skin_dir()
     assert (skin / "index.html").is_file()
     assert (skin / "engine.js").is_file()
+    engine = (skin / "engine.js").read_text(encoding="utf-8")
+    assert "if (!cortexOrigin()) return null" in engine
+    assert "/cortex/constructor/generate" in engine
     res = dms_client.get(
         "/cortex/constructor/engine.js",
         headers={"X-API-Key": api_keys_env["viewer"]},
@@ -417,3 +426,74 @@ def test_ov_token_accepts_flat_valid_true(monkeypatch):
     caller = resolve_caller("ov_flat")
     assert caller is not None
     assert caller.actor == "ov_flat1"
+
+
+def test_generate_named_seeds_include_foundry_kinds():
+    for prompt in NAMED_GENERATE:
+        graph = generate_constructor_graph(prompt)
+        assert graph["ok"] is True, prompt
+        assert graph["ghost"] is True, prompt
+        kinds = {n["kind"] for n in graph["nodes"]}
+        assert FOUNDRY_KINDS <= kinds, prompt
+        assert graph["pattern"] == "orchestrator_subagent"
+        compile_constructor_graph({"nodes": graph["nodes"], "edges": graph["edges"]})
+
+
+def test_generate_govern_agents_keeps_agent_and_foundry():
+    graph = generate_constructor_graph("govern agents")
+    kinds = {n["kind"] for n in graph["nodes"]}
+    assert "agent" in kinds
+    assert FOUNDRY_KINDS <= kinds
+    assert graph["action"] == "agent.checked"
+
+
+def test_generate_inventory_pptx_is_foundry_path():
+    graph = generate_constructor_graph("export inventory pptx")
+    kinds = {n["kind"] for n in graph["nodes"]}
+    assert FOUNDRY_KINDS <= kinds
+    assert graph["pattern"] == "orchestrator_subagent"
+    assert graph["action"] == "export_pptx"
+    assert "inventory" in graph["objects"]
+
+
+def test_generate_object_types_stay_on_semantic_layer_tables():
+    from pathlib import Path
+
+    import yaml
+
+    sem = yaml.safe_load(
+        (Path(__file__).resolve().parents[2] / "packs" / "dms" / "semantic_layer.yaml").read_text(
+            encoding="utf-8"
+        )
+    )
+    tables = set(sem["tables"])
+    for prompt in (*NAMED_GENERATE, "export inventory pptx", "intake suppliers"):
+        graph = generate_constructor_graph(prompt)
+        used = {n.get("object_type") for n in graph["nodes"] if n.get("object_type")}
+        assert used <= tables, prompt
+
+
+def test_generate_refuses_stalk_without_a_graph():
+    graph = generate_constructor_graph("stalk suppliers on public webcams")
+    assert graph["ok"] is False
+    assert graph["refused"] is True
+    assert graph["nodes"] == []
+
+
+def test_generate_endpoint_is_ghost_and_key_gated(dms_client, api_keys_env):
+    denied = dms_client.post("/cortex/constructor/generate", json={"prompt": "define data"})
+    assert denied.status_code == 401
+    res = dms_client.post(
+        "/cortex/constructor/generate",
+        json={"prompt": "understand this company"},
+        headers={"X-API-Key": api_keys_env["viewer"]},
+    )
+    assert res.status_code == 200, res.text
+    body = res.json()
+    assert body["ok"] is True
+    assert body["ghost"] is True
+    assert "fetches" not in body
+    kinds = {n["kind"] for n in body["nodes"]}
+    assert FOUNDRY_KINDS <= kinds
+    assert "run" not in body
+

--- a/tests/dms/test_constructor_graph.py
+++ b/tests/dms/test_constructor_graph.py
@@ -6,9 +6,9 @@ import pytest
 from fastapi.testclient import TestClient
 
 from CortexOS.constructor_graph import (
-    ConstructorGraphError,
     FOUNDRY_KINDS,
     NAMED_GENERATE,
+    ConstructorGraphError,
     compile_constructor_graph,
     generate_constructor_graph,
 )


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Constructor generate now compiles Palantir-shaped prompts onto the existing Foundry path. P1/O6/P17 stay parked. No Foundry/n8n clone.

## What
- `generate_constructor_graph()` seeds for `understand this company` / `define data` / `govern agents` / `business insights` always include `ontology` + `insight` + `foundry` + `app`.
- `govern agents` also keeps an `agent` node (does not drop the Foundry kinds).
- Object types stay on `packs/dms/semantic_layer.yaml` tables. No extra object without a matching table. Ontology YAML was already at name-parity; left untouched.
- `POST /cortex/constructor/generate` is ghost-only (no DuckDB fetch, no `run_dag`). Live run stays `POST /cortex/constructor/run`.
- Pages still does not fetch. Named prompts on a non-`/cortex` origin load the local Foundry sample.

## Verify
```
python -m pytest tests/dms/test_constructor_graph.py tests/dms/test_ontology_registry.py -q
```
Local: 40 passed.

Closes Cortex#110. Do not merge from this agent.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-5208f458-15da-41b3-a450-4c856ce7676c?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-5208f458-15da-41b3-a450-4c856ce7676c&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

