### PR TITLE
C7-05: live held-out engine scorer (no L2 serve cutover) (#104)

### DIFF
--- a/bench/heldout.py
+++ b/bench/heldout.py
@@ -8,13 +8,17 @@ even if gold SQL also returned nothing.
 
 The frozen split is ``bench/heldout/c7_heldout_v1.yaml``. CI invokes
 ``score_fixture`` on a tiny canned envelope set so the gate can go red
-without serving L2 or calling the answer engine.
+without serving L2 or calling the answer engine. ``score_engine`` is the
+C7-05 live path: it scores ``answer()`` envelopes and reports G-abs /
+G-err / G-env. It does not set ``DMS_L2_ENABLED`` as a process default.
 """
 from __future__ import annotations
 
 import argparse
 import json
+import os
 import re
+from collections.abc import Callable
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any
@@ -397,15 +401,97 @@ def summarize(results: list[HeldoutResult]) -> dict[str, Any]:
     must = by_split.get("must_abstain") or {"total": 0, "abstained": 0}
     must_n = int(must["total"])
     must_ok = int(must.get("abstained") or 0)
+    g_abs_recall = (must_ok / must_n) if must_n else 1.0
+    incorrect_rate = (
+        totals["incorrect"] / totals["total"] if totals["total"] else 0.0
+    )
+    g_env_hits = [
+        r.to_dict()
+        for r in results
+        if r.outcome == "incorrect"
+        and (
+            "G-env" in r.detail
+            or "SKU-BETA" in r.detail
+            or r.detail.startswith("empty rows on an answerable")
+            or r.detail.startswith("refusal badge with served rows")
+        )
+    ]
     return {
         "totals": totals,
         "by_split": by_split,
-        "g_abs_recall": (must_ok / must_n) if must_n else 1.0,
-        "incorrect_rate": (
-            totals["incorrect"] / totals["total"] if totals["total"] else 0.0
-        ),
+        "g_abs_recall": g_abs_recall,
+        "incorrect_rate": incorrect_rate,
+        "g_env_violations": len(g_env_hits),
+        "gates": {
+            "g_abs": g_abs_recall >= 1.0 and must_n > 0,
+            "g_err": incorrect_rate < 0.02,
+            "g_env": len(g_env_hits) == 0,
+        },
         "results": [r.to_dict() for r in results],
     }
+
+
+def shadow_line_count(path: Path | str | None = None) -> int:
+    """G-sh input. Missing file is 0 lines, not a hidden pass."""
+    if path is None:
+        from CortexOS.paths import data_path
+
+        target = data_path("engine", "l2_shadow.jsonl")
+    else:
+        target = Path(path)
+    if not target.is_file():
+        return 0
+    n = 0
+    with target.open(encoding="utf-8") as fh:
+        for line in fh:
+            if line.strip():
+                n += 1
+    return n
+
+
+def score_engine(
+    items: list[HeldoutItem] | None = None,
+    *,
+    ask: Callable[..., dict[str, Any]] | None = None,
+    enable_l2: bool = False,
+    count_shadow: bool = True,
+) -> dict[str, Any]:
+    """Score frozen items against ``answer()``. Does not persist L2-on.
+
+    ``enable_l2=True`` sets ``DMS_L2_ENABLED=1`` for this call only so L2 can
+    run on L0/L1 miss. The previous env value is restored. Cutover still
+    requires G-abs/G-err/G-env/G-man/G-sh on a real report.
+    """
+    rows = items if items is not None else load_heldout()
+    if ask is None:
+        from CortexOS.dms.answer_engine import answer as ask
+    prev = os.environ.get("DMS_L2_ENABLED")
+    if enable_l2:
+        os.environ["DMS_L2_ENABLED"] = "1"
+    results: list[HeldoutResult] = []
+    try:
+        for item in rows:
+            env = ask(item.question)
+            if not isinstance(env, dict):
+                env = {}
+            results.append(score_envelope(item, env))
+    finally:
+        if enable_l2:
+            if prev is None:
+                os.environ.pop("DMS_L2_ENABLED", None)
+            else:
+                os.environ["DMS_L2_ENABLED"] = prev
+    report = summarize(results)
+    report["engine"] = True
+    report["l2_enabled_for_run"] = enable_l2
+    if count_shadow:
+        report["shadow_lines"] = shadow_line_count()
+    else:
+        report["shadow_lines"] = 0
+    report["gates"]["g_sh"] = report["shadow_lines"] >= 500
+    report["gates"]["g_man"] = None  # pytest tests/test_execution, not this harness
+    report["cutover"] = False
+    return report
 
 
 def load_fixture(path: Path | str) -> tuple[list[HeldoutItem], dict[str, dict[str, Any]]]:
@@ -444,14 +530,31 @@ def main() -> None:
         default=None,
         help="YAML with items + envelopes (CI path; no live serve)",
     )
+    parser.add_argument(
+        "--engine",
+        action="store_true",
+        help="score frozen items via answer(); does not persist DMS_L2_ENABLED",
+    )
+    parser.add_argument(
+        "--enable-l2",
+        action="store_true",
+        help="with --engine, set DMS_L2_ENABLED=1 for this process run only",
+    )
     parser.add_argument("--json", default=None, help="write report JSON")
     args = parser.parse_args()
-    if not args.fixture:
-        parser.error(
-            "pass --fixture PATH; live engine scoring is C7-05, not this harness default"
-        )
-    report = score_fixture(args.fixture)
-    print(json.dumps(report["totals"]))
+    if args.engine:
+        report = score_engine(enable_l2=args.enable_l2)
+        print(json.dumps({
+            "totals": report["totals"],
+            "gates": report["gates"],
+            "cutover": report["cutover"],
+            "shadow_lines": report["shadow_lines"],
+        }))
+    elif args.fixture:
+        report = score_fixture(args.fixture)
+        print(json.dumps(report["totals"]))
+    else:
+        parser.error("pass --fixture PATH or --engine")
     if args.json:
         Path(args.json).write_text(json.dumps(report, indent=2), encoding="utf-8")
 

--- a/docs/subagents_findings/2026-09-04_c7-05-engine-scorer.md
+++ b/docs/subagents_findings/2026-09-04_c7-05-engine-scorer.md
@@ -1,0 +1,18 @@
+# C7-05: live held-out engine scorer (no serve cutover)
+
+- Date: 2026-09-04
+- Keywords: C7-05, held-out, score_engine, G-abs, G-err, G-env, G-sh, DMS_L2_ENABLED
+- Main idea: `bench/heldout.py --engine` scores frozen items via `answer()` envelopes and reports G-abs/G-err/G-env. `--enable-l2` is process-local and restored. `cutover` stays false. Do not set `DMS_L2_ENABLED` as the serve default until G-man + G-sh also pass on a real report.
+- Path: this file
+
+## PREFLIGHT
+
+PARTIAL. reuse: `2026-09-04_c7-04-heldout-harness.md`, `2026-09-04_c7-03-plausibility.md`. spawn: skip (executor).
+
+## Verify
+
+```
+D:\Cortex\.venv\Scripts\python.exe -m pytest tests/dms/test_c7_heldout.py -q --tb=short
+```
+
+Does not prove: live FreeRoute quality, G-sh >= 500 shadow lines, or L2-on-miss serve.

--- a/docs/subagents_findings/INDEX.md
+++ b/docs/subagents_findings/INDEX.md
@@ -2,6 +2,7 @@
 
 | Date | Topic | Keywords | Main idea | Path |
 |------|-------|----------|-----------|------|
+| 2026-09-04 | c7-05-engine-scorer | C7-05, held-out, score_engine, G-abs, G-err, G-env, DMS_L2_ENABLED | Live engine scorer on frozen items; L2 env is process-local; cutover stays false until G-man/G-sh too. | `2026-09-04_c7-05-engine-scorer.md` |
 | 2026-09-04 | c7-03-plausibility | C7-03, plausibility, empty-success, implausible_shape, retrieval miss, L2_VALIDATED | After L2 execute, `l2_plausibility.assess_plausibility` abstains (badge=abstain, empty rows) on empty-success, scalar-vs-listing, retrieval-miss, leftover literals, or score below 0.55. Does not rewrite SQL or call the enforcer. | `2026-09-04_c7-03-plausibility.md` |
 | 2026-09-04 | c7-04-heldout-harness | C7-04, held-out, BIRD, Spider, must-abstain, envelope, SKU-BETA, metrics.yaml, EPIC-006 | Frozen BIRD/Spider split plus different-model abstain; harness scores envelope classes; empty rows never correct; CI fixture not live L2. | `2026-09-04_c7-04-heldout-harness.md` |
 | 2026-09-04 | wave1-ticket-closeout | SPACE-01, EVAL-01, C7-01, CI, EPIC-002, EPIC-015, auto-merge, INDEX | Engine tickets that could land without founder TTY are on github/main. RAG-02/03 were false-closed; reopened. | `2026-09-04_wave1-ticket-closeout.md` |

--- a/tests/dms/test_c7_heldout.py
+++ b/tests/dms/test_c7_heldout.py
@@ -171,3 +171,68 @@ def test_dms_envelope_spelling_is_accepted():
         "route": "sql",
     }
     assert score_envelope(item, env_ok).outcome == "correct"
+
+
+def test_score_engine_uses_ask_callable_not_live_l2():
+    import os
+
+    from bench.heldout import score_engine
+
+    item = HeldoutItem(
+        id="must_abs",
+        split="must_abstain",
+        provenance="different_model_abstain",
+        question="esg plus berlin weather 1997",
+        expect="abstain",
+    )
+    os.environ.pop("DMS_L2_ENABLED", None)
+    seen: dict[str, str | None] = {}
+
+    def ask(question: str) -> dict:
+        seen["flag"] = os.environ.get("DMS_L2_ENABLED")
+        del question
+        return {
+            "answer": "I can't answer that.",
+            "rows": [],
+            "badge": "abstain",
+            "route": "needs_clarification",
+        }
+
+    report = score_engine(
+        [item], ask=ask, enable_l2=True, count_shadow=False
+    )
+    assert seen["flag"] == "1"
+    assert os.environ.get("DMS_L2_ENABLED") is None
+    assert report["totals"]["abstained"] == 1
+    assert report["gates"]["g_abs"] is True
+    assert report["cutover"] is False
+    assert report["l2_enabled_for_run"] is True
+
+
+def test_score_engine_does_not_claim_cutover_when_g4_empty_success():
+    from bench.heldout import score_engine
+
+    item = HeldoutItem(
+        id="sql_empty",
+        split="sql",
+        provenance="bird_style",
+        question="how many skus",
+        expect="correct_rows",
+        match="scalar",
+        key_columns=["n"],
+        expected_rows=[{"n": 4}],
+    )
+
+    def ask(question: str) -> dict:
+        del question
+        return {
+            "answer": "none",
+            "rows": [],
+            "badge": "L2_VALIDATED",
+            "route": "sql",
+        }
+
+    report = score_engine([item], ask=ask, count_shadow=False)
+    assert report["totals"]["incorrect"] == 1
+    assert report["gates"]["g_env"] is False
+    assert report["cutover"] is False


### PR DESCRIPTION
## Summary
- Parent **EPIC-006 / Cortex#17**. Ticket **Cortex#104** (measurement only).
- `bench/heldout.py --engine` scores the frozen split through `answer()` envelopes and reports G-abs / G-err / G-env.
- `--enable-l2` sets `DMS_L2_ENABLED=1` for that process run only and restores the previous value. `cutover` stays false.
- Does **not** enable L2 as the serve default. G-man (`pytest tests/test_execution`) and G-sh (>=500 shadow lines) are still required before C7-05 cutover.

Stacked on `cursor/c7-03-plausibility` (PR #123). Retarget to `main` after that lands.

## Test plan
- [x] `D:\Cortex\.venv\Scripts\python.exe -m pytest tests/dms/test_c7_heldout.py -q --tb=short` (11 passed)
- [ ] Live FreeRoute scoring of `c7_heldout_v1.yaml`
- [ ] Do not merge as C7-05 complete until G-abs/G-err/G-env/G-man/G-sh all pass on a real report

Made with [Cursor](https://cursor.com)