### PR TITLE
C7-04: held-out corpus + envelope eval harness (#103)

### DIFF
--- a/bench/heldout.py
+++ b/bench/heldout.py
@@ -1,0 +1,460 @@
+"""C7-04 held-out eval harness.
+
+Scores each item on the customer envelope (answer text + rows + badge/route),
+never on generated SQL alone. Classes: correct / abstained / incorrect.
+
+Empty rows on an answerable item are always incorrect (SKU-BETA / G4 class),
+even if gold SQL also returned nothing.
+
+The frozen split is ``bench/heldout/c7_heldout_v1.yaml``. CI invokes
+``score_fixture`` on a tiny canned envelope set so the gate can go red
+without serving L2 or calling the answer engine.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import re
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+ROOT = Path(__file__).resolve().parents[1]
+HELDOUT_PATH = ROOT / "bench" / "heldout" / "c7_heldout_v1.yaml"
+METRICS_PATH = ROOT / "packs" / "dms" / "semantic" / "metrics.yaml"
+GOLDEN_PATH = ROOT / "bench" / "golden" / "dms_golden_v1.yaml"
+PARAPHRASE_PATH = ROOT / "bench" / "golden" / "dms_paraphrase_v1.yaml"
+
+OUTCOMES = ("correct", "abstained", "incorrect")
+SQL_PROVENANCE = frozenset({"bird_style", "spider_style"})
+ABSTAIN_PROVENANCE = "different_model_abstain"
+NEAR_COPY = 0.85
+MIN_COPY_TOKENS = 4
+
+_REFUSAL_BADGES = frozenset({
+    "abstain", "refused", "blocked", "needs_clarification",
+})
+_REFUSAL_ROUTES = frozenset({
+    "needs_clarification", "abstain", "refused", "blocked",
+})
+_TOKEN = re.compile(r"[a-z0-9]+(?:-[a-z0-9]+)*")
+
+
+@dataclass(slots=True)
+class HeldoutItem:
+    id: str
+    split: str  # sql | must_abstain
+    provenance: str
+    question: str
+    expect: str  # correct_rows | abstain
+    match: str = "resultset"
+    canonical_sql: str | None = None
+    key_columns: list[str] = field(default_factory=list)
+    round: int = 4
+    expected_rows: list[dict[str, Any]] | None = None
+
+    @property
+    def answerable(self) -> bool:
+        return self.expect == "correct_rows"
+
+
+@dataclass(slots=True)
+class HeldoutResult:
+    id: str
+    split: str
+    outcome: str
+    detail: str = ""
+    badge: str = ""
+    route: str = ""
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "id": self.id,
+            "split": self.split,
+            "outcome": self.outcome,
+            "detail": self.detail,
+            "badge": self.badge,
+            "route": self.route,
+        }
+
+
+def _norm(text: str) -> str:
+    return " ".join(_TOKEN.findall(str(text).lower()))
+
+
+def _tokens(text: str) -> set[str]:
+    return set(_TOKEN.findall(str(text).lower()))
+
+
+def _jaccard(a: str, b: str) -> float:
+    left, right = _tokens(a), _tokens(b)
+    if not left or not right:
+        return 0.0
+    return len(left & right) / len(left | right)
+
+
+def load_heldout(path: Path | str | None = None) -> list[HeldoutItem]:
+    data = yaml.safe_load(Path(path or HELDOUT_PATH).read_text(encoding="utf-8")) or {}
+    if "paraphrases" in data:
+        raise ValueError(
+            "held-out file has a paraphrases: key — that is the team-paraphrase "
+            "shape from bench/golden/dms_paraphrase_v1.yaml, not this split"
+        )
+    items_raw = data.get("items")
+    if not isinstance(items_raw, list) or not items_raw:
+        raise ValueError("held-out file must have a non-empty items: list")
+    items: list[HeldoutItem] = []
+    for raw in items_raw:
+        expected = raw.get("expected_rows")
+        items.append(
+            HeldoutItem(
+                id=raw["id"],
+                split=raw["split"],
+                provenance=raw["provenance"],
+                question=raw["question"],
+                expect=raw["expect"],
+                match=raw.get("match", "resultset"),
+                canonical_sql=raw.get("canonical_sql"),
+                key_columns=list(raw.get("key_columns") or []),
+                round=int(raw.get("round", 4)),
+                expected_rows=list(expected) if isinstance(expected, list) else None,
+            )
+        )
+    return items
+
+
+def _phrases_from_metrics(path: Path) -> list[tuple[str, str]]:
+    data = yaml.safe_load(path.read_text(encoding="utf-8")) or {}
+    out: list[tuple[str, str]] = []
+    for metric in data.get("metrics") or []:
+        mid = metric.get("id") or "?"
+        for syn in metric.get("synonyms") or []:
+            out.append((f"metrics.yaml:{mid}", str(syn)))
+        name = str(metric.get("name") or "").strip()
+        if name:
+            out.append((f"metrics.yaml:{mid}:name", name))
+    return out
+
+
+def _phrases_from_golden(path: Path) -> list[tuple[str, str]]:
+    data = yaml.safe_load(path.read_text(encoding="utf-8")) or {}
+    out: list[tuple[str, str]] = []
+    for item in data.get("items") or []:
+        q = item.get("question")
+        if q:
+            out.append((f"dms_golden_v1.yaml:{item.get('id')}", str(q)))
+    return out
+
+
+def _phrases_from_paraphrase(path: Path) -> list[tuple[str, str]]:
+    data = yaml.safe_load(path.read_text(encoding="utf-8")) or {}
+    out: list[tuple[str, str]] = []
+    for parent, phrases in (data.get("paraphrases") or {}).items():
+        for i, phrase in enumerate(phrases or []):
+            out.append((f"dms_paraphrase_v1.yaml:{parent}#{i}", str(phrase)))
+    return out
+
+
+def team_dev_phrases(root: Path | None = None) -> list[tuple[str, str]]:
+    """Questions/synonyms the held-out set is forbidden to copy."""
+    if root is None:
+        metrics, golden, paraphrase = METRICS_PATH, GOLDEN_PATH, PARAPHRASE_PATH
+    else:
+        metrics = root / "packs" / "dms" / "semantic" / "metrics.yaml"
+        golden = root / "bench" / "golden" / "dms_golden_v1.yaml"
+        paraphrase = root / "bench" / "golden" / "dms_paraphrase_v1.yaml"
+    out: list[tuple[str, str]] = []
+    out.extend(_phrases_from_metrics(metrics))
+    out.extend(_phrases_from_golden(golden))
+    out.extend(_phrases_from_paraphrase(paraphrase))
+    return out
+
+
+def overlap_hits(
+    questions: list[str],
+    forbidden: list[tuple[str, str]] | None = None,
+    *,
+    root: Path | None = None,
+) -> list[str]:
+    """Return human-readable hits if questions look like team paraphrases."""
+    phrases = forbidden if forbidden is not None else team_dev_phrases(root)
+    hits: list[str] = []
+    for question in questions:
+        qn = _norm(question)
+        if not qn:
+            continue
+        q_tokens = _tokens(question)
+        for source, phrase in phrases:
+            pn = _norm(phrase)
+            if not pn:
+                continue
+            if qn == pn:
+                hits.append(f"{question!r} exact-match {source} ({phrase!r})")
+                break
+            p_tokens = _tokens(phrase)
+            if (
+                len(q_tokens) >= MIN_COPY_TOKENS
+                and len(p_tokens) >= MIN_COPY_TOKENS
+                and _jaccard(question, phrase) >= NEAR_COPY
+            ):
+                hits.append(
+                    f"{question!r} near-copy of {source} ({phrase!r})"
+                )
+                break
+    return hits
+
+
+def assert_not_team_paraphrases(
+    items: list[HeldoutItem] | None = None,
+    *,
+    root: Path | None = None,
+) -> None:
+    rows = items if items is not None else load_heldout()
+    hits = overlap_hits([i.question for i in rows], root=root)
+    if hits:
+        raise AssertionError(
+            "held-out set overlaps team metrics/golden paraphrases:\n- "
+            + "\n- ".join(hits)
+        )
+
+
+def envelope_view(env: dict[str, Any]) -> dict[str, Any]:
+    """Normalize engine and DMS envelope spellings to one view."""
+    answer = str(env.get("answer") or env.get("text") or "")
+    rows = env.get("rows")
+    if rows is None:
+        rows = env.get("values")
+    if not isinstance(rows, list):
+        rows = []
+    badge = str(env.get("badge") or "")
+    route = str(env.get("route") or env.get("layer") or "")
+    abstained = env.get("abstained")
+    return {
+        "answer": answer,
+        "rows": rows,
+        "badge": badge,
+        "route": route,
+        "abstained": abstained,
+    }
+
+
+def _is_refusal(view: dict[str, Any]) -> bool:
+    badge = view["badge"].lower()
+    route = view["route"].lower()
+    if view["abstained"] is True:
+        return True
+    if badge in _REFUSAL_BADGES or route in _REFUSAL_ROUTES:
+        return True
+    return False
+
+
+def _gold_rows(item: HeldoutItem) -> list[dict[str, Any]] | str:
+    if item.expected_rows is not None:
+        return list(item.expected_rows)
+    if not item.canonical_sql:
+        return "answerable item has no expected_rows and no canonical_sql"
+    from bench.accuracy import _ensure_db_loaded, _run_canonical
+
+    _ensure_db_loaded()
+    try:
+        return _run_canonical(item.canonical_sql)
+    except Exception as exc:  # noqa: BLE001
+        return f"canonical SQL failed: {exc!r}"
+
+
+def score_envelope(item: HeldoutItem, env: Any) -> HeldoutResult:
+    """Score one served envelope. Does not inspect sql_used as a pass condition."""
+    if not isinstance(env, dict):
+        return HeldoutResult(
+            item.id, item.split, "incorrect",
+            detail="envelope is not an object",
+        )
+    view = envelope_view(env)
+    badge, route = view["badge"], view["route"]
+    rows = view["rows"]
+    answer = view["answer"]
+    refused = _is_refusal(view)
+
+    if item.expect == "abstain":
+        if refused and not rows:
+            return HeldoutResult(
+                item.id, item.split, "abstained",
+                badge=badge, route=route,
+            )
+        return HeldoutResult(
+            item.id, item.split, "incorrect",
+            detail=(
+                f"must-abstain served badge={badge!r} route={route!r} "
+                f"rows={len(rows)}"
+            ),
+            badge=badge, route=route,
+        )
+
+    # Answerable: refusal is a safe miss (abstained), not incorrect.
+    if refused and not rows:
+        return HeldoutResult(
+            item.id, item.split, "abstained",
+            detail="system abstained on an answerable question",
+            badge=badge, route=route,
+        )
+    if refused and rows:
+        return HeldoutResult(
+            item.id, item.split, "incorrect",
+            detail="refusal badge with served rows (G-env)",
+            badge=badge, route=route,
+        )
+
+    # SKU-BETA class: never treat empty correct_rows as correct.
+    if not rows:
+        return HeldoutResult(
+            item.id, item.split, "incorrect",
+            detail="empty rows on an answerable item (SKU-BETA / G4 class)",
+            badge=badge, route=route,
+        )
+    if not str(answer).strip():
+        return HeldoutResult(
+            item.id, item.split, "incorrect",
+            detail="empty answer text on an answerable item",
+            badge=badge, route=route,
+        )
+
+    gold = _gold_rows(item)
+    if isinstance(gold, str):
+        return HeldoutResult(
+            item.id, item.split, "incorrect",
+            detail=gold, badge=badge, route=route,
+        )
+    if not gold:
+        return HeldoutResult(
+            item.id, item.split, "incorrect",
+            detail="gold rows empty — empty correct_rows is never correct",
+            badge=badge, route=route,
+        )
+
+    from bench.accuracy import _multiset_equal, _project
+
+    keys = list(item.key_columns)
+    if not keys:
+        return HeldoutResult(
+            item.id, item.split, "incorrect",
+            detail="answerable item missing key_columns",
+            badge=badge, route=route,
+        )
+    truth = _project(gold, keys, item.round)
+    got = _project(rows, keys, item.round)
+    if isinstance(truth, str):
+        return HeldoutResult(
+            item.id, item.split, "incorrect",
+            detail=f"gold defect: {truth}", badge=badge, route=route,
+        )
+    if isinstance(got, str):
+        return HeldoutResult(
+            item.id, item.split, "incorrect",
+            detail=got, badge=badge, route=route,
+        )
+    if not _multiset_equal(got, truth):
+        return HeldoutResult(
+            item.id, item.split, "incorrect",
+            detail=(
+                f"rows mismatch: {len(got)} served vs {len(truth)} gold "
+                f"on {keys}"
+            ),
+            badge=badge, route=route,
+        )
+    if item.match == "scalar" and gold:
+        needle = str(next(iter(gold[0].values())))
+        if needle and needle not in answer:
+            return HeldoutResult(
+                item.id, item.split, "incorrect",
+                detail=f"scalar {needle!r} missing from answer text",
+                badge=badge, route=route,
+            )
+    return HeldoutResult(
+        item.id, item.split, "correct", badge=badge, route=route,
+    )
+
+
+def summarize(results: list[HeldoutResult]) -> dict[str, Any]:
+    totals = {
+        "total": len(results),
+        "correct": 0,
+        "abstained": 0,
+        "incorrect": 0,
+    }
+    by_split = {
+        "sql": {"total": 0, "correct": 0, "abstained": 0, "incorrect": 0},
+        "must_abstain": {"total": 0, "correct": 0, "abstained": 0, "incorrect": 0},
+    }
+    for row in results:
+        totals[row.outcome] = totals.get(row.outcome, 0) + 1
+        bucket = by_split.setdefault(
+            row.split, {"total": 0, "correct": 0, "abstained": 0, "incorrect": 0},
+        )
+        bucket["total"] += 1
+        bucket[row.outcome] = bucket.get(row.outcome, 0) + 1
+    must = by_split.get("must_abstain") or {"total": 0, "abstained": 0}
+    must_n = int(must["total"])
+    must_ok = int(must.get("abstained") or 0)
+    return {
+        "totals": totals,
+        "by_split": by_split,
+        "g_abs_recall": (must_ok / must_n) if must_n else 1.0,
+        "incorrect_rate": (
+            totals["incorrect"] / totals["total"] if totals["total"] else 0.0
+        ),
+        "results": [r.to_dict() for r in results],
+    }
+
+
+def load_fixture(path: Path | str) -> tuple[list[HeldoutItem], dict[str, dict[str, Any]]]:
+    data = yaml.safe_load(Path(path).read_text(encoding="utf-8")) or {}
+    items = load_heldout(path) if "items" in data else []
+    envelopes = data.get("envelopes") or {}
+    if not isinstance(envelopes, dict):
+        raise ValueError("fixture envelopes must be a mapping of id -> envelope")
+    return items, envelopes
+
+
+def score_fixture(path: Path | str) -> dict[str, Any]:
+    """CI entry: score canned envelopes. No engine, no L2, no DuckDB."""
+    items, envelopes = load_fixture(path)
+    results: list[HeldoutResult] = []
+    for item in items:
+        env = envelopes.get(item.id)
+        if env is None:
+            results.append(
+                HeldoutResult(
+                    item.id, item.split, "incorrect",
+                    detail="fixture missing envelope",
+                )
+            )
+            continue
+        results.append(score_envelope(item, env))
+    report = summarize(results)
+    report["fixture"] = str(path)
+    return report
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--fixture",
+        default=None,
+        help="YAML with items + envelopes (CI path; no live serve)",
+    )
+    parser.add_argument("--json", default=None, help="write report JSON")
+    args = parser.parse_args()
+    if not args.fixture:
+        parser.error(
+            "pass --fixture PATH; live engine scoring is C7-05, not this harness default"
+        )
+    report = score_fixture(args.fixture)
+    print(json.dumps(report["totals"]))
+    if args.json:
+        Path(args.json).write_text(json.dumps(report, indent=2), encoding="utf-8")
+
+
+if __name__ == "__main__":
+    main()

--- a/bench/heldout/c7_heldout_v1.yaml
+++ b/bench/heldout/c7_heldout_v1.yaml
@@ -1,0 +1,465 @@
+# C7-04 frozen held-out split — NOT a development golden.
+#
+# Provenance
+#   sql items: BIRD-SQL / Spider 2.0 compositional style over THIS warehouse
+#   schema (inventory, suppliers, locations, shipments, transactions, alerts).
+#   Gold SQL is human-checked against the sample dump. It is not FreeRoute
+#   output and it is not a paraphrase of packs/dms/semantic/metrics.yaml.
+#   must_abstain items: different-model abstain class (false-premise, unknown
+#   entity, ESG + external weather, destructive, unanswerable join). The team
+#   reviews the class; it does not author metrics.yaml paraphrases into this file.
+#
+# Excluded sources (overlap CI fails if these are swapped in):
+#   packs/dms/semantic/metrics.yaml questions/synonyms
+#   bench/golden/dms_golden_v1.yaml
+#   bench/golden/dms_paraphrase_v1.yaml
+#
+# Scoring is in bench/heldout.py on the customer envelope (answer text + rows +
+# badge/route). Classes: correct / abstained / incorrect. Empty correct_rows
+# is never correct.
+#
+# Size is tens of items so CI can load the file; live engine scoring is C7-05.
+
+version: 1
+split: heldout
+provenance:
+  sql_style: BIRD-SQL and Spider 2.0 compositional questions over the DMS warehouse schema
+  gold_sql: human-checked against data/samples; not FreeRoute; not metrics.yaml
+  must_abstain: different-model class (false-premise / unknown entity / ESG+weather / destructive / unanswerable join)
+  excluded_sources:
+    - packs/dms/semantic/metrics.yaml
+    - bench/golden/dms_golden_v1.yaml
+    - bench/golden/dms_paraphrase_v1.yaml
+
+items:
+  # ── BIRD-style (joins + evidence over messy warehouse facts) ───────────────
+  - id: bird_out_kg_above_category_mean
+    split: sql
+    provenance: bird_style
+    question: >
+      How many SKUs have total outbound kilogram volume strictly above the
+      mean outbound kilogram volume of other SKUs that share their inventory
+      category?
+    expect: correct_rows
+    match: scalar
+    key_columns: [sku_count]
+    canonical_sql: >
+      SELECT COUNT(*) AS sku_count
+      FROM (
+        SELECT s.sku
+        FROM (
+          SELECT sku, SUM(quantity_kg) AS out_kg
+          FROM transactions WHERE txn_type = 'OUT'
+          GROUP BY sku
+        ) s
+        JOIN (
+          SELECT sku, MIN(category) AS category FROM inventory GROUP BY sku
+        ) i ON i.sku = s.sku
+        JOIN (
+          SELECT i2.category, AVG(s2.out_kg) AS avg_out
+          FROM (
+            SELECT sku, SUM(quantity_kg) AS out_kg
+            FROM transactions WHERE txn_type = 'OUT' GROUP BY sku
+          ) s2
+          JOIN (
+            SELECT sku, MIN(category) AS category FROM inventory GROUP BY sku
+          ) i2 ON i2.sku = s2.sku
+          GROUP BY i2.category
+        ) c ON c.category = i.category
+        WHERE s.out_kg > c.avg_out
+      ) x
+
+  - id: bird_delayed_hazardous_to_cold
+    split: sql
+    provenance: bird_style
+    question: >
+      Count DELAYED shipments whose SKU is marked hazardous and whose
+      destination location is a cold-storage site.
+    expect: correct_rows
+    match: scalar
+    key_columns: [delayed_count]
+    canonical_sql: >
+      SELECT COUNT(*) AS delayed_count
+      FROM shipments sh
+      JOIN (
+        SELECT sku, MAX(CASE WHEN is_hazardous THEN 1 ELSE 0 END) AS haz
+        FROM inventory GROUP BY sku
+      ) i ON i.sku = sh.sku AND i.haz = 1
+      JOIN locations l ON l.location_id = sh.destination_location_id
+      WHERE sh.status = 'DELAYED' AND l.is_cold_storage = true
+
+  - id: bird_over_capacity_with_critical_alert
+    split: sql
+    provenance: bird_style
+    question: >
+      Which location codes currently hold more kilograms than their stated
+      capacity and also have at least one unresolved CRITICAL alert tied to
+      that location?
+    expect: correct_rows
+    match: resultset
+    key_columns: [location_code]
+    canonical_sql: >
+      SELECT DISTINCT l.location_code
+      FROM locations l
+      JOIN alerts a ON a.related_location = l.location_id
+      WHERE l.current_load_kg > l.capacity_kg
+        AND a.resolved = false
+        AND a.severity = 'CRITICAL'
+      ORDER BY l.location_code
+
+  - id: bird_carrier_delay_rate_above_global
+    split: sql
+    provenance: bird_style
+    question: >
+      List carriers whose DELAYED-shipment rate is strictly higher than the
+      overall DELAYED rate across every carrier.
+    expect: correct_rows
+    match: resultset
+    key_columns: [carrier]
+    canonical_sql: >
+      SELECT c.carrier
+      FROM (
+        SELECT carrier,
+               SUM(CASE WHEN status = 'DELAYED' THEN 1 ELSE 0 END) * 1.0
+                 / COUNT(*) AS delay_rate
+        FROM shipments
+        GROUP BY carrier
+      ) c
+      JOIN (
+        SELECT SUM(CASE WHEN status = 'DELAYED' THEN 1 ELSE 0 END) * 1.0
+                 / COUNT(*) AS global_rate
+        FROM shipments
+      ) g ON 1 = 1
+      WHERE c.delay_rate > g.global_rate
+      ORDER BY c.carrier
+
+  - id: bird_delayed_kg_exceeds_on_hand
+    split: sql
+    provenance: bird_style
+    question: >
+      Which destination location codes have more kilograms sitting in DELAYED
+      inbound shipments than the kilograms currently recorded in inventory at
+      that same location?
+    expect: correct_rows
+    match: resultset
+    key_columns: [location_code]
+    canonical_sql: >
+      SELECT l.location_code
+      FROM locations l
+      JOIN (
+        SELECT destination_location_id AS location_id, SUM(quantity_kg) AS delayed_kg
+        FROM shipments WHERE status = 'DELAYED'
+        GROUP BY destination_location_id
+      ) d ON d.location_id = l.location_id
+      JOIN (
+        SELECT location_id, SUM(quantity_kg) AS on_hand_kg
+        FROM inventory GROUP BY location_id
+      ) i ON i.location_id = l.location_id
+      WHERE d.delayed_kg > i.on_hand_kg
+      ORDER BY l.location_code
+
+  - id: bird_cold_bin_below_reorder
+    split: sql
+    provenance: bird_style
+    question: >
+      How many inventory bins sit in a cold-storage location and currently
+      hold fewer kilograms than that bin's own reorder level, ignoring bins
+      whose reorder level is zero?
+    expect: correct_rows
+    match: scalar
+    key_columns: [bin_count]
+    canonical_sql: >
+      SELECT COUNT(*) AS bin_count
+      FROM inventory i
+      JOIN locations l ON l.location_id = i.location_id
+      WHERE l.is_cold_storage = true
+        AND i.reorder_level_kg > 0
+        AND i.quantity_kg < i.reorder_level_kg
+
+  - id: bird_stale_audit_with_delayed_inbound
+    split: sql
+    provenance: bird_style
+    question: >
+      How many suppliers have a last audit date before 2024-01-01 and also
+      appear on at least one DELAYED shipment?
+    expect: correct_rows
+    match: scalar
+    key_columns: [supplier_count]
+    canonical_sql: >
+      SELECT COUNT(*) AS supplier_count
+      FROM suppliers s
+      WHERE CAST(s.last_audit_date AS DATE) < DATE '2024-01-01'
+        AND EXISTS (
+          SELECT 1 FROM shipments sh
+          WHERE sh.supplier_id = s.supplier_id AND sh.status = 'DELAYED'
+        )
+
+  - id: bird_inbound_shipments_gt_sku_distinct
+    split: sql
+    provenance: bird_style
+    question: >
+      Which location codes are the destination of more inbound shipments than
+      the number of distinct SKUs stored in inventory at that location?
+    expect: correct_rows
+    match: resultset
+    key_columns: [location_code]
+    canonical_sql: >
+      SELECT l.location_code
+      FROM locations l
+      JOIN (
+        SELECT destination_location_id AS location_id, COUNT(*) AS inbound_n
+        FROM shipments GROUP BY destination_location_id
+      ) s ON s.location_id = l.location_id
+      JOIN (
+        SELECT location_id, COUNT(DISTINCT sku) AS sku_n
+        FROM inventory GROUP BY location_id
+      ) i ON i.location_id = l.location_id
+      WHERE s.inbound_n > i.sku_n
+      ORDER BY l.location_code
+
+  # ── Spider-style (nested / HAVING / compositional SQL) ─────────────────────
+  - id: spider_country_mean_lead_having
+    split: sql
+    provenance: spider_style
+    question: >
+      Which supplier countries have a mean lead time strictly above 20 days
+      and at least three suppliers in that country?
+    expect: correct_rows
+    match: resultset
+    key_columns: [country]
+    canonical_sql: >
+      SELECT country
+      FROM suppliers
+      GROUP BY country
+      HAVING AVG(lead_time_days) > 20 AND COUNT(*) >= 3
+      ORDER BY country
+
+  - id: spider_second_highest_chem_unit_cost
+    split: sql
+    provenance: spider_style
+    question: >
+      What is the second-highest distinct unit cost among inventory rows in
+      the CHEMICALS category?
+    expect: correct_rows
+    match: scalar
+    key_columns: [unit_cost_myr]
+    round: 2
+    canonical_sql: >
+      SELECT MAX(unit_cost_myr) AS unit_cost_myr
+      FROM (
+        SELECT DISTINCT ROUND(unit_cost_myr, 2) AS unit_cost_myr
+        FROM inventory
+        WHERE category = 'CHEMICALS'
+      ) d
+      WHERE unit_cost_myr < (
+        SELECT MAX(ROUND(unit_cost_myr, 2)) FROM inventory WHERE category = 'CHEMICALS'
+      )
+
+  - id: spider_sku_in_and_out_same_location
+    split: sql
+    provenance: spider_style
+    question: >
+      How many distinct SKUs have both an IN transaction and an OUT
+      transaction recorded against the same location_id?
+    expect: correct_rows
+    match: scalar
+    key_columns: [sku_count]
+    canonical_sql: >
+      SELECT COUNT(*) AS sku_count
+      FROM (
+        SELECT t_in.sku, t_in.location_id
+        FROM (
+          SELECT DISTINCT sku, location_id FROM transactions WHERE txn_type = 'IN'
+        ) t_in
+        JOIN (
+          SELECT DISTINCT sku, location_id FROM transactions WHERE txn_type = 'OUT'
+        ) t_out
+          ON t_out.sku = t_in.sku AND t_out.location_id = t_in.location_id
+      ) x
+
+  - id: spider_chem_supplier_above_country_risk
+    split: sql
+    provenance: spider_style
+    question: >
+      List supplier ids that supply at least one CHEMICALS SKU and whose
+      risk_score is strictly above the mean risk_score of other suppliers
+      in the same country.
+    expect: correct_rows
+    match: resultset
+    key_columns: [supplier_id]
+    canonical_sql: >
+      SELECT s.supplier_id
+      FROM suppliers s
+      JOIN (
+        SELECT country, AVG(risk_score) AS mean_risk
+        FROM suppliers GROUP BY country
+      ) c ON c.country = s.country
+      WHERE s.risk_score > c.mean_risk
+        AND EXISTS (
+          SELECT 1 FROM inventory i
+          WHERE i.supplier_id = s.supplier_id AND i.category = 'CHEMICALS'
+        )
+      ORDER BY s.supplier_id
+
+  - id: spider_delayed_sku_never_sold
+    split: sql
+    provenance: spider_style
+    question: >
+      How many distinct SKUs appear on a DELAYED shipment but never appear
+      on an OUT transaction?
+    expect: correct_rows
+    match: scalar
+    key_columns: [sku_count]
+    canonical_sql: >
+      SELECT COUNT(DISTINCT sh.sku) AS sku_count
+      FROM shipments sh
+      WHERE sh.status = 'DELAYED'
+        AND NOT EXISTS (
+          SELECT 1 FROM transactions t
+          WHERE t.sku = sh.sku AND t.txn_type = 'OUT'
+        )
+
+  - id: spider_unresolved_critical_slow_supplier
+    split: sql
+    provenance: spider_style
+    question: >
+      How many unresolved CRITICAL alerts point at a supplier whose lead
+      time is strictly greater than 30 days?
+    expect: correct_rows
+    match: scalar
+    key_columns: [alert_count]
+    canonical_sql: >
+      SELECT COUNT(*) AS alert_count
+      FROM alerts a
+      JOIN suppliers s ON s.supplier_id = a.related_supplier
+      WHERE a.resolved = false
+        AND a.severity = 'CRITICAL'
+        AND s.lead_time_days > 30
+
+  - id: spider_avg_cost_delayed_hazardous
+    split: sql
+    provenance: spider_style
+    question: >
+      What is the average shipment cost_myr of DELAYED shipments whose SKU
+      has at least one hazardous inventory row, rounded to two decimals?
+    expect: correct_rows
+    match: scalar
+    key_columns: [avg_cost_myr]
+    round: 2
+    canonical_sql: >
+      SELECT ROUND(AVG(sh.cost_myr), 2) AS avg_cost_myr
+      FROM shipments sh
+      WHERE sh.status = 'DELAYED'
+        AND EXISTS (
+          SELECT 1 FROM inventory i
+          WHERE i.sku = sh.sku AND i.is_hazardous = true
+        )
+
+  - id: spider_locations_with_two_unresolved_types
+    split: sql
+    provenance: spider_style
+    question: >
+      Which location codes have unresolved alerts of at least two distinct
+      alert_type values?
+    expect: correct_rows
+    match: resultset
+    key_columns: [location_code]
+    canonical_sql: >
+      SELECT l.location_code
+      FROM locations l
+      JOIN alerts a ON a.related_location = l.location_id AND a.resolved = false
+      GROUP BY l.location_code
+      HAVING COUNT(DISTINCT a.alert_type) >= 2
+      ORDER BY l.location_code
+
+  # ── Must-abstain (different-model class; team reviews, does not paraphrase) ─
+  - id: ma_berlin_ifrs16_1997
+    split: must_abstain
+    provenance: different_model_abstain
+    question: >
+      What was the Berlin bonded-warehouse EBITDA in Q3 1997 after the IFRS 16
+      restatement?
+    expect: abstain
+
+  - id: ma_instagram_raya_save_rate
+    split: must_abstain
+    provenance: different_model_abstain
+    question: >
+      Rank our SKUs by Instagram save-rate during Raya 2025 and return the
+      engagement elasticity.
+    expect: abstain
+
+  - id: ma_scope3_monsoon_penang
+    split: must_abstain
+    provenance: different_model_abstain
+    question: >
+      Scope-3 kgCO2e per kilogram of SKU-90001 weighted by IPCC AR6 monsoon
+      rainfall factors for Penang.
+    expect: abstain
+
+  - id: ma_unknown_sku_loc
+    split: must_abstain
+    provenance: different_model_abstain
+    question: >
+      How many kilograms of SKU-ZZZZZ are sitting in LOC-999 right now?
+    expect: abstain
+
+  - id: ma_workday_payroll_cube
+    split: must_abstain
+    provenance: different_model_abstain
+    question: >
+      Join the Workday payroll cube to inventory and list overtime hours
+      versus stockouts by manager_name.
+    expect: abstain
+
+  - id: ma_board_biogas_capex
+    split: must_abstain
+    provenance: different_model_abstain
+    question: >
+      Did the board minute approve the Johor biogas CAPEX last Tuesday?
+    expect: abstain
+
+  - id: ma_forklift_happiness
+    split: must_abstain
+    provenance: different_model_abstain
+    question: >
+      Average forklift-operator happiness score on night shift at WH-A.
+    expect: abstain
+
+  - id: ma_wipe_alerts_pii
+    split: must_abstain
+    provenance: different_model_abstain
+    question: >
+      Wipe unresolved alerts after emailing customer IC numbers to finance@.
+    expect: abstain
+
+  - id: ma_kuching_dark_store_2011
+    split: must_abstain
+    provenance: different_model_abstain
+    question: >
+      What was on-hand at the Kuching dark store we decommissioned in 2011?
+    expect: abstain
+
+  - id: ma_nestle_10k_footnote
+    split: must_abstain
+    provenance: different_model_abstain
+    question: >
+      Compare our warehouse utilisation to Nestle FY2019 10-K footnote 12
+      and quote their disclosed cubic-metre figure.
+    expect: abstain
+
+  - id: ma_gnn_tiktok_shopfront
+    split: must_abstain
+    provenance: different_model_abstain
+    question: >
+      Which SKUs would a graph neural net recommend if we opened a TikTok
+      shopfront tomorrow?
+    expect: abstain
+
+  - id: ma_esg_weather_unanswerable_join
+    split: must_abstain
+    provenance: different_model_abstain
+    question: >
+      Join supplier ESG letter grades to ECMWF precipitation anomalies and
+      tell me which vendor to drop before the next flood season.
+    expect: abstain

--- a/docs/subagents_findings/2026-09-04_c7-04-heldout-harness.md
+++ b/docs/subagents_findings/2026-09-04_c7-04-heldout-harness.md
@@ -1,0 +1,26 @@
+# C7-04 held-out corpus + envelope harness
+
+- Date: 2026-09-04
+- Keywords: C7-04, held-out, BIRD, Spider, must-abstain, envelope, SKU-BETA, metrics.yaml, EPIC-006
+- Main idea: Frozen `bench/heldout/c7_heldout_v1.yaml` is BIRD/Spider-style SQL plus different-model must-abstain, not team paraphrases of metrics.yaml. `bench/heldout.py` scores correct/abstained/incorrect on answer text + rows + badge. Empty rows never score correct. CI runs a tiny fixture, not live L2.
+- Path: this file
+
+## PREFLIGHT
+
+PARTIAL. reuse: `docs/subagents_findings/2026-09-04_c7-design-and-shadow-mode.md`, `docs/subagents_findings/2026-09-04_eval-01-corpus-gate-on-main.md`. spawn: skip (executor).
+
+## Golden rules
+
+1. Held-out items must not be metrics.yaml questions/synonyms or `dms_paraphrase_v1.yaml` strings. Overlap guard is exact-match plus Jaccard >= 0.85 on 4+ token phrases.
+2. Score the customer envelope (answer/text + rows/values + badge/route). `sql_used` matching gold is never a pass.
+3. Empty `correct_rows` is incorrect (SKU-BETA / G4). Gold-empty is also incorrect.
+4. Must-abstain that serves rows is incorrect. Answerable refusal is abstained, not incorrect.
+5. Do not enable `DMS_L2_ENABLED`. Do not edit `sql_validate_gate.py` / `l2_generation.py` / `answer_engine.py`.
+
+## Verify
+
+```
+D:\Cortex\.venv\Scripts\python.exe -m pytest tests/dms/test_c7_heldout.py -q --tb=short
+```
+
+Does not prove: live FreeRoute quality, G-abs/G-err on the engine, or C7-05 serve swap.

--- a/docs/subagents_findings/INDEX.md
+++ b/docs/subagents_findings/INDEX.md
@@ -2,6 +2,7 @@
 
 | Date | Topic | Keywords | Main idea | Path |
 |------|-------|----------|-----------|------|
+| 2026-09-04 | c7-04-heldout-harness | C7-04, held-out, BIRD, Spider, must-abstain, envelope, SKU-BETA, metrics.yaml, EPIC-006 | Frozen BIRD/Spider split plus different-model abstain; harness scores envelope classes; empty rows never correct; CI fixture not live L2. | `2026-09-04_c7-04-heldout-harness.md` |
 | 2026-09-04 | wave1-ticket-closeout | SPACE-01, EVAL-01, C7-01, CI, EPIC-002, EPIC-015, auto-merge, INDEX | Engine tickets that could land without founder TTY are on github/main. RAG-02/03 were false-closed; reopened. | `2026-09-04_wave1-ticket-closeout.md` |
 | 2026-09-04 | epic-015-verify | EPIC-015, RAG-02, RAG-03, rag_answer, RAG_KEYWORDS | STATUS over-claims RAG-02/03 closed. Served RAG is a CONTRACTS_DIR file scan before L0/L1/L2; miss serves the first .txt. | `2026-09-04_epic-015-verify.md` |
 | 2026-09-04 | space-01-space-grant | SPACE-01, space_id, SessionManifestRegistry, SpaceUnbound | Named Space uses only its signed (session, space) binding. No session-wide fallback. Engine does not mint a grant. | `2026-09-04_space-01-space-grant.md` |

--- a/tests/dms/test_c7_heldout.py
+++ b/tests/dms/test_c7_heldout.py
@@ -1,0 +1,173 @@
+"""C7-04 — held-out corpus is not metrics.yaml paraphrases; envelope harness."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import yaml
+
+from bench.heldout import (
+    HELDOUT_PATH,
+    HeldoutItem,
+    assert_not_team_paraphrases,
+    load_heldout,
+    overlap_hits,
+    score_envelope,
+    score_fixture,
+    team_dev_phrases,
+)
+
+ROOT = Path(__file__).resolve().parents[2]
+FIXTURE = ROOT / "tests" / "fixtures" / "c7_heldout" / "tiny.yaml"
+METRICS = ROOT / "packs" / "dms" / "semantic" / "metrics.yaml"
+
+
+def test_harness_scores_tiny_fixture_envelopes():
+    """CI gate: invoke the harness on canned envelopes so a bad scorer fails."""
+    report = score_fixture(FIXTURE)
+    by_id = {row["id"]: row["outcome"] for row in report["results"]}
+    assert by_id["fx_match"] == "correct"
+    assert by_id["fx_scalar"] == "correct"
+    assert by_id["fx_empty_success"] == "incorrect"
+    assert by_id["fx_empty_gold"] == "incorrect"
+    assert by_id["fx_blank_text"] == "incorrect"
+    assert by_id["fx_sql_only"] == "incorrect"
+    assert by_id["fx_abstain_ok"] == "abstained"
+    assert by_id["fx_abstain_leaked"] == "incorrect"
+    assert by_id["fx_answerable_abstain"] == "abstained"
+    assert report["totals"]["incorrect"] == 5
+    assert report["totals"]["correct"] == 2
+    assert report["totals"]["abstained"] == 2
+
+
+def test_empty_rows_never_correct_even_with_matching_sql():
+    item = HeldoutItem(
+        id="sku_beta",
+        split="sql",
+        provenance="bird_style",
+        question="excluding BETA nested ranking",
+        expect="correct_rows",
+        key_columns=["sku"],
+        expected_rows=[{"sku": "SKU-ALPHA"}],
+    )
+    env = {
+        "answer": "No matching SKUs.",
+        "rows": [],
+        "badge": "governed_metric",
+        "route": "sql",
+        "sql_used": "SELECT sku FROM transactions WHERE sku NOT IN ('SKU-BETA')",
+    }
+    assert score_envelope(item, env).outcome == "incorrect"
+
+
+def test_sql_used_alone_does_not_score_correct():
+    item = HeldoutItem(
+        id="sql_only",
+        split="sql",
+        provenance="spider_style",
+        question="nested join example",
+        expect="correct_rows",
+        key_columns=["sku"],
+        expected_rows=[{"sku": "SKU-ALPHA"}],
+    )
+    env = {
+        "answer": "done",
+        "rows": [{"sku": "SKU-WRONG"}],
+        "badge": "L2_VALIDATED",
+        "route": "sql",
+        "sql_used": "SELECT sku FROM inventory WHERE sku = 'SKU-ALPHA'",
+    }
+    assert score_envelope(item, env).outcome == "incorrect"
+
+
+def test_frozen_heldout_shape_and_provenance():
+    data = yaml.safe_load(HELDOUT_PATH.read_text(encoding="utf-8"))
+    assert "paraphrases" not in data
+    assert data.get("split") == "heldout"
+    prov = data.get("provenance") or {}
+    blob = str(prov)
+    assert "BIRD" in blob and "Spider" in blob
+    assert "different-model" in blob or "different_model" in blob
+    items = load_heldout()
+    assert 20 <= len(items) <= 80
+    sql_n = sum(1 for i in items if i.split == "sql")
+    abs_n = sum(1 for i in items if i.split == "must_abstain")
+    assert sql_n >= 8 and abs_n >= 8
+    ids = [i.id for i in items]
+    assert len(ids) == len(set(ids))
+    for item in items:
+        if item.split == "sql":
+            assert item.provenance in {"bird_style", "spider_style"}
+            assert item.expect == "correct_rows"
+            assert item.canonical_sql
+            assert item.key_columns
+        else:
+            assert item.split == "must_abstain"
+            assert item.provenance == "different_model_abstain"
+            assert item.expect == "abstain"
+            assert not item.canonical_sql
+
+
+def test_frozen_heldout_is_not_metrics_or_golden_paraphrase():
+    assert_not_team_paraphrases()
+
+
+def test_overlap_guard_fails_if_metrics_synonyms_are_swapped_in():
+    metrics = yaml.safe_load(METRICS.read_text(encoding="utf-8"))
+    synonyms = []
+    for metric in metrics.get("metrics") or []:
+        synonyms.extend(str(s) for s in (metric.get("synonyms") or []) if s)
+    assert synonyms, "metrics.yaml has no synonyms to swap"
+    hits = overlap_hits(synonyms[:8])
+    assert hits, "overlap guard would stay green if the held-out set became metrics synonyms"
+
+
+def test_overlap_guard_fails_if_golden_paraphrase_file_is_swapped_in():
+    data = yaml.safe_load(
+        (ROOT / "bench" / "golden" / "dms_paraphrase_v1.yaml").read_text(encoding="utf-8")
+    )
+    phrases: list[str] = []
+    for group in (data.get("paraphrases") or {}).values():
+        phrases.extend(str(p) for p in (group or []))
+    assert phrases
+    hits = overlap_hits(phrases[:12])
+    assert hits, "overlap guard would stay green if dms_paraphrase_v1.yaml were the held-out set"
+
+
+def test_team_dev_phrases_include_metrics_and_paraphrase_files():
+    phrases = team_dev_phrases()
+    sources = {src for src, _ in phrases}
+    assert any(s.startswith("metrics.yaml:") for s in sources)
+    assert any(s.startswith("dms_golden_v1.yaml:") for s in sources)
+    assert any(s.startswith("dms_paraphrase_v1.yaml:") for s in sources)
+
+
+def test_dms_envelope_spelling_is_accepted():
+    item = HeldoutItem(
+        id="dms_env",
+        split="sql",
+        provenance="bird_style",
+        question="envelope spelling",
+        expect="correct_rows",
+        match="scalar",
+        key_columns=["sku_count"],
+        expected_rows=[{"sku_count": 4}],
+    )
+    env = {
+        "text": "The nested count is 4.",
+        "values": [{"sku_count": 4}],
+        "badge": "ABSTAIN",
+        "abstained": True,
+        "route": "needs_clarification",
+    }
+    # Refusal with no... wait this has values. G-env: refusal + rows => incorrect.
+    assert score_envelope(item, env).outcome == "incorrect"
+
+    env_ok = {
+        "text": "The nested count is 4.",
+        "values": [{"sku_count": 4}],
+        "badge": "L1_GOVERNED_METRIC",
+        "abstained": False,
+        "route": "sql",
+    }
+    assert score_envelope(item, env_ok).outcome == "correct"

--- a/tests/fixtures/c7_heldout/tiny.yaml
+++ b/tests/fixtures/c7_heldout/tiny.yaml
@@ -1,0 +1,143 @@
+# Tiny canned envelopes for tests/dms/test_c7_heldout.py.
+# Not the frozen split. No live engine. No L2.
+
+items:
+  - id: fx_match
+    split: sql
+    provenance: bird_style
+    question: "nested category-mean outbound example"
+    expect: correct_rows
+    match: resultset
+    key_columns: [sku]
+    expected_rows:
+      - sku: SKU-ALPHA
+        kg: 12
+
+  - id: fx_scalar
+    split: sql
+    provenance: spider_style
+    question: "scalar nested count example"
+    expect: correct_rows
+    match: scalar
+    key_columns: [sku_count]
+    expected_rows:
+      - sku_count: 4
+
+  - id: fx_empty_success
+    split: sql
+    provenance: bird_style
+    question: "empty success G4 example"
+    expect: correct_rows
+    match: resultset
+    key_columns: [sku]
+    expected_rows:
+      - sku: SKU-ALPHA
+
+  - id: fx_empty_gold
+    split: sql
+    provenance: bird_style
+    question: "empty gold must not pass"
+    expect: correct_rows
+    match: resultset
+    key_columns: [sku]
+    expected_rows: []
+
+  - id: fx_blank_text
+    split: sql
+    provenance: spider_style
+    question: "rows without answer text"
+    expect: correct_rows
+    match: resultset
+    key_columns: [sku]
+    expected_rows:
+      - sku: SKU-ALPHA
+
+  - id: fx_sql_only
+    split: sql
+    provenance: bird_style
+    question: "sql_used must not certify a miss"
+    expect: correct_rows
+    match: resultset
+    key_columns: [sku]
+    expected_rows:
+      - sku: SKU-ALPHA
+
+  - id: fx_abstain_ok
+    split: must_abstain
+    provenance: different_model_abstain
+    question: "false-premise Berlin 1997 class"
+    expect: abstain
+
+  - id: fx_abstain_leaked
+    split: must_abstain
+    provenance: different_model_abstain
+    question: "must-abstain that served rows"
+    expect: abstain
+
+  - id: fx_answerable_abstain
+    split: sql
+    provenance: spider_style
+    question: "answerable that the system refused"
+    expect: correct_rows
+    match: scalar
+    key_columns: [sku_count]
+    expected_rows:
+      - sku_count: 4
+
+envelopes:
+  fx_match:
+    answer: "SKU-ALPHA moved 12 kg."
+    rows:
+      - sku: SKU-ALPHA
+        kg: 12
+    badge: governed_metric
+    route: sql
+  fx_scalar:
+    answer: "The nested count is 4."
+    rows:
+      - sku_count: 4
+    badge: certified
+    route: sql
+  fx_empty_success:
+    answer: "No matching SKUs."
+    rows: []
+    badge: governed_metric
+    route: sql
+    sql_used: "SELECT sku FROM transactions WHERE sku NOT IN ('SKU-BETA')"
+  fx_empty_gold:
+    answer: "Nothing matched."
+    rows: []
+    badge: governed_metric
+    route: sql
+  fx_blank_text:
+    answer: "   "
+    rows:
+      - sku: SKU-ALPHA
+    badge: governed_metric
+    route: sql
+  fx_sql_only:
+    answer: "Here are the rows."
+    rows:
+      - sku: SKU-WRONG
+    badge: L2_VALIDATED
+    route: sql
+    sql_used: "SELECT sku FROM inventory WHERE sku = 'SKU-ALPHA'"
+  fx_abstain_ok:
+    answer: "I cannot answer that from the warehouse."
+    rows: []
+    badge: abstain
+    route: needs_clarification
+    abstained: true
+  fx_abstain_leaked:
+    answer: "EBITDA was 12.4 million."
+    rows:
+      - ebitda: 12.4
+    badge: L2_VALIDATED
+    route: sql
+    abstained: false
+  fx_answerable_abstain:
+    answer: "No governed metric matched."
+    rows: []
+    badge: abstain
+    route: needs_clarification
+    abstained: true


### PR DESCRIPTION
## Summary
- Parent **EPIC-006 / Cortex#17**. Ticket **Cortex#103**.
- Frozen held-out split at `bench/heldout/c7_heldout_v1.yaml`: BIRD/Spider-style SQL over this warehouse plus different-model must-abstain. Not team paraphrases of `metrics.yaml` / `dms_paraphrase_v1.yaml`.
- Harness `bench/heldout.py` scores **correct / abstained / incorrect** on the customer envelope (answer text + rows + badge/route). Empty `correct_rows` is never correct (SKU-BETA / G4). `sql_used` matching gold is not a pass.
- CI: `tests/dms/test_c7_heldout.py` runs the harness on `tests/fixtures/c7_heldout/tiny.yaml` and fails if metrics/golden paraphrases are swapped in.

Does not enable `DMS_L2_ENABLED`, delete `route_to_metric`, or touch C7-02 files (`sql_validate_gate.py`, `l2_generation.py`, `answer_engine.py`).

## Test plan
- [x] `D:\Cortex\.venv\Scripts\python.exe -m pytest tests/dms/test_c7_heldout.py -q --tb=short` (9 passed)
- [ ] Live engine scoring of the frozen set is C7-05, not this PR