### PR TITLE
C7-02: enforce_manifest before EXPLAIN on every L2 candidate (Cortex#101)

### DIFF
--- a/CortexOS/dms/answer_engine.py
+++ b/CortexOS/dms/answer_engine.py
@@ -1561,12 +1561,18 @@ def answer(
     if sql is None:
         # L2 lives on the engine port module, not here. This file must not
         # import pack generation code (C2).
-        from CortexOS.dms.l2_generation import attempt_l2
+        from CortexOS.dms.l2_generation import L2_MANIFEST_REASON_PREFIX, attempt_l2
 
         l2_out = attempt_l2(question, verified=verified)
         if l2_out is None:
             return _abs("no governed metric or certified query matched")
         if not l2_out.sql:
+            if l2_out.refused or (l2_out.reason or "").startswith(
+                L2_MANIFEST_REASON_PREFIX
+            ):
+                refused = _abstain_refused(question, audit_id, reason=l2_out.reason)
+                refused["violations_blocked"] = list(l2_out.violations or [])
+                return _done(refused)
             return _abs(l2_out.reason)
         sql = l2_out.sql
         layer, badge = l2_out.layer, l2_out.badge

--- a/CortexOS/dms/l2_generation.py
+++ b/CortexOS/dms/l2_generation.py
@@ -78,6 +78,10 @@ def _load_active_pack() -> None:
         return
 
 
+#: Stable prefix so answer() can emit refused, not coverage abstain (C7-02).
+L2_MANIFEST_REASON_PREFIX = "L2_MANIFEST:"
+
+
 @dataclass(slots=True)
 class L2Attempt:
     """Outcome of the L2 path. ``sql`` set means the gate passed."""
@@ -88,10 +92,29 @@ class L2Attempt:
     badge: str = "L2_VALIDATED"
     assumptions: str = ""
     violations: list[str] | None = None
+    refused: bool = False
+    retrieved_tables: tuple[str, ...] = ()
 
 
 def _env_on(name: str) -> bool:
     return os.environ.get(name, "").lower() in ("1", "true", "yes")
+
+
+def _manifest_l2_attempt(violations: list[str]) -> L2Attempt:
+    from CortexOS.dms.sql_validate_gate import MANIFEST_VIOLATION_PREFIX
+
+    code = "manifest_error"
+    for item in violations:
+        if item.startswith(MANIFEST_VIOLATION_PREFIX):
+            code = item[len(MANIFEST_VIOLATION_PREFIX) :]
+            break
+    return L2Attempt(
+        reason=f"{L2_MANIFEST_REASON_PREFIX}{code}",
+        layer="refused",
+        badge="refused",
+        violations=list(violations),
+        refused=True,
+    )
 
 
 def attempt_l2(
@@ -129,28 +152,41 @@ def attempt_l2(
     semantic_early = load_semantic_layer()
     reduced = l2.retrieve_schema(question)
 
+    leftover: list[str] = []
+
     def _gen(prior: list[str]) -> str | None:
-        cands = l2.generate_candidates(
-            question,
-            reduced,
-            prior_violations=prior,
+        if leftover:
+            return leftover.pop(0)
+        cands = list(
+            l2.generate_candidates(
+                question,
+                reduced,
+                prior_violations=prior,
+            )
+            or []
         )
-        return cands[0] if cands else None
+        if not cands:
+            return None
+        leftover.extend(cands[1:])
+        return cands[0]
 
     con_explain = None
     try:
-        if verified is None:
-            con_explain = get_connection(
-                DEFAULT_DB, read_only=read_only_queries_enabled()
-            )
+        # EXPLAIN must run on post-enforce SQL even when a session is bound.
+        con_explain = get_connection(
+            DEFAULT_DB, read_only=read_only_queries_enabled()
+        )
         gate = gate_with_retry(
             _gen,
             question,
             semantic_early,
             con=con_explain,
+            verified=verified,
             max_retries=2,
         )
     except SqlGateAbstain as exc:
+        if exc.manifest_refused:
+            return _manifest_l2_attempt(list(exc.violations))
         return L2Attempt(
             reason=f"L2 generation failed validation gate: {exc}",
             violations=list(exc.violations),
@@ -160,6 +196,8 @@ def attempt_l2(
             con_explain.close()
 
     if not gate.passed or not gate.safe_sql:
+        if gate.manifest_refused:
+            return _manifest_l2_attempt(list(gate.violations))
         return L2Attempt(
             reason="L2 generation failed validation gate",
             violations=list(gate.violations),
@@ -171,10 +209,11 @@ def attempt_l2(
             l2.record_validated(question, sql)
         except Exception:  # noqa: BLE001 — promotion signal must not block answers
             pass
-    tables = list((reduced.get("tables") or {}).keys())
+    tables = tuple((reduced.get("tables") or {}).keys())
     return L2Attempt(
         sql=sql,
-        assumptions=f"L2 FreeRoute SQL over reduced schema tables={tables}",
+        assumptions=f"L2 FreeRoute SQL over reduced schema tables={list(tables)}",
+        retrieved_tables=tables,
     )
 
 
@@ -306,6 +345,7 @@ __all__ = [
     "L2Attempt",
     "L2GenerationPort",
     "L2NotRegistered",
+    "L2_MANIFEST_REASON_PREFIX",
     "attempt_l2",
     "clear_l2_generation",
     "maybe_record_l2_shadow",

--- a/CortexOS/dms/sql_validate_gate.py
+++ b/CortexOS/dms/sql_validate_gate.py
@@ -1,8 +1,9 @@
-"""C7-min — EXPLAIN dry-run + bounded retry before execute.
+"""C7 — sqlglot + optional manifest enforce + EXPLAIN + bounded retry.
 
-Assembles existing sqlglot guardrail + DuckDB EXPLAIN. Does not weaken
-manifest refusals. L2 generation hooks call this gate; without a model the
-answer engine still abstains.
+A grounded session runs ``enforce_manifest`` before EXPLAIN so the dry-run
+never sees pre-enforce SQL (C7-02). Manifest refusals are not retried for
+the same SQL. This module does not narrow ``CortexOS.execution.manifest``
+refusals.
 """
 
 from __future__ import annotations
@@ -12,6 +13,10 @@ from dataclasses import dataclass, field
 from typing import Any
 
 from CortexOS.dms.sql_guardrail import GuardrailResult, validate_sql
+from CortexOS.execution.manifest import VerifiedManifest
+
+#: Violation token when enforce_manifest refuses a candidate (C7-02).
+MANIFEST_VIOLATION_PREFIX = "MANIFEST:"
 
 
 @dataclass(slots=True)
@@ -22,14 +27,23 @@ class ValidateGateResult:
     explain_ok: bool = False
     attempts: int = 0
     explain_error: str | None = None
+    manifest_refused: bool = False
+    source_sql: str | None = None
 
 
 class SqlGateAbstain(Exception):
     """Raised when validation/EXPLAIN retries are exhausted — caller must abstain."""
 
-    def __init__(self, message: str, *, violations: list[str] | None = None) -> None:
+    def __init__(
+        self,
+        message: str,
+        *,
+        violations: list[str] | None = None,
+        manifest_refused: bool = False,
+    ) -> None:
         super().__init__(message)
         self.violations = list(violations or [])
+        self.manifest_refused = manifest_refused
 
     def __str__(self) -> str:
         # FF-03 / dms#59 — callers interpolate `{exc}` into the envelope reason.
@@ -60,8 +74,14 @@ def run_gate(
     semantic: dict[str, Any],
     *,
     con: Any | None = None,
+    verified: VerifiedManifest | None = None,
 ) -> ValidateGateResult:
-    """sqlglot allowlist + optional EXPLAIN dry-run."""
+    """sqlglot allowlist, then enforce_manifest (if bound), then EXPLAIN.
+
+    EXPLAIN sees only post-enforce SQL. ``source_sql`` is the pre-enforce
+    candidate so ``execute_sql`` can enforce once. A ManifestError fails the
+    candidate without EXPLAIN.
+    """
     guard = validate_sql(sql, semantic)
     if not guard.passed or not guard.safe_sql:
         return ValidateGateResult(
@@ -72,31 +92,51 @@ def run_gate(
             attempts=1,
         )
 
+    source = guard.safe_sql
+    safe_sql = source
+    if verified is not None:
+        from CortexOS.execution.manifest import ManifestError, enforce_manifest
+
+        try:
+            safe_sql = enforce_manifest(source, verified)
+        except ManifestError as exc:
+            return ValidateGateResult(
+                passed=False,
+                violations=[f"{MANIFEST_VIOLATION_PREFIX}{type(exc).__name__}:{exc.code}"],
+                safe_sql=None,
+                explain_ok=False,
+                attempts=1,
+                manifest_refused=True,
+            )
+
     if con is None:
         return ValidateGateResult(
             passed=True,
             violations=[],
-            safe_sql=guard.safe_sql,
-            explain_ok=True,  # no connection — parse-only pass
+            safe_sql=safe_sql,
+            explain_ok=True,
             attempts=1,
+            source_sql=source,
         )
 
-    ok, detail = explain_dry_run(con, guard.safe_sql)
+    ok, detail = explain_dry_run(con, safe_sql)
     if not ok:
         return ValidateGateResult(
             passed=False,
             violations=[f"EXPLAIN_FAILED:{detail}"],
-            safe_sql=guard.safe_sql,
+            safe_sql=safe_sql,
             explain_ok=False,
             attempts=1,
             explain_error=detail,
+            source_sql=source,
         )
     return ValidateGateResult(
         passed=True,
         violations=[],
-        safe_sql=guard.safe_sql,
+        safe_sql=safe_sql,
         explain_ok=True,
         attempts=1,
+        source_sql=source,
     )
 
 
@@ -106,14 +146,19 @@ def gate_with_retry(
     semantic: dict[str, Any],
     *,
     con: Any | None = None,
+    verified: VerifiedManifest | None = None,
     max_retries: int = 2,
 ) -> ValidateGateResult:
     """Call generate_fn up to max_retries+1 times, feeding prior violations back.
 
     ``generate_fn(prior_violations) -> sql | None``. Exhaustion raises SqlGateAbstain.
+    ManifestError aborts that candidate (no EXPLAIN, no second try of the same
+    SQL). A later generate_fn result may still pass.
     """
     prior: list[str] = []
     last = ValidateGateResult(passed=False, attempts=0)
+    saw_manifest = False
+    refused_sql: set[str] = set()
     for attempt in range(1, max_retries + 2):
         sql = generate_fn(prior)
         if not sql:
@@ -121,16 +166,27 @@ def gate_with_retry(
                 passed=False,
                 violations=prior + ["NO_CANDIDATE"],
                 attempts=attempt,
+                manifest_refused=saw_manifest,
             )
             break
-        last = run_gate(sql, semantic, con=con)
+        last = run_gate(sql, semantic, con=con, verified=verified)
         last.attempts = attempt
+        if last.manifest_refused:
+            saw_manifest = True
+            if sql in refused_sql:
+                raise SqlGateAbstain(
+                    "SQL validation gate exhausted retries",
+                    violations=last.violations,
+                    manifest_refused=True,
+                )
+            refused_sql.add(sql)
         if last.passed and last.safe_sql:
             return last
         prior = list(last.violations)
     raise SqlGateAbstain(
         "SQL validation gate exhausted retries",
         violations=last.violations,
+        manifest_refused=saw_manifest or last.manifest_refused,
     )
 
 
@@ -143,6 +199,7 @@ def guard_result_from_gate(gate: ValidateGateResult) -> GuardrailResult:
 
 
 __all__ = [
+    "MANIFEST_VIOLATION_PREFIX",
     "SqlGateAbstain",
     "ValidateGateResult",
     "explain_dry_run",

--- a/docs/subagents_findings/2026-09-04_c7-02-manifest-before-explain.md
+++ b/docs/subagents_findings/2026-09-04_c7-02-manifest-before-explain.md
@@ -1,0 +1,33 @@
+# C7-02: Manifest before EXPLAIN on every L2 candidate
+
+- Date: 2026-09-04
+- Keywords: C7-02, C7, L2, enforce_manifest, EXPLAIN, ManifestError, PathNotAllowed, refused, sql_validate_gate, attempt_l2
+- Main idea: When L2 generates SQL for a grounded session, `run_gate` calls `enforce_manifest` after sqlglot and before EXPLAIN. ManifestError fails that candidate without EXPLAIN, `attempt_l2` signals `refused` / `L2_MANIFEST:`, and `answer()` emits route/layer/badge=refused (not SESSION abstain). EXPLAIN sees only post-enforce SQL.
+- Path: this file
+
+## PREFLIGHT
+
+HIT. reuse: `docs/subagents_findings/2026-09-04_c7-design-and-shadow-mode.md`. spawn: skip (executor).
+
+## Golden rules
+
+1. Never weaken `CortexOS/execution/manifest.py` refusals. Enforcer before EXPLAIN.
+2. CortexOS must not statically import `packs.*`. L2 stays on `CortexOS.dms.l2_generation`.
+3. ManifestError is refused, not `_abs()` SESSION-adjacent abstain.
+4. Customer-envelope assertions (answer text + rows + badge), not SQL-only gates.
+5. Do not set `DMS_L2_ENABLED` as the serve default. Do not implement C7-03.
+
+## What shipped
+
+- `run_gate` / `gate_with_retry` take optional `verified`. After sqlglot, `enforce_manifest`; on `ManifestError` return `passed=False` with `MANIFEST:{Type}:{code}` and skip EXPLAIN. Then EXPLAIN the enforced SQL only. `max_retries=2` stays; violations feed the next candidate.
+- `attempt_l2` always opens the warehouse connection when it will EXPLAIN (including when `verified` is set). Gate exhaustion from ManifestError returns `L2Attempt(refused=True, reason=L2_MANIFEST:...)`.
+- `answer()` maps that to `_abstain_refused` (route/layer/badge=refused).
+
+## Verify
+
+```
+ruff check CortexOS/dms/sql_validate_gate.py CortexOS/dms/l2_generation.py CortexOS/dms/answer_engine.py tests/dms/test_sql_validate_gate.py tests/dms/test_c7_02_manifest_before_explain.py
+D:\Cortex\.venv\Scripts\python.exe -m pytest tests/dms/test_sql_validate_gate.py tests/dms/test_c7_02_manifest_before_explain.py tests/dms/test_c7_l2_shadow.py tests/test_execution/test_submit_c4.py -q --tb=short
+```
+
+Does not prove: C7-03 plausibility, L1 cutover, live FreeRoute quality, or that a later L2 candidate that passes enforce is served when `require_grounding` has empty `planned_tables`.

--- a/tests/dms/test_c7_02_manifest_before_explain.py
+++ b/tests/dms/test_c7_02_manifest_before_explain.py
@@ -1,0 +1,277 @@
+"""C7-02: enforce_manifest runs on every L2 candidate before EXPLAIN.
+
+Served envelope assertions (R-0001): POST /dms/query and POST /v1/contract/ask.
+"""
+
+from __future__ import annotations
+
+import base64
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from typing import Any
+
+import pytest
+from cortex_contract.execution import Manifest
+from cryptography.hazmat.primitives import serialization
+from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PrivateKey
+
+from CortexOS.dms import l2_generation
+from CortexOS.dms.l2_generation import L2_MANIFEST_REASON_PREFIX
+from CortexOS.dms.sql_validate_gate import MANIFEST_VIOLATION_PREFIX
+from CortexOS.execution.manifest import (
+    JwksCache,
+    ManifestVerifier,
+    VerifiedManifest,
+    canonical_manifest_bytes,
+)
+from CortexOS.execution.session_manifests import (
+    get_session_registry,
+    reset_session_registry_for_tests,
+)
+
+SESSION = "c7-02-sess"
+REVENUE_Q = "what is our total revenue"
+L2_Q = "correlate hazmat dwell time with rainfall percentiles"
+OUTSIDE_SQL = "SELECT sku FROM inventory LIMIT 5"
+
+
+def _b64u(raw: bytes) -> str:
+    return base64.urlsafe_b64encode(raw).decode().rstrip("=")
+
+
+def _jwk(kid: str, private: Ed25519PrivateKey) -> dict[str, object]:
+    raw = private.public_key().public_bytes(
+        serialization.Encoding.Raw, serialization.PublicFormat.Raw
+    )
+    return {
+        "kty": "OKP",
+        "crv": "Ed25519",
+        "alg": "EdDSA",
+        "use": "sig",
+        "kid": kid,
+        "x": _b64u(raw),
+    }
+
+
+def _verified(predicates: dict[str, str]) -> VerifiedManifest:
+    when = datetime.now(timezone.utc)
+    manifest = Manifest(
+        session_id="c7-02-unit",
+        org_id="acme",
+        pool_id="default",
+        issuer_key_id="int-1",
+        allowed_paths=["/data/pool/acme/**"],
+        row_predicates=predicates,
+        issued_at=when.isoformat(),
+        expires_at=(when + timedelta(minutes=5)).isoformat(),
+        signature="not-checked-here",
+    )
+    return VerifiedManifest(manifest=manifest, issuer_kid="int-1", verified_at=when)
+
+
+class _OutsideGrantPort:
+    def is_configured(self) -> bool:
+        return True
+
+    def retrieve_schema(self, question: str) -> dict:
+        del question
+        return {"tables": {"inventory": {}}}
+
+    def generate_candidates(self, question, schema, *, prior_violations=None):
+        del question, schema, prior_violations
+        return [OUTSIDE_SQL]
+
+    def record_validated(self, question, sql):
+        raise AssertionError("manifest-refused L2 must not promote")
+
+
+@pytest.fixture
+def dms_http(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    from fastapi.testclient import TestClient
+
+    from bench.accuracy import _ensure_db_loaded
+    from CortexOS.api.app import create_app
+    from CortexOS.dms.answer_engine import clear_session
+    from CortexOS.execution.pool import PoolConfig, reset_read_pool_for_tests
+    from CortexOS.execution.submit import set_verifier_for_tests
+    from packs.dms.security.rate_limit import reset_limiter
+    from packs.dms.semantic.loader import reload
+
+    monkeypatch.setenv("PACK", "dms")
+    monkeypatch.setenv("DMS_AUTH_DISABLED", "1")
+    import netie.config
+
+    netie.config._cached_config = None
+
+    _ensure_db_loaded()
+    reload()
+
+    issuer = Ed25519PrivateKey.generate()
+    cache = JwksCache(path=tmp_path / "jwks.json")
+    cache.install({"keys": [_jwk("int-1", issuer)]})
+    verifier = ManifestVerifier(cache)
+    set_verifier_for_tests(verifier)
+    reset_session_registry_for_tests()
+    reset_read_pool_for_tests(PoolConfig("default", 4, 5.0, 30.0))
+    reset_limiter(10_000)
+
+    def _bind(
+        session_id: str,
+        row_predicates: dict[str, str],
+        *,
+        space_id: str | None = None,
+    ) -> None:
+        now = datetime.now(timezone.utc)
+        manifest = Manifest(
+            session_id=session_id,
+            org_id="acme",
+            space_id=space_id,
+            pool_id="default",
+            issuer_key_id="int-1",
+            allowed_paths=["/data/pool/acme/**"],
+            row_predicates=row_predicates,
+            issued_at=now.isoformat(),
+            expires_at=(now + timedelta(minutes=5)).isoformat(),
+            signature="",
+        )
+        manifest.signature = _b64u(issuer.sign(canonical_manifest_bytes(manifest)))
+        get_session_registry().bind(verifier.verify(manifest))
+        clear_session(session_id, space_id=space_id)
+
+    client = TestClient(create_app())
+    client.bind_session = _bind  # type: ignore[attr-defined]
+    yield client
+
+    set_verifier_for_tests(None)
+    reset_session_registry_for_tests()
+    reset_limiter()
+    netie.config._cached_config = None
+
+
+def _badge(body: dict[str, Any]) -> str:
+    raw = body.get("badge")
+    if raw:
+        return str(raw)
+    prov = body.get("provenance") or {}
+    if isinstance(prov, dict):
+        return str(prov.get("badge") or "")
+    return ""
+
+
+def _force_l2(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("DMS_L2_ENABLED", "1")
+    monkeypatch.setattr(l2_generation, "resolve_l2_generation", lambda: _OutsideGrantPort())
+    monkeypatch.setattr("CortexOS.dms.answer_engine.match_certified", lambda q: None)
+    monkeypatch.setattr("CortexOS.dms.answer_engine.route_to_metric", lambda q: None)
+    monkeypatch.setattr("CortexOS.dms.answer_engine.undefined_subject", lambda q: None)
+    monkeypatch.setattr("CortexOS.dms.answer_engine._shape_refusal", lambda q: None)
+    monkeypatch.setattr("packs.dms.semantic.query_skills.find", lambda *a, **k: None)
+    monkeypatch.setattr(
+        "packs.dms.semantic.catalog_answer.is_catalog_intent", lambda q: False
+    )
+
+
+def test_attempt_l2_manifest_skips_explain_and_signals_refused(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    from bench.accuracy import _ensure_db_loaded
+
+    _ensure_db_loaded()
+    calls: list[str] = []
+
+    def _boom(con, sql, params=None):
+        del con, params
+        calls.append(sql)
+        return True, "ok"
+
+    monkeypatch.setattr(
+        "CortexOS.dms.sql_validate_gate.explain_dry_run", _boom
+    )
+    monkeypatch.setenv("DMS_L2_ENABLED", "1")
+    monkeypatch.setattr(
+        l2_generation, "resolve_l2_generation", lambda: _OutsideGrantPort()
+    )
+    out = l2_generation.attempt_l2(
+        L2_Q, verified=_verified({"transactions": "TRUE"})
+    )
+    assert out is not None
+    assert out.sql is None
+    assert out.refused is True
+    assert (out.reason or "").startswith(L2_MANIFEST_REASON_PREFIX)
+    assert "PathNotAllowed" in (out.reason or "")
+    assert "path_not_allowed" in (out.reason or "")
+    assert out.violations
+    assert any(MANIFEST_VIOLATION_PREFIX in v for v in out.violations)
+    assert calls == []
+
+
+def test_l2_outside_grant_served_refused(dms_http, monkeypatch: pytest.MonkeyPatch):
+    _force_l2(monkeypatch)
+    dms_http.bind_session(SESSION, {"transactions": "TRUE"})
+
+    resp = dms_http.post(
+        "/dms/query", json={"question": L2_Q, "session_id": SESSION}
+    )
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    assert body.get("route") == "refused"
+    assert body.get("layer") == "refused"
+    assert _badge(body) == "refused"
+    assert _badge(body).lower() != "session"
+    text = body.get("answer") or ""
+    assert "can't" in text.lower() or "cannot" in text.lower()
+    assert "PathNotAllowed" in text or "path_not_allowed" in text
+    assert L2_MANIFEST_REASON_PREFIX in (body.get("assumptions") or text)
+    assert body.get("rows") in ([], None)
+    assert body.get("sql_used") is None
+    assert "80375993" not in str(body).replace(",", "")
+
+    contract = dms_http.post(
+        "/v1/contract/ask", json={"question": L2_Q, "session_id": SESSION}
+    )
+    assert contract.status_code == 200, contract.text
+    cbody = contract.json()
+    badge = _badge(cbody).lower()
+    assert badge in {"refused", "abstain"}
+    assert badge != "session"
+    layer = str(cbody.get("layer") or "").lower()
+    prov = cbody.get("provenance") or {}
+    if isinstance(prov, dict):
+        layer = str(prov.get("layer") or layer).lower()
+        pb = str(prov.get("badge") or badge).lower()
+        assert pb != "session"
+    assert layer in {"refused", "abstain"}
+    ctext = cbody.get("answer") or ""
+    assert "PathNotAllowed" in ctext or "path_not_allowed" in ctext or "L2_MANIFEST" in ctext
+    assert cbody.get("rows") in ([], None)
+    assert cbody.get("sql_used") is None
+
+
+def test_same_grant_l1_revenue_still_answers(dms_http, monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.setenv("DMS_L2_ENABLED", "1")
+    monkeypatch.setattr(
+        l2_generation, "resolve_l2_generation", lambda: _OutsideGrantPort()
+    )
+    dms_http.bind_session(SESSION, {"transactions": "TRUE"})
+
+    resp = dms_http.post(
+        "/dms/query", json={"question": REVENUE_Q, "session_id": SESSION}
+    )
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    assert _badge(body) not in {"abstain", "refused", "blocked"}
+    rows = body.get("rows") or []
+    assert rows, "L1 revenue over the granted table must still return rows"
+    assert float(rows[0].get("revenue_myr") or 0) > 0
+    assert body.get("answer")
+    assert body.get("sql_used")
+
+    contract = dms_http.post(
+        "/v1/contract/ask", json={"question": REVENUE_Q, "session_id": SESSION}
+    )
+    assert contract.status_code == 200, contract.text
+    cbody = contract.json()
+    assert _badge(cbody).lower() not in {"abstain", "refused", "blocked"}
+    crows = cbody.get("rows") or []
+    assert crows
+    assert cbody.get("answer")

--- a/tests/dms/test_sql_validate_gate.py
+++ b/tests/dms/test_sql_validate_gate.py
@@ -2,15 +2,36 @@
 
 from __future__ import annotations
 
+from datetime import datetime, timedelta, timezone
+
 import pytest
+from cortex_contract.execution import Manifest
 
 from CortexOS.dms.sql_validate_gate import (
+    MANIFEST_VIOLATION_PREFIX,
     SqlGateAbstain,
     explain_dry_run,
     gate_with_retry,
     run_gate,
 )
 from CortexOS.dms.warehouse_db import DEFAULT_DB, get_connection, load_semantic_layer
+from CortexOS.execution.manifest import VerifiedManifest, enforce_manifest
+
+
+def _verified(predicates: dict[str, str]) -> VerifiedManifest:
+    when = datetime.now(timezone.utc)
+    manifest = Manifest(
+        session_id="c7-02-gate",
+        org_id="acme",
+        pool_id="default",
+        issuer_key_id="int-1",
+        allowed_paths=["/data/pool/acme/**"],
+        row_predicates=predicates,
+        issued_at=when.isoformat(),
+        expires_at=(when + timedelta(minutes=5)).isoformat(),
+        signature="not-checked-here",
+    )
+    return VerifiedManifest(manifest=manifest, issuer_kid="int-1", verified_at=when)
 
 
 @pytest.fixture(scope="module")
@@ -115,3 +136,193 @@ def test_l2_without_model_abstains(monkeypatch):
     assert "L2" in (r.get("assumptions") or "") or "L2" in (r.get("answer") or "") or True
     # Must not invent rows
     assert not r.get("rows")
+
+
+def test_run_gate_manifest_skips_explain(semantic, monkeypatch):
+    calls: list[tuple] = []
+
+    def _boom(con, sql, params=None):
+        calls.append((con, sql, params))
+        return True, "ok"
+
+    monkeypatch.setattr(
+        "CortexOS.dms.sql_validate_gate.explain_dry_run", _boom
+    )
+    verified = _verified({"transactions": "TRUE"})
+    gate = run_gate(
+        "SELECT sku FROM inventory LIMIT 5",
+        semantic,
+        con=object(),
+        verified=verified,
+    )
+    assert gate.passed is False
+    assert gate.explain_ok is False
+    assert gate.manifest_refused is True
+    assert calls == []
+    blob = " ".join(gate.violations)
+    assert MANIFEST_VIOLATION_PREFIX in blob
+    assert "PathNotAllowed" in blob
+    assert "path_not_allowed" in blob
+
+
+def test_run_gate_explains_post_enforce_sql(semantic, monkeypatch):
+    captured: list[str] = []
+    held: dict[str, str] = {}
+
+    def _explain(con, sql, params=None):
+        del con, params
+        captured.append(sql)
+        return True, "ok"
+
+    real_enforce = enforce_manifest
+
+    def _spy(sql, verified):
+        out = real_enforce(sql, verified)
+        held["sql"] = out
+        return out
+
+    monkeypatch.setattr(
+        "CortexOS.dms.sql_validate_gate.explain_dry_run", _explain
+    )
+    monkeypatch.setattr(
+        "CortexOS.execution.manifest.enforce_manifest", _spy
+    )
+    verified = _verified({"inventory": "TRUE"})
+    gate = run_gate(
+        "SELECT sku FROM inventory LIMIT 5",
+        semantic,
+        con=object(),
+        verified=verified,
+    )
+    assert gate.passed is True
+    assert gate.explain_ok is True
+    assert held["sql"]
+    assert captured == [held["sql"]]
+    assert gate.safe_sql is held["sql"]
+
+
+def test_gate_retries_manifest_then_accepts_granted(semantic, monkeypatch):
+    captured: list[str] = []
+
+    def _explain(con, sql, params=None):
+        del con, params
+        captured.append(sql)
+        return True, "ok"
+
+    monkeypatch.setattr(
+        "CortexOS.dms.sql_validate_gate.explain_dry_run", _explain
+    )
+    n = {"i": 0}
+    priors: list[list[str]] = []
+
+    def _gen(prior: list[str]) -> str | None:
+        priors.append(list(prior))
+        n["i"] += 1
+        if n["i"] == 1:
+            return "SELECT sku FROM inventory LIMIT 5"
+        return "SELECT sku FROM transactions LIMIT 5"
+
+    verified = _verified({"transactions": "TRUE"})
+    gate = gate_with_retry(
+        _gen, "q", semantic, con=object(), verified=verified, max_retries=2
+    )
+    assert gate.passed is True
+    assert n["i"] == 2
+    assert any(MANIFEST_VIOLATION_PREFIX in v for v in priors[1])
+    assert len(captured) == 1
+    assert "transactions" in captured[0].lower()
+
+
+def test_gate_manifest_exhausts_at_max_retries(semantic, monkeypatch):
+    calls = {"explain": 0, "gen": 0}
+
+    def _explain(con, sql, params=None):
+        del con, sql, params
+        calls["explain"] += 1
+        return True, "ok"
+
+    monkeypatch.setattr(
+        "CortexOS.dms.sql_validate_gate.explain_dry_run", _explain
+    )
+
+    def _gen(_prior: list[str]) -> str | None:
+        calls["gen"] += 1
+        return "SELECT sku FROM inventory LIMIT 5"
+
+    verified = _verified({"transactions": "TRUE"})
+    with pytest.raises(SqlGateAbstain) as ei:
+        gate_with_retry(
+            _gen, "q", semantic, con=object(), verified=verified, max_retries=2
+        )
+    assert calls["gen"] == 2
+    assert calls["explain"] == 0
+    assert ei.value.manifest_refused is True
+    assert any(MANIFEST_VIOLATION_PREFIX in v for v in ei.value.violations)
+
+
+def test_l2_next_candidate_after_manifest_skip(monkeypatch):
+    from CortexOS.dms import l2_generation
+
+    class _Port:
+        def is_configured(self) -> bool:
+            return True
+
+        def retrieve_schema(self, question: str) -> dict:
+            return {"tables": {"transactions": {}}}
+
+        def generate_candidates(self, question, schema, *, prior_violations=None):
+            del question, schema, prior_violations
+            return [
+                "SELECT sku FROM inventory LIMIT 5",
+                "SELECT sku FROM transactions LIMIT 5",
+            ]
+
+        def record_validated(self, question, sql):
+            del question, sql
+            return None
+
+    monkeypatch.setenv("DMS_L2_ENABLED", "1")
+    monkeypatch.setattr(l2_generation, "resolve_l2_generation", lambda: _Port())
+    out = l2_generation.attempt_l2(
+        "free form anything",
+        verified=_verified({"transactions": "TRUE"}),
+    )
+    assert out is not None
+    assert out.sql
+    assert out.refused is False
+    assert "transactions" in out.sql.lower()
+
+
+def test_l2_manifest_error_customer_envelope_is_refused(monkeypatch):
+    from CortexOS.dms import l2_generation
+    from CortexOS.dms.answer_engine import answer
+
+    class _Port:
+        def is_configured(self) -> bool:
+            return True
+
+        def retrieve_schema(self, question: str) -> dict:
+            return {"tables": {"inventory": {}}}
+
+        def generate_candidates(self, question, schema, *, prior_violations=None):
+            del question, schema, prior_violations
+            return ["SELECT sku FROM inventory LIMIT 5"]
+
+        def record_validated(self, question, sql):
+            raise AssertionError("must not promote a refused candidate")
+
+    monkeypatch.setenv("DMS_L2_ENABLED", "1")
+    monkeypatch.setattr(l2_generation, "resolve_l2_generation", lambda: _Port())
+    r = answer(
+        "Correlate supplier ESG scores with weather anomalies",
+        verified=_verified({"transactions": "TRUE"}),
+    )
+    assert r["route"] == "refused"
+    assert r["layer"] == "refused"
+    assert r["badge"] == "refused"
+    assert r["badge"] != "session"
+    assert r["rows"] == []
+    assert r.get("sql_used") is None
+    text = f"{r.get('answer') or ''} {r.get('assumptions') or ''}"
+    assert "L2_MANIFEST" in text or "PathNotAllowed" in text
+    assert r.get("violations_blocked")


### PR DESCRIPTION
## Summary
- L2 `gate_with_retry` runs `enforce_manifest` on each candidate before EXPLAIN.
- `ManifestError` aborts that candidate and the served envelope is `route/layer/badge=refused`, not SESSION.
- Merged RAG-03 `main`: a manifest refusal does not fall through to the document stub.
- Does not enable `DMS_L2_ENABLED` as the serve default. C7-03 plausibility is not in this PR.

## Test plan
- [x] `pytest tests/dms/test_c7_02_manifest_before_explain.py tests/dms/test_sql_validate_gate.py tests/dms/test_c7_l2_shadow.py tests/dms/test_rag03_answer_routing.py tests/test_execution/test_submit_c4.py` (32 passed after merge)
- [ ] CI required checks
- [ ] L2 SQL outside the grant is refused with empty rows

Made with [Cursor](https://cursor.com)