### PR TITLE
C7-03: plausibility / abstain-confidence after L2 execute (#102)

### DIFF
--- a/CortexOS/dms/answer_engine.py
+++ b/CortexOS/dms/answer_engine.py
@@ -1446,6 +1446,7 @@ def answer(
     metric_slots: dict[str, Any] = {}
     skill_score: float | None = None
     planned_tables: tuple[str, ...] = ()
+    l2_retrieved: tuple[str, ...] = ()
 
     q_low = question.lower()
     prior = _SESSION.get(_session_key(session_id, space_id))
@@ -1575,6 +1576,11 @@ def answer(
             sql = l2_out.sql
             layer, badge = l2_out.layer, l2_out.badge
             assumptions = l2_out.assumptions
+            l2_retrieved = tuple(l2_out.retrieved_tables)
+            from CortexOS.dms.l2_plausibility import sql_table_names
+
+            used = tuple(sorted(sql_table_names(sql)))
+            planned_tables = used or l2_retrieved
         else:
             if l2_out is not None and not l2_out.sql:
                 if l2_out.refused or (l2_out.reason or "").startswith(
@@ -1683,6 +1689,23 @@ def answer(
 
     if not guard_result.passed:
         return _abs(f"internal SQL failed guardrail {guard_result.violations}")
+
+    if layer == "generated":
+        from CortexOS.dms.l2_plausibility import (
+            assess_plausibility,
+            leftover_literals_via_port,
+        )
+
+        used_sql = guard_result.safe_sql or sql or ""
+        trip = assess_plausibility(
+            question,
+            used_sql,
+            rows,
+            retrieved_tables=l2_retrieved,
+            leftover_literals=leftover_literals_via_port(used_sql),
+        )
+        if not trip.ok:
+            return _abs(trip.reason)
 
     truncated = total_count is not None and len(rows) >= MAX_LIMIT and total_count > len(rows)
     answer_text = synthesize_answer(rows, question)

--- a/CortexOS/dms/l2_generation.py
+++ b/CortexOS/dms/l2_generation.py
@@ -203,7 +203,9 @@ def attempt_l2(
             violations=list(gate.violations),
         )
 
-    sql = gate.safe_sql
+    # Serve pre-enforce SQL so execute_sql / enforce_manifest runs once.
+    # Post-enforce SQL re-submitted as a candidate collides local bind + grant.
+    sql = gate.source_sql or gate.safe_sql
     if promote:
         try:
             l2.record_validated(question, sql)

--- a/CortexOS/dms/l2_plausibility.py
+++ b/CortexOS/dms/l2_plausibility.py
@@ -1,0 +1,146 @@
+"""C7-03 — plausibility after L2 execute, before synthesize.
+
+Pass or abstain only. Does not generate SQL, rewrite SQL, or call
+``enforce_manifest``. Any trip returns empty rows to the caller.
+"""
+
+from __future__ import annotations
+
+import re
+from collections.abc import Sequence
+from dataclasses import dataclass
+from typing import Any
+
+import sqlglot
+from sqlglot import exp
+from sqlglot.errors import SqlglotError
+
+SCORE_CUT = 0.55
+
+_ASSERTED = re.compile(
+    r"\b(top|highest|lowest|rank|which|above|below|greater|less than|at least|"
+    r"over|under)\b",
+    re.I,
+)
+_SCALAR = re.compile(r"\b(how many|count of|average|avg\b|total\b|sum of)\b", re.I)
+
+
+@dataclass(slots=True)
+class PlausibilityResult:
+    ok: bool
+    code: str = ""
+    reason: str = ""
+
+
+def sql_table_names(sql: str) -> set[str]:
+    """Physical table names in ``sql``. Empty on parse failure (fail closed)."""
+    try:
+        tree = sqlglot.parse_one(sql, read="duckdb")
+    except SqlglotError:
+        return set()
+    if tree is None:
+        return set()
+    names: set[str] = set()
+    for table in tree.find_all(exp.Table):
+        name = (table.name or "").strip().lower()
+        if name:
+            names.add(name)
+    return names
+
+
+def assess_plausibility(
+    question: str,
+    sql: str,
+    rows: Sequence[dict[str, Any]],
+    *,
+    retrieved_tables: Sequence[str] | None = None,
+    leftover_literals: Sequence[str] | None = None,
+    score: float | None = None,
+    score_cut: float = SCORE_CUT,
+) -> PlausibilityResult:
+    """Fail-closed checks. Order is load-bearing: 1-4 override a passing score."""
+    n = len(rows)
+    q = question or ""
+
+    if n == 0 and _ASSERTED.search(q):
+        return PlausibilityResult(
+            ok=False,
+            code="implausible_empty",
+            reason="empty-success: question asserted matches but execute returned no rows",
+        )
+
+    if _SCALAR.search(q) and n > 1:
+        return PlausibilityResult(
+            ok=False,
+            code="implausible_shape",
+            reason="shape: scalar question returned a listing",
+        )
+    if n == 1 and rows:
+        row = rows[0]
+        if len(row) == 1:
+            key = next(iter(row))
+            val = row[key]
+            if isinstance(val, (int, float)) and not _SCALAR.search(q) and _ASSERTED.search(q):
+                if key.lower() in {"value", "col0", "v", "n"} or key.startswith("_"):
+                    return PlausibilityResult(
+                        ok=False,
+                        code="implausible_shape",
+                        reason="shape: listing question returned a single unlabeled number",
+                    )
+
+    retrieved = {t.strip().lower() for t in (retrieved_tables or ()) if t and t.strip()}
+    used = sql_table_names(sql)
+    if retrieved and used and used.isdisjoint(retrieved):
+        return PlausibilityResult(
+            ok=False,
+            code="implausible_tables",
+            reason="retrieval miss: SQL tables are disjoint from schema retrieval",
+        )
+    if retrieved and not used:
+        return PlausibilityResult(
+            ok=False,
+            code="implausible_tables",
+            reason="retrieval miss: SQL tables could not be analysed",
+        )
+
+    leftovers = [item for item in (leftover_literals or ()) if item]
+    if leftovers:
+        return PlausibilityResult(
+            ok=False,
+            code="implausible_literal",
+            reason=f"literal leftover: {leftovers[0]}",
+        )
+
+    if score is not None and score < score_cut:
+        return PlausibilityResult(
+            ok=False,
+            code="low_confidence",
+            reason=f"low_confidence: score {score} below {score_cut}",
+        )
+    return PlausibilityResult(ok=True)
+
+
+def leftover_literals_via_port(sql: str) -> list[str]:
+    """Ask the L2 port for un-normalized literals. Engine never imports packs."""
+    from CortexOS.dms.l2_generation import L2NotRegistered, resolve_l2_generation
+
+    try:
+        port = resolve_l2_generation()
+    except L2NotRegistered:
+        return []
+    fn = getattr(port, "leftover_literals", None)
+    if not callable(fn):
+        return []
+    try:
+        return [str(item) for item in (fn(sql) or []) if item]
+    except Exception:  # noqa: BLE001 — fail closed rather than skip the check
+        return ["LEFTOVER_CHECK_FAILED"]
+
+
+__all__ = [
+    "PlausibilityResult",
+    "SCORE_CUT",
+    "assess_plausibility",
+    "leftover_literals_via_port",
+    "sql_table_names",
+]

--- a/docs/subagents_findings/2026-09-04_c7-03-plausibility.md
+++ b/docs/subagents_findings/2026-09-04_c7-03-plausibility.md
@@ -1,0 +1,25 @@
+# C7-03: Plausibility after L2 execute
+
+- Date: 2026-09-04
+- Keywords: C7-03, plausibility, empty-success, implausible_shape, retrieval miss, leftover literals, low_confidence
+- Main idea: After L2 execute and before synthesize, `CortexOS/dms/l2_plausibility.py` can only pass or abstain. Empty-success, scalar-vs-listing, SQL tables disjoint from retrieval, leftover value-dict literals, and score below 0.55 become badge=abstain with empty rows. SQL is not rewritten. Enforcer is not skipped.
+- Path: this file
+
+## PREFLIGHT
+
+HIT. reuse: `docs/design/2026-09-04_C7_ROUTE_TO_METRIC_REPLACEMENT.md` section (c), C7-02 finding. spawn: skip (executor).
+
+## Golden rules
+
+1. Plausibility does not generate SQL and does not call `enforce_manifest`.
+2. Customer envelope: badge=abstain, rows=[], reason in assumptions.
+3. Serve pre-enforce SQL from C7-02 so `execute_sql` does not double-wrap (shadowing PathNotAllowed).
+4. Do not enable `DMS_L2_ENABLED` as the serve default (C7-05).
+
+## Verify
+
+```
+D:\Cortex\.venv\Scripts\python.exe -m pytest tests/dms/test_l2_plausibility.py tests/dms/test_c7_full_generation.py tests/dms/test_c7_l2_shadow.py tests/dms/test_c7_02_manifest_before_explain.py -q
+```
+
+Does not prove C7-05 serve, live FreeRoute quality, or numeric G-abs/G-err gates.

--- a/docs/subagents_findings/INDEX.md
+++ b/docs/subagents_findings/INDEX.md
@@ -2,6 +2,7 @@
 
 | Date | Topic | Keywords | Main idea | Path |
 |------|-------|----------|-----------|------|
+| 2026-09-04 | c7-03-plausibility | C7-03, plausibility, empty-success, implausible_shape, retrieval miss, L2_VALIDATED | After L2 execute, `l2_plausibility.assess_plausibility` abstains (badge=abstain, empty rows) on empty-success, scalar-vs-listing, retrieval-miss, leftover literals, or score below 0.55. Does not rewrite SQL or call the enforcer. | `2026-09-04_c7-03-plausibility.md` |
 | 2026-09-04 | c7-04-heldout-harness | C7-04, held-out, BIRD, Spider, must-abstain, envelope, SKU-BETA, metrics.yaml, EPIC-006 | Frozen BIRD/Spider split plus different-model abstain; harness scores envelope classes; empty rows never correct; CI fixture not live L2. | `2026-09-04_c7-04-heldout-harness.md` |
 | 2026-09-04 | wave1-ticket-closeout | SPACE-01, EVAL-01, C7-01, CI, EPIC-002, EPIC-015, auto-merge, INDEX | Engine tickets that could land without founder TTY are on github/main. RAG-02/03 were false-closed; reopened. | `2026-09-04_wave1-ticket-closeout.md` |
 | 2026-09-04 | epic-015-verify | EPIC-015, RAG-02, RAG-03, rag_answer, RAG_KEYWORDS | STATUS over-claims RAG-02/03 closed. Served RAG is a CONTRACTS_DIR file scan before L0/L1/L2; miss serves the first .txt. | `2026-09-04_epic-015-verify.md` |

--- a/packs/dms/generative/l2_adapter.py
+++ b/packs/dms/generative/l2_adapter.py
@@ -35,3 +35,11 @@ class DmsL2Generation:
         from packs.dms.generative import promotion
 
         return promotion.record_validated(question, sql)
+
+    def leftover_literals(self, sql: str) -> list[str]:
+        from packs.dms.generative.literal_normalize import normalize_sql_literals
+
+        result = normalize_sql_literals(sql)
+        if not result.ok:
+            return list(result.violations)
+        return [f"{col}:{old}->{new}" for col, old, new in result.replacements]

--- a/tests/dms/test_l2_plausibility.py
+++ b/tests/dms/test_l2_plausibility.py
@@ -106,20 +106,15 @@ def test_pass_does_not_rewrite_sql():
 
 
 def test_l2_empty_success_customer_envelope(monkeypatch):
-    from datetime import datetime, timedelta, timezone
-
-    from cortex_contract.execution import Manifest
-
     from CortexOS.dms import l2_generation
     from CortexOS.dms.answer_engine import answer
-    from CortexOS.dms.warehouse_db import KNOWN_TABLES
-    from CortexOS.execution.manifest import VerifiedManifest
 
     class _Port:
         def is_configured(self) -> bool:
             return True
 
         def retrieve_schema(self, question: str) -> dict:
+            del question
             return {"tables": {"suppliers": {}}}
 
         def generate_candidates(self, question, schema, *, prior_violations=None):
@@ -143,47 +138,25 @@ def test_l2_empty_success_customer_envelope(monkeypatch):
     monkeypatch.setattr(
         "packs.dms.semantic.catalog_answer.is_catalog_intent", lambda q: False
     )
-    when = datetime.now(timezone.utc)
-    manifest = Manifest(
-        session_id="c7-03",
-        org_id="acme",
-        pool_id="default",
-        issuer_key_id="int-1",
-        allowed_paths=["/**"],
-        row_predicates={name: "TRUE" for name in KNOWN_TABLES},
-        issued_at=when.isoformat(),
-        expires_at=(when + timedelta(minutes=5)).isoformat(),
-        signature="not-checked-here",
-    )
-    verified = VerifiedManifest(
-        manifest=manifest, issuer_kid="int-1", verified_at=when
-    )
-    r = answer(
-        "which suppliers have a risk score above 9.5?",
-        verified=verified,
-    )
+    r = answer("which suppliers have a risk score above 9.5?")
     assert r["badge"] == "abstain"
     assert r["route"] != "sql"
     assert r["rows"] == []
     assert "empty-success" in (r.get("assumptions") or "")
+    assert "empty-success" in (r.get("answer") or "")
     assert r.get("sql_used") is None
 
 
 def test_l2_retrieval_miss_customer_envelope(monkeypatch):
-    from datetime import datetime, timedelta, timezone
-
-    from cortex_contract.execution import Manifest
-
     from CortexOS.dms import l2_generation
     from CortexOS.dms.answer_engine import answer
-    from CortexOS.dms.warehouse_db import KNOWN_TABLES
-    from CortexOS.execution.manifest import VerifiedManifest
 
     class _Port:
         def is_configured(self) -> bool:
             return True
 
         def retrieve_schema(self, question: str) -> dict:
+            del question
             return {"tables": {"suppliers": {}}}
 
         def generate_candidates(self, question, schema, *, prior_violations=None):
@@ -207,26 +180,9 @@ def test_l2_retrieval_miss_customer_envelope(monkeypatch):
     monkeypatch.setattr(
         "packs.dms.semantic.catalog_answer.is_catalog_intent", lambda q: False
     )
-    when = datetime.now(timezone.utc)
-    manifest = Manifest(
-        session_id="c7-03-miss",
-        org_id="acme",
-        pool_id="default",
-        issuer_key_id="int-1",
-        allowed_paths=["/**"],
-        row_predicates={name: "TRUE" for name in KNOWN_TABLES},
-        issued_at=when.isoformat(),
-        expires_at=(when + timedelta(minutes=5)).isoformat(),
-        signature="not-checked-here",
-    )
-    verified = VerifiedManifest(
-        manifest=manifest, issuer_kid="int-1", verified_at=when
-    )
-    r = answer(
-        "which suppliers have a risk score above 0.7?",
-        verified=verified,
-    )
+    r = answer("which suppliers have a risk score above 0.7?")
     assert r["badge"] == "abstain"
     assert r["rows"] == []
     assert "retrieval miss" in (r.get("assumptions") or "")
+    assert "retrieval miss" in (r.get("answer") or "")
     assert r.get("sql_used") is None

--- a/tests/dms/test_l2_plausibility.py
+++ b/tests/dms/test_l2_plausibility.py
@@ -1,0 +1,232 @@
+"""C7-03 — plausibility stage. Envelope assertions, not SQL-only."""
+
+from __future__ import annotations
+
+from CortexOS.dms.l2_plausibility import assess_plausibility, sql_table_names
+
+
+def test_sql_table_names():
+    assert sql_table_names("SELECT sku FROM inventory LIMIT 5") == {"inventory"}
+    assert sql_table_names("SELEC bad") == set()
+
+
+def test_empty_success_abstains():
+    trip = assess_plausibility(
+        "which suppliers have a risk score above 0.7?",
+        "SELECT * FROM suppliers WHERE risk_score > 0.7",
+        [],
+        retrieved_tables=["suppliers"],
+    )
+    assert trip.ok is False
+    assert trip.code == "implausible_empty"
+
+
+def test_empty_without_assertion_passes():
+    trip = assess_plausibility(
+        "anything else in the notes",
+        "SELECT note FROM alerts LIMIT 5",
+        [],
+        retrieved_tables=["alerts"],
+    )
+    assert trip.ok is True
+
+
+def test_scalar_listing_shape():
+    trip = assess_plausibility(
+        "how many shipments are delayed?",
+        "SELECT shipment_id FROM shipments",
+        [{"shipment_id": "1"}, {"shipment_id": "2"}],
+        retrieved_tables=["shipments"],
+    )
+    assert trip.ok is False
+    assert trip.code == "implausible_shape"
+
+
+def test_retrieval_miss():
+    sql = "SELECT sku FROM inventory LIMIT 5"
+    trip = assess_plausibility(
+        "which suppliers have a risk score above 0.7?",
+        sql,
+        [{"sku": "SKU-ALPHA"}],
+        retrieved_tables=["suppliers"],
+    )
+    assert trip.ok is False
+    assert trip.code == "implausible_tables"
+    assert sql_table_names(sql) == {"inventory"}
+
+
+def test_literal_leftover():
+    sql = "SELECT sku FROM inventory WHERE sku = 'BETA'"
+    trip = assess_plausibility(
+        "stock for BETA",
+        sql,
+        [{"sku": "SKU-ALPHA"}],
+        retrieved_tables=["inventory"],
+        leftover_literals=["sku:BETA->SKU-BETA"],
+    )
+    assert trip.ok is False
+    assert trip.code == "implausible_literal"
+    assert sql == "SELECT sku FROM inventory WHERE sku = 'BETA'"
+
+
+def test_low_confidence_does_not_override_empty():
+    trip = assess_plausibility(
+        "which suppliers have a risk score above 0.7?",
+        "SELECT * FROM suppliers",
+        [],
+        retrieved_tables=["suppliers"],
+        score=0.99,
+    )
+    assert trip.code == "implausible_empty"
+
+
+def test_low_confidence_when_rows_ok():
+    trip = assess_plausibility(
+        "stock on hand",
+        "SELECT sku, quantity_kg FROM inventory LIMIT 5",
+        [{"sku": "SKU-ALPHA", "quantity_kg": 1}],
+        retrieved_tables=["inventory"],
+        score=0.4,
+    )
+    assert trip.ok is False
+    assert trip.code == "low_confidence"
+
+
+def test_pass_does_not_rewrite_sql():
+    sql = "SELECT sku FROM inventory LIMIT 5"
+    trip = assess_plausibility(
+        "list some skus",
+        sql,
+        [{"sku": "SKU-ALPHA"}],
+        retrieved_tables=["inventory"],
+        score=0.9,
+    )
+    assert trip.ok is True
+    assert sql == "SELECT sku FROM inventory LIMIT 5"
+
+
+def test_l2_empty_success_customer_envelope(monkeypatch):
+    from datetime import datetime, timedelta, timezone
+
+    from cortex_contract.execution import Manifest
+
+    from CortexOS.dms import l2_generation
+    from CortexOS.dms.answer_engine import answer
+    from CortexOS.dms.warehouse_db import KNOWN_TABLES
+    from CortexOS.execution.manifest import VerifiedManifest
+
+    class _Port:
+        def is_configured(self) -> bool:
+            return True
+
+        def retrieve_schema(self, question: str) -> dict:
+            return {"tables": {"suppliers": {}}}
+
+        def generate_candidates(self, question, schema, *, prior_violations=None):
+            del question, schema, prior_violations
+            return ["SELECT supplier_id FROM suppliers WHERE risk_score > 999999"]
+
+        def record_validated(self, question, sql):
+            del question, sql
+            return None
+
+    monkeypatch.setenv("DMS_L2_ENABLED", "1")
+    from bench.accuracy import _ensure_db_loaded
+
+    _ensure_db_loaded()
+    monkeypatch.setattr(l2_generation, "resolve_l2_generation", lambda: _Port())
+    monkeypatch.setattr("CortexOS.dms.answer_engine.match_certified", lambda q: None)
+    monkeypatch.setattr("CortexOS.dms.answer_engine.route_to_metric", lambda q: None)
+    monkeypatch.setattr("CortexOS.dms.answer_engine.undefined_subject", lambda q: None)
+    monkeypatch.setattr("CortexOS.dms.answer_engine._shape_refusal", lambda q: None)
+    monkeypatch.setattr("packs.dms.semantic.query_skills.find", lambda *a, **k: None)
+    monkeypatch.setattr(
+        "packs.dms.semantic.catalog_answer.is_catalog_intent", lambda q: False
+    )
+    when = datetime.now(timezone.utc)
+    manifest = Manifest(
+        session_id="c7-03",
+        org_id="acme",
+        pool_id="default",
+        issuer_key_id="int-1",
+        allowed_paths=["/**"],
+        row_predicates={name: "TRUE" for name in KNOWN_TABLES},
+        issued_at=when.isoformat(),
+        expires_at=(when + timedelta(minutes=5)).isoformat(),
+        signature="not-checked-here",
+    )
+    verified = VerifiedManifest(
+        manifest=manifest, issuer_kid="int-1", verified_at=when
+    )
+    r = answer(
+        "which suppliers have a risk score above 9.5?",
+        verified=verified,
+    )
+    assert r["badge"] == "abstain"
+    assert r["route"] != "sql"
+    assert r["rows"] == []
+    assert "empty-success" in (r.get("assumptions") or "")
+    assert r.get("sql_used") is None
+
+
+def test_l2_retrieval_miss_customer_envelope(monkeypatch):
+    from datetime import datetime, timedelta, timezone
+
+    from cortex_contract.execution import Manifest
+
+    from CortexOS.dms import l2_generation
+    from CortexOS.dms.answer_engine import answer
+    from CortexOS.dms.warehouse_db import KNOWN_TABLES
+    from CortexOS.execution.manifest import VerifiedManifest
+
+    class _Port:
+        def is_configured(self) -> bool:
+            return True
+
+        def retrieve_schema(self, question: str) -> dict:
+            return {"tables": {"suppliers": {}}}
+
+        def generate_candidates(self, question, schema, *, prior_violations=None):
+            del question, schema, prior_violations
+            return ["SELECT sku FROM inventory LIMIT 5"]
+
+        def record_validated(self, question, sql):
+            del question, sql
+            return None
+
+    monkeypatch.setenv("DMS_L2_ENABLED", "1")
+    from bench.accuracy import _ensure_db_loaded
+
+    _ensure_db_loaded()
+    monkeypatch.setattr(l2_generation, "resolve_l2_generation", lambda: _Port())
+    monkeypatch.setattr("CortexOS.dms.answer_engine.match_certified", lambda q: None)
+    monkeypatch.setattr("CortexOS.dms.answer_engine.route_to_metric", lambda q: None)
+    monkeypatch.setattr("CortexOS.dms.answer_engine.undefined_subject", lambda q: None)
+    monkeypatch.setattr("CortexOS.dms.answer_engine._shape_refusal", lambda q: None)
+    monkeypatch.setattr("packs.dms.semantic.query_skills.find", lambda *a, **k: None)
+    monkeypatch.setattr(
+        "packs.dms.semantic.catalog_answer.is_catalog_intent", lambda q: False
+    )
+    when = datetime.now(timezone.utc)
+    manifest = Manifest(
+        session_id="c7-03-miss",
+        org_id="acme",
+        pool_id="default",
+        issuer_key_id="int-1",
+        allowed_paths=["/**"],
+        row_predicates={name: "TRUE" for name in KNOWN_TABLES},
+        issued_at=when.isoformat(),
+        expires_at=(when + timedelta(minutes=5)).isoformat(),
+        signature="not-checked-here",
+    )
+    verified = VerifiedManifest(
+        manifest=manifest, issuer_kid="int-1", verified_at=when
+    )
+    r = answer(
+        "which suppliers have a risk score above 0.7?",
+        verified=verified,
+    )
+    assert r["badge"] == "abstain"
+    assert r["rows"] == []
+    assert "retrieval miss" in (r.get("assumptions") or "")
+    assert r.get("sql_used") is None


### PR DESCRIPTION
## Summary
- Parent **EPIC-006 / Cortex#17**. Ticket **Cortex#102**.
- After L2 execute and before synthesize, `CortexOS/dms/l2_plausibility.py` can only pass or abstain. Empty-success, scalar-vs-listing, retrieval miss, leftover literals, and score below 0.55 become `badge=abstain`, empty rows, reason in assumptions.
- Does not rewrite SQL or skip `enforce_manifest`. `attempt_l2` serves pre-enforce SQL so `execute_sql` enforces once (C7-02 PathNotAllowed double-wrap).
- Pack leftover check is on the L2 port (`leftover_literals`); engine never imports `packs.*`.

Does not enable `DMS_L2_ENABLED` as the serve default (C7-05) or delete `route_to_metric` (C7-06).

## Test plan
- [x] `D:\Cortex\.venv\Scripts\python.exe -m pytest tests/dms/test_l2_plausibility.py tests/dms/test_sql_validate_gate.py tests/dms/test_c7_l2_shadow.py tests/dms/test_c7_02_manifest_before_explain.py tests/dms/test_c7_full_generation.py -q --tb=short` (39 passed)
- [ ] Live FreeRoute quality / G-abs G-err (C7-05)

Made with [Cursor](https://cursor.com)