### PR TITLE
VQ-01: categoty synonym hits certified top-3 category sales (dms#39)

### DIFF
--- a/CortexOS/dms/answer_engine.py
+++ b/CortexOS/dms/answer_engine.py
@@ -1491,27 +1491,25 @@ def answer(
         refused = _shape_refusal(question)
         if refused:
             return _abs(refused)
-        unknown = undefined_subject(question)
-        if unknown:
-            named = ", ".join(_answerable_entities())
-            return _abs(
-                f"the question names '{unknown}', which the semantic layer does "
-                f"not define; it can answer about {named}"
-            )
         cq = match_certified(question)
         if cq is not None:
             sql, layer, badge = cq.sql, "certified", "certified"
             assumptions = f"certified query {cq.id}"
             metric_id = cq.id
             planned_tables = tuple(cq.tables)
-            # VQ-01 — certified SQL is a trusted asset; literals still must
-            # match the column encoding (BETA → SKU-BETA). Unresolved → abstain.
             from packs.dms.semantic.loader import normalize_certified_sql
 
             sql, violations = normalize_certified_sql(cq)
             if violations:
                 return _abs(f"certified query {cq.id} unresolved literal {violations}")
-        else:
+        if sql is None:
+            unknown = undefined_subject(question)
+            if unknown:
+                named = ", ".join(_answerable_entities())
+                return _abs(
+                    f"the question names '{unknown}', which the semantic layer does "
+                    f"not define; it can answer about {named}"
+                )
             plan = route_to_metric(question)
             if plan is not None:
                 from packs.dms.semantic.loader import SemanticError, compile_metric, load_all

--- a/packs/dms/semantic/certified_queries.yaml
+++ b/packs/dms/semantic/certified_queries.yaml
@@ -170,3 +170,21 @@ certified:
     verified_by: seed
     verified_at: "2026-07-20"
     tags: [suppliers, time]
+
+  - id: cq_top3_category_sales
+    question: "show top 3 category sales"
+    synonyms:
+      - "show top 3 categoty sales"
+      - "top 3 category sales"
+    sql: >
+      SELECT i.category,
+             ROUND(SUM(t.quantity_kg * t.unit_cost_myr), 2) AS sales_value_myr
+      FROM transactions t
+      JOIN inventory i ON t.sku = i.sku
+      WHERE t.txn_type = 'OUT'
+      GROUP BY i.category
+      ORDER BY sales_value_myr DESC, i.category ASC
+      LIMIT 3
+    verified_by: seed
+    verified_at: "2026-09-04"
+    tags: [sales, rank]

--- a/tests/dms/test_certified_synonyms.py
+++ b/tests/dms/test_certified_synonyms.py
@@ -87,3 +87,28 @@ def test_value_norm_lookup_hits_certified_canonical(monkeypatch):
     hit = ae.match_certified("stock of BETA")
     assert hit is not None
     assert hit.id == "cq_beta"
+
+
+def test_categoty_typo_hits_certified_top3_category_sales():
+    """VQ-01: curated synonym, not product-intent regex. Envelope on answer()."""
+    cq = match_certified("show top 3 categoty sales")
+    assert cq is not None
+    assert cq.id == "cq_top3_category_sales"
+
+    from CortexOS.dms.answer_engine import answer
+
+    r = answer("show top 3 categoty sales")
+    assert r["layer"] == "certified", r.get("answer")
+    assert r["badge"] == "certified"
+    assert r["route"] == "sql"
+    rows = r.get("rows") or []
+    assert len(rows) == 3, f"expected 3 category rows, got {len(rows)}: {r.get('answer')!r}"
+    text = r.get("answer") or ""
+    assert text.strip()
+    prev = None
+    for row in rows:
+        cat = str(row["category"])
+        val = float(row["sales_value_myr"])
+        assert cat in text
+        assert prev is None or val <= prev
+        prev = val


### PR DESCRIPTION
## Summary
- Parent **DMS EPIC-019 / dms#39**. Curated synonym `show top 3 categoty sales` on `cq_top3_category_sales`.
- L0 `match_certified` runs **before** `undefined_subject`, so a declared typo is not an unknown noun. L1 `route_to_metric` stays after unknown-noun so `customers` cannot become a SKU rank.
- Engine envelope: `layer/badge=certified`, 3 ranked category rows. DMS already maps `certified` -> `L0_CERTIFIED`.

No product-intent regex for the typo. Does not enable `DMS_L2_ENABLED`.

## Test plan
- [x] `D:\Cortex\.venv\Scripts\python.exe -m pytest tests/dms/test_certified_synonyms.py tests/dms/test_unknown_subject_abstain.py -q --tb=short` (17 passed)

Made with [Cursor](https://cursor.com)