### PR TITLE
C7-02: Manifest before EXPLAIN on every L2 candidate

### DIFF
--- a/CortexOS/dms/sql_validate_gate.py
+++ b/CortexOS/dms/sql_validate_gate.py
@@ -69,6 +69,19 @@ def explain_dry_run(
         return False, str(exc)[:400]
 
 
+def sql_for_explain(sql: str, *, verified: VerifiedManifest | None = None) -> str:
+    """SQL that EXPLAIN (and fetch) may see.
+
+    Grounded sessions return ``enforce_manifest`` output (C7-02) and raise
+    ``ManifestError``. Ungrounded sessions return ``sql`` unchanged.
+    """
+    if verified is None:
+        return sql
+    from CortexOS.execution.manifest import enforce_manifest
+
+    return enforce_manifest(sql, verified)
+
+
 def run_gate(
     sql: str,
     semantic: dict[str, Any],
@@ -92,22 +105,20 @@ def run_gate(
             attempts=1,
         )
 
-    source = guard.safe_sql
-    safe_sql = source
-    if verified is not None:
-        from CortexOS.execution.manifest import ManifestError, enforce_manifest
+    from CortexOS.execution.manifest import ManifestError
 
-        try:
-            safe_sql = enforce_manifest(source, verified)
-        except ManifestError as exc:
-            return ValidateGateResult(
-                passed=False,
-                violations=[f"{MANIFEST_VIOLATION_PREFIX}{type(exc).__name__}:{exc.code}"],
-                safe_sql=None,
-                explain_ok=False,
-                attempts=1,
-                manifest_refused=True,
-            )
+    source = guard.safe_sql
+    try:
+        safe_sql = sql_for_explain(source, verified=verified)
+    except ManifestError as exc:
+        return ValidateGateResult(
+            passed=False,
+            violations=[f"{MANIFEST_VIOLATION_PREFIX}{type(exc).__name__}:{exc.code}"],
+            safe_sql=None,
+            explain_ok=False,
+            attempts=1,
+            manifest_refused=True,
+        )
 
     if con is None:
         return ValidateGateResult(
@@ -206,4 +217,5 @@ __all__ = [
     "gate_with_retry",
     "guard_result_from_gate",
     "run_gate",
+    "sql_for_explain",
 ]

--- a/CortexOS/execution/submit.py
+++ b/CortexOS/execution/submit.py
@@ -18,7 +18,6 @@ from CortexOS.execution.manifest import (
     ManifestMalformed,
     ManifestVerifier,
     VerifiedManifest,
-    enforce_manifest,
 )
 from CortexOS.execution.pool import PoolSaturated, get_read_pool
 from CortexOS.execution.session_manifests import get_session_registry
@@ -189,9 +188,14 @@ def execute_sql(
     """
     import os
 
-    from CortexOS.dms.sql_validate_gate import SqlGateAbstain, explain_dry_run
+    from CortexOS.dms.sql_validate_gate import (
+        SqlGateAbstain,
+        explain_dry_run,
+        sql_for_explain,
+    )
 
-    safe_sql = enforce_manifest(sql, verified)
+    # C7-02: EXPLAIN must see only this rewritten SQL, never the pre-enforce text.
+    safe_sql = sql_for_explain(sql, verified=verified)
     use_explain = (
         explain_gate
         if explain_gate is not None

--- a/tests/test_execution/test_submit_c4.py
+++ b/tests/test_execution/test_submit_c4.py
@@ -197,6 +197,38 @@ def test_submit_sql_and_count_apply_predicate(
     assert "tenant_id" in rewritten.lower()
 
 
+def test_execute_sql_explain_sees_only_post_enforce_sql(
+    verifier: ManifestVerifier, issuer: Ed25519PrivateKey, tmp_path: Path, monkeypatch
+) -> None:
+    """C7-02: submit EXPLAIN is invoked on rewritten SQL, never the pre-enforce text."""
+    import duckdb
+
+    db = tmp_path / "t.duckdb"
+    con = duckdb.connect(str(db))
+    con.execute("CREATE TABLE orders (id INTEGER, tenant_id VARCHAR)")
+    con.execute("INSERT INTO orders VALUES (1, 'acme'), (2, 'other')")
+    con.close()
+
+    m = _signed(issuer, predicates={"orders": "tenant_id = 'acme'"})
+    verified = verify_and_check_pool(m, "pool-a")
+    get_session_registry().bind(verified)
+
+    original = "SELECT id, tenant_id FROM orders"
+    rewritten = enforce_manifest(original, verified)
+    assert "tenant_id" in rewritten.lower()
+    seen: list[str] = []
+
+    def spy(con, sql, params=None):
+        seen.append(sql)
+        return True, "ok"
+
+    monkeypatch.setattr("CortexOS.dms.sql_validate_gate.explain_dry_run", spy)
+    rows, _, _ = execute_sql(verified, original, db_path=db)
+    assert seen == [rewritten]
+    assert original not in seen
+    assert {r["tenant_id"] for r in rows} == {"acme"}
+
+
 def test_tampered_signature_fails_submit(verifier: ManifestVerifier, issuer: Ed25519PrivateKey) -> None:
     m = _signed(issuer)
     m.signature = _b64u(b"\x00" * 64)


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Closes Cortex#101. Parent: Cortex#17 (EPIC-006).

## Acceptance

WHEN L2 generates SQL for a grounded session
THE SYSTEM SHALL run `enforce_manifest` on that SQL before EXPLAIN; a `ManifestError` SHALL surface as customer `route/layer/badge=refused` (not SESSION) and SHALL abort retry of that candidate; EXPLAIN SHALL see only post-enforce SQL. No refusal in `CortexOS/execution/manifest.py` may be narrowed to pass a candidate.

## Rebase (live)

C7-02 already landed on `main` as `#122`. This branch is rebased onto `origin/main` (`d2ea2ae`, includes `#122` + C7-04 `#121`).

Conflict files (second rebase):
- `CortexOS/dms/answer_engine.py`
- `CortexOS/dms/l2_generation.py`
- `CortexOS/dms/sql_validate_gate.py`
- `tests/dms/test_sql_validate_gate.py`

Resolution: keep `#122` for those four (refused-before-RAG, `manifest_refused`, L2 candidate skip). Unique leftover on this PR: `sql_for_explain` shared helper, `execute_sql` uses it, submit EXPLAIN spy test. Did not touch `CortexOS/crew`.

Head: `30593e7689057980d011eb48a5b84468ef3796a2`

Draft for Verify different-run.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d53467d0-fa91-4aed-81f9-6438cb4be807?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d53467d0-fa91-4aed-81f9-6438cb4be807&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

