### PR TITLE
VQ-01: lot-deduped top-3 category sales certified asset (dms#39)

### DIFF
--- a/packs/dms/semantic/certified_queries.yaml
+++ b/packs/dms/semantic/certified_queries.yaml
@@ -171,19 +171,23 @@ certified:
     verified_at: "2026-07-20"
     tags: [suppliers, time]
 
+  # inventory is one row per lot (~14.5 lots/SKU). JOIN inventory ON sku
+  # fans outbound sales ~14.8x and can flip rank (FOOD_DRY vs FOOD_COLD).
   - id: cq_top3_category_sales
     question: "show top 3 category sales"
     synonyms:
       - "show top 3 categoty sales"
+      - "top 3 categoty sales"
       - "top 3 category sales"
+      - "top 3 categories by sales value"
     sql: >
-      SELECT i.category,
+      SELECT c.category,
              ROUND(SUM(t.quantity_kg * t.unit_cost_myr), 2) AS sales_value_myr
       FROM transactions t
-      JOIN inventory i ON t.sku = i.sku
+      JOIN (SELECT DISTINCT sku, category FROM inventory) c ON t.sku = c.sku
       WHERE t.txn_type = 'OUT'
-      GROUP BY i.category
-      ORDER BY sales_value_myr DESC, i.category ASC
+      GROUP BY c.category
+      ORDER BY sales_value_myr DESC, c.category ASC
       LIMIT 3
     verified_by: seed
     verified_at: "2026-09-04"

--- a/tests/dms/test_certified_synonyms.py
+++ b/tests/dms/test_certified_synonyms.py
@@ -98,14 +98,54 @@ TOP3_CATEGORY_SALES_PHRASES = (
     "top 3 categories by sales value",
 )
 
-# Warehouse OUT revenue by category after DISTINCT sku, category (lot dedupe).
-# Naive JOIN inventory ON sku inflates ~14.8x (ELECTRONICS 133,931,869.04).
-EXPECTED_TOP3_CATEGORY_SALES = (
-    ("ELECTRONICS", 8_953_922.60),
-    ("CHEMICALS", 8_799_446.70),
-    ("FOOD_COLD", 8_754_427.11),
-)
-NAIVE_JOIN_ELECTRONICS_MYR = 133_931_869.04
+# Independent of certified YAML: map sku -> category via GROUP BY, not DISTINCT.
+_ORACLE_CATEGORY_SALES = """
+SELECT m.category,
+       ROUND(SUM(t.quantity_kg * t.unit_cost_myr), 2) AS sales_value_myr
+FROM transactions t
+JOIN (
+    SELECT sku, MIN(category) AS category
+    FROM inventory
+    GROUP BY sku
+) m ON t.sku = m.sku
+WHERE t.txn_type = 'OUT'
+GROUP BY m.category
+ORDER BY sales_value_myr DESC, m.category ASC
+"""
+_NAIVE_LOT_JOIN_TOP = """
+SELECT i.category,
+       ROUND(SUM(t.quantity_kg * t.unit_cost_myr), 2) AS sales_value_myr
+FROM transactions t
+JOIN inventory i ON t.sku = i.sku
+WHERE t.txn_type = 'OUT'
+GROUP BY i.category
+ORDER BY sales_value_myr DESC, i.category ASC
+LIMIT 1
+"""
+_OUT_REVENUE = """
+SELECT ROUND(SUM(quantity_kg * unit_cost_myr), 2)
+FROM transactions WHERE txn_type = 'OUT'
+"""
+
+
+def _category_sales_oracle():
+    from CortexOS.dms.warehouse_db import DEFAULT_DB, get_connection
+
+    con = get_connection(DEFAULT_DB, read_only=True)
+    try:
+        overall = float(con.execute(_OUT_REVENUE).fetchone()[0])
+        all_rows = [
+            (str(r[0]), float(r[1])) for r in con.execute(_ORACLE_CATEGORY_SALES).fetchall()
+        ]
+        naive_top = float(con.execute(_NAIVE_LOT_JOIN_TOP).fetchone()[1])
+        mixed = con.execute(
+            "SELECT COUNT(*) FROM ("
+            "SELECT sku FROM inventory GROUP BY sku "
+            "HAVING COUNT(DISTINCT category) > 1)"
+        ).fetchone()[0]
+    finally:
+        con.close()
+    return overall, all_rows, naive_top, int(mixed)
 
 
 @pytest.mark.parametrize("phrase", TOP3_CATEGORY_SALES_PHRASES)
@@ -134,13 +174,22 @@ def test_categoty_typo_hits_certified_top3_category_sales():
     assert len(rows) == 3, f"expected 3 category rows, got {len(rows)}: {r.get('answer')!r}"
     text = r.get("answer") or ""
     assert text.strip()
+
+    overall, oracle_all, naive_top, mixed_sku = _category_sales_oracle()
+    assert mixed_sku == 0, "DISTINCT sku, category is unsafe if a SKU has two categories"
+    oracle_sum = round(sum(v for _, v in oracle_all), 2)
+    assert oracle_sum == pytest.approx(overall, abs=0.011)
+    assert naive_top > overall, (
+        f"naive lot JOIN should exceed OUT revenue ({naive_top} vs {overall})"
+    )
+    expected = oracle_all[:3]
     got = [(str(row["category"]), float(row["sales_value_myr"])) for row in rows]
-    assert [c for c, _ in got] == [c for c, _ in EXPECTED_TOP3_CATEGORY_SALES]
-    for (cat, val), (exp_cat, exp_val) in zip(got, EXPECTED_TOP3_CATEGORY_SALES, strict=True):
+    assert [c for c, _ in got] == [c for c, _ in expected]
+    blob = (text + str(rows)).replace(",", "")
+    for (cat, val), (exp_cat, exp_val) in zip(got, expected, strict=True):
         assert cat == exp_cat
         assert val == pytest.approx(exp_val, abs=0.011)
+        assert val < overall, f"{cat}={val} exceeds OUT total {overall} (lot fan-out)"
         assert cat in text
         assert str(int(exp_val)) in text.replace(",", "")
-    assert "FOOD_DRY" not in {c for c, _ in got}
-    blob = text.replace(",", "") + str(rows)
-    assert f"{NAIVE_JOIN_ELECTRONICS_MYR:.2f}".replace(",", "") not in blob.replace(",", "")
+        assert f"{int(naive_top)}" not in blob

--- a/tests/dms/test_certified_synonyms.py
+++ b/tests/dms/test_certified_synonyms.py
@@ -89,6 +89,35 @@ def test_value_norm_lookup_hits_certified_canonical(monkeypatch):
     assert hit.id == "cq_beta"
 
 
+# Canonical + curated synonyms (F32 typo `categoty` included). Not intent regex.
+TOP3_CATEGORY_SALES_PHRASES = (
+    "show top 3 category sales",
+    "show top 3 categoty sales",
+    "top 3 categoty sales",
+    "top 3 category sales",
+    "top 3 categories by sales value",
+)
+
+# Warehouse OUT revenue by category after DISTINCT sku, category (lot dedupe).
+# Naive JOIN inventory ON sku inflates ~14.8x (ELECTRONICS 133,931,869.04).
+EXPECTED_TOP3_CATEGORY_SALES = (
+    ("ELECTRONICS", 8_953_922.60),
+    ("CHEMICALS", 8_799_446.70),
+    ("FOOD_COLD", 8_754_427.11),
+)
+NAIVE_JOIN_ELECTRONICS_MYR = 133_931_869.04
+
+
+@pytest.mark.parametrize("phrase", TOP3_CATEGORY_SALES_PHRASES)
+def test_match_certified_hits_top3_category_sales(phrase: str):
+    cq = match_certified(phrase)
+    assert cq is not None, phrase
+    assert cq.id == "cq_top3_category_sales"
+    compact = " ".join(cq.sql.split()).lower()
+    assert "select distinct sku, category from inventory" in compact
+    assert "join inventory i on t.sku = i.sku" not in compact
+
+
 def test_categoty_typo_hits_certified_top3_category_sales():
     """VQ-01: curated synonym, not product-intent regex. Envelope on answer()."""
     cq = match_certified("show top 3 categoty sales")
@@ -105,10 +134,13 @@ def test_categoty_typo_hits_certified_top3_category_sales():
     assert len(rows) == 3, f"expected 3 category rows, got {len(rows)}: {r.get('answer')!r}"
     text = r.get("answer") or ""
     assert text.strip()
-    prev = None
-    for row in rows:
-        cat = str(row["category"])
-        val = float(row["sales_value_myr"])
+    got = [(str(row["category"]), float(row["sales_value_myr"])) for row in rows]
+    assert [c for c, _ in got] == [c for c, _ in EXPECTED_TOP3_CATEGORY_SALES]
+    for (cat, val), (exp_cat, exp_val) in zip(got, EXPECTED_TOP3_CATEGORY_SALES, strict=True):
+        assert cat == exp_cat
+        assert val == pytest.approx(exp_val, abs=0.011)
         assert cat in text
-        assert prev is None or val <= prev
-        prev = val
+        assert str(int(exp_val)) in text.replace(",", "")
+    assert "FOOD_DRY" not in {c for c, _ in got}
+    blob = text.replace(",", "") + str(rows)
+    assert f"{NAIVE_JOIN_ELECTRONICS_MYR:.2f}".replace(",", "") not in blob.replace(",", "")


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Parent: [Netie-AI/dms#39](https://github.com/Netie-AI/dms/issues/39) (VQ-01 / EPIC-019). Cortex pack half only. Does not attach Cortex#4 / #41 / #42 / #43 / #44.

## Why

`cq_top3_category_sales` landed in #125 with the F32 `categoty` synonym, but the SQL was a naive `JOIN inventory ON sku`. Inventory is one row per **lot**, so that fan-out inflates outbound sales ~14.8x and can flip rank. A certified badge on those numbers is worse than abstain.

## What

- Certified SQL uses `JOIN (SELECT DISTINCT sku, category FROM inventory)` so category sales conserve overall OUT revenue.
- Curated synonyms (collision-free, no product intent regex):
  - `show top 3 categoty sales`
  - `top 3 categoty sales`
  - `top 3 category sales`
  - `top 3 categories by sales value`
- Tests: `match_certified` hits this asset for those phrases. `answer("show top 3 categoty sales")` must match an independent `GROUP BY sku` oracle, conserve `SUM(OUT)`, stay below that total per category, and must not emit the naive lot-JOIN magnitude.

The dms#39 snapshot (ELECTRONICS 8,953,922.60 / CHEMICALS 8,799,446.70 / FOOD_COLD 8,754,427.11) is the founder's local `dms_demo.duckdb`. CI and this agent load `data/samples/*.csv` (this run: FOOD_DRY / ELECTRONICS / PPE, OUT 80,787,598.30). Conservation is the invariant that survives both warehouses; wrong-sheet/lot-fan-out SQL is not certified.

## Out of scope

Studio UI (VQ-02). gen-cFSM / JEPA / DAG-chooser. Engine `match_certified` rewrite. STATUS/CHANGELOG.

Draft on purpose: independent verify before close; do not merge from this run.

## Local verify

```
PYTHONPATH=/workspace:/workspace/packages python3 -m pytest tests/dms/test_certified_synonyms.py tests/dms/test_ans03_grouped_ranking.py -q
```

15 passed.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-9daadc3a-435b-42b4-888f-4495821617ac?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-9daadc3a-435b-42b4-888f-4495821617ac&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

