### PR TITLE
C7-06: retire route_to_metric as serve chooser (gated, no invent-green) (#105)

### DIFF
--- a/CHANGELOG_DMS.md
+++ b/CHANGELOG_DMS.md
@@ -139,6 +139,15 @@ add `leases` / `lease_owner`. Chrome Claim/Release calls those POSTs; 409/403 to
 with no silent retry. Does not write CLAIMS.json. Local `tests/test_crew` 208 passed.
 Does not prove live `:8020` until restart.
 
+## C7-06: retire route_to_metric as serve chooser (gated) — 2026-09-04
+
+`answer()` now picks L1 via `choose_governed_metric`, not `route_to_metric`
+directly. The keyword cascade still serves until a held-out report shows
+L2-as-L1-replacement beating L1 on G-err with G-abs still holding, **and**
+`DMS_C7_RETIRE_CASCADE=1`. A flag, `DMS_L2_ENABLED`, or JSON `cutover: true`
+cannot invent that. Slot extractors stay. The 25 `_metric_plan` branches are
+not deleted (no held-out numbers yet). `cutover` stays false. Cortex#105.
+
 ## Engine capability: cost ledger + DAG parallel + T0 routing — 2026-08-28
 
 General Cortex engine (not DMS-specific):

--- a/CortexOS/dms/answer_engine.py
+++ b/CortexOS/dms/answer_engine.py
@@ -5,11 +5,14 @@ abstains rather than guess. This is the "adaptive, fail-then-escalate" core:
 
   L0 CERTIFIED   exact (normalized) match against the verified-query repo →
                  deterministic replay. Highest trust, zero LLM.
-  L1 METRIC      rule-based intent+slot routing → compile a governed metric
-                 template (Q1) → guardrail-verified SQL. Deterministic.
-  L2 FREEFORM    (flag DMS_L2_ENABLED, default OFF) sampled LLM SQL →
-                 parse+allowlist+execute+plausibility. Badge L2_VALIDATED only
-                 after plausibility. Not the process default (C7-05).
+  L1 METRIC      choose_governed_metric → compile a governed metric template
+                 (Q1) → guardrail-verified SQL. Default chooser is the
+                 keyword cascade. C7-06 skips it only when L2-as-L1
+                 replacement beats L1 on G-err and G-abs still holds.
+  L2 FREEFORM    (flag DMS_L2_ENABLED, default OFF) schema retrieval →
+                 generate → sqlglot → enforce_manifest → EXPLAIN → retry →
+                 plausibility. Badge L2_VALIDATED only after plausibility.
+                 Not the process default (C7-05).
   L3 ABSTAIN     no trustworthy layer fired → clarify + suggest nearest
                  answerable questions. Never the old confident-wrong fallback.
 
@@ -25,6 +28,7 @@ from typing import Any
 
 import sqlglot
 
+from CortexOS.dms.c7_cutover import cascade_retired
 from CortexOS.dms.sql_guardrail import (
     MAX_LIMIT,
     AuditEntry,
@@ -1046,6 +1050,18 @@ def route_to_metric(question: str) -> MetricPlan | None:
     return _plan_from_declared_synonyms(q, q_raw)
 
 
+def choose_governed_metric(question: str) -> MetricPlan | None:
+    """Serve chooser for L1. Not ``route_to_metric`` once C7-06 gates pass.
+
+    Slot extractors (``_days``, ``_explicit_limit``, ``_sales_rank_slots``)
+    stay on this module for L0 / query-skill. The cascade classifier remains
+    callable for tests; ``answer()`` must not use it as chooser when retired.
+    """
+    if cascade_retired():
+        return None
+    return route_to_metric(question)
+
+
 # ── truncation-honest total ──────────────────────────────────────────────────
 def _true_count(
     sql: str,
@@ -1772,7 +1788,7 @@ def answer(
                     f"the question names '{unknown}', which the semantic layer does "
                     f"not define; it can answer about {named}"
                 )
-            plan = route_to_metric(question)
+            plan = choose_governed_metric(question)
             if plan is not None:
                 from packs.dms.semantic.loader import SemanticError, compile_metric, load_all
 

--- a/CortexOS/dms/c7_cutover.py
+++ b/CortexOS/dms/c7_cutover.py
@@ -1,0 +1,137 @@
+"""C7-06 — ``route_to_metric`` is not the serve chooser once L2 beats L1.
+
+The 25 ``_metric_plan`` branches stay until a commit body carries held-out
+numbers. A flag or a JSON ``cutover: true`` cannot invent that. Keyword slot
+helpers remain on ``answer_engine`` for L0 / query-skill slots.
+"""
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+from typing import Any
+
+G_ERR_MAX = 0.02
+
+
+def _env_on(name: str) -> bool:
+    return os.environ.get(name, "").lower() in ("1", "true", "yes")
+
+
+def l2_enabled() -> bool:
+    return _env_on("DMS_L2_ENABLED")
+
+
+def retire_cascade_requested() -> bool:
+    return _env_on("DMS_C7_RETIRE_CASCADE")
+
+
+def load_cutover_report(path: str | None = None) -> dict[str, Any] | None:
+    raw = path if path is not None else os.environ.get("DMS_C7_CUTOVER_REPORT", "")
+    raw = (raw or "").strip()
+    if not raw:
+        return None
+    target = Path(raw)
+    if not target.is_file():
+        return None
+    try:
+        data = json.loads(target.read_text(encoding="utf-8"))
+    except (OSError, UnicodeDecodeError, json.JSONDecodeError):
+        return None
+    return data if isinstance(data, dict) else None
+
+
+def _totals(report: dict[str, Any]) -> dict[str, Any]:
+    totals = report.get("totals")
+    return totals if isinstance(totals, dict) else {}
+
+
+def incorrect_count(report: dict[str, Any]) -> int:
+    try:
+        return int(_totals(report).get("incorrect") or 0)
+    except (TypeError, ValueError):
+        return 0
+
+
+def incorrect_rate(report: dict[str, Any]) -> float:
+    raw = report.get("incorrect_rate")
+    if raw is not None:
+        try:
+            return float(raw)
+        except (TypeError, ValueError):
+            return 1.0
+    totals = _totals(report)
+    try:
+        total = int(totals.get("total") or 0)
+        bad = int(totals.get("incorrect") or 0)
+    except (TypeError, ValueError):
+        return 1.0
+    return (bad / total) if total else 1.0
+
+
+def g_abs_holds(report: dict[str, Any]) -> bool:
+    gates = report.get("gates")
+    if isinstance(gates, dict) and "g_abs" in gates:
+        return bool(gates["g_abs"])
+    recall = report.get("g_abs_recall")
+    if recall is None:
+        return False
+    try:
+        return float(recall) >= 1.0
+    except (TypeError, ValueError):
+        return False
+
+
+def g_err_holds(report: dict[str, Any]) -> bool:
+    gates = report.get("gates")
+    if isinstance(gates, dict) and "g_err" in gates:
+        if not gates["g_err"]:
+            return False
+        return incorrect_rate(report) < G_ERR_MAX
+    return incorrect_rate(report) < G_ERR_MAX
+
+
+def l2_replaces_l1(
+    l1_report: dict[str, Any] | None,
+    l2_report: dict[str, Any] | None,
+) -> bool:
+    """True only when L2-as-L1-replacement beats L1 on G-err and G-abs holds.
+
+    G-err: L2 incorrect < 2% and <= L1 incorrect on the same items. L2 must
+    have run with the cascade skipped; an L2-on-miss (C7-05) report cannot
+    retire the chooser.
+    """
+    if not isinstance(l1_report, dict) or not isinstance(l2_report, dict):
+        return False
+    if not l2_report.get("cascade_skipped"):
+        return False
+    if not g_abs_holds(l1_report) or not g_abs_holds(l2_report):
+        return False
+    if not g_err_holds(l2_report):
+        return False
+    return incorrect_count(l2_report) <= incorrect_count(l1_report)
+
+
+def cutover_flags(report: dict[str, Any] | None = None) -> dict[str, Any]:
+    """Operator-visible flags. ``cutover`` is never inferred from a file."""
+    data = report if report is not None else load_cutover_report()
+    l1 = l2 = None
+    if isinstance(data, dict):
+        l1 = data.get("l1")
+        l2 = data.get("l2_as_l1_replacement")
+    replaces = l2_replaces_l1(
+        l1 if isinstance(l1, dict) else None,
+        l2 if isinstance(l2, dict) else None,
+    )
+    requested = retire_cascade_requested()
+    return {
+        "l2_enabled": l2_enabled(),
+        "retire_cascade_requested": requested,
+        "l2_replaces_l1": replaces,
+        "cascade_retired": bool(requested and replaces),
+        "cutover": False,
+    }
+
+
+def cascade_retired() -> bool:
+    return bool(cutover_flags()["cascade_retired"])

--- a/STATUS.md
+++ b/STATUS.md
@@ -1,5 +1,12 @@
 # STATUS.md
-**Last updated:** 2026-09-07 | **Gate:** G2.3 OSR **SHIPPED** | **Active:** C7-02..06; EPIC-015 RAG served-path; GOLD-01 founder TTY; **CREW-INSIGHTS**
+**Last updated:** 2026-09-09 | **Gate:** G2.3 OSR **SHIPPED** | **Active:** C7-06 draft #128 (gated chooser); EPIC-015 RAG served-path; GOLD-01 founder TTY; **CREW-INSIGHTS**
+
+> **2026-09-09 (C7-06 rebase):** `choose_governed_metric` is the L1 serve chooser.
+> Default still calls `route_to_metric`. Cascade is skipped only when
+> `DMS_C7_RETIRE_CASCADE=1` and a cutover report shows L2-as-L1-replacement
+> beating L1 on G-err with G-abs holding (`cascade_skipped` true). A C7-05
+> L2-on-miss `score_engine` report cannot retire. `cutover` stays false. Did
+> not delete the 25 `_metric_plan` branches. Stay draft. Cortex#105.
 
 > **2026-09-07 (CREW-INSIGHTS):** Cortex #196 ask+ontology spine. Intent retrieves
 > ontology **where** (object/table locations) and **importance** (ranked metrics /

--- a/docs/subagents_findings/2026-09-04_c7-06-retire-cascade.md
+++ b/docs/subagents_findings/2026-09-04_c7-06-retire-cascade.md
@@ -7,7 +7,7 @@
 
 ## PREFLIGHT
 
-PARTIAL. reuse: `docs/design/2026-09-04_C7_ROUTE_TO_METRIC_REPLACEMENT.md` C7-06, `2026-09-04_c7-design-and-shadow-mode.md`, `2026-09-04_c7-04-heldout-harness.md`. spawn: skip (executor). C7-05 PR #126 left untouched.
+PARTIAL. reuse: `docs/design/2026-09-04_C7_ROUTE_TO_METRIC_REPLACEMENT.md` C7-06, `2026-09-04_c7-design-and-shadow-mode.md`, `2026-09-04_c7-04-heldout-harness.md`, `2026-09-04_c7-05-engine-scorer.md`. spawn: skip (executor). Rebased onto origin/main after C7-05 #126/#143 landed.
 
 ## Golden rules
 
@@ -21,6 +21,12 @@ PARTIAL. reuse: `docs/design/2026-09-04_C7_ROUTE_TO_METRIC_REPLACEMENT.md` C7-06
 
 ```
 python -m pytest tests/dms/test_c7_06_retire_cascade.py tests/dms/test_q2_answer_engine.py tests/dms/test_c7_l2_shadow.py tests/dms/test_c7_full_generation.py -q
+python -m bench.heldout --engine
 ```
 
 Does not prove: live FreeRoute L2-as-L1-replacement, G-sh >= 500, or that the cascade can be deleted.
+
+## Live L1 after rebase onto C7-05 main (2026-09-04)
+
+`python -m bench.heldout --engine` (DMS_L2_ENABLED unset): 28 items, 1 correct / 27 abstained / 0 incorrect. G-abs/G-err/G-env true. G-sh 0 lines. `cutover` false. This is **L1 cascade**, not L2-as-L1-replacement (`cascade_skipped` absent). Do not undraft.
+

--- a/docs/subagents_findings/2026-09-04_c7-06-retire-cascade.md
+++ b/docs/subagents_findings/2026-09-04_c7-06-retire-cascade.md
@@ -1,0 +1,26 @@
+# C7-06: retire route_to_metric as serve chooser (gated)
+
+- Date: 2026-09-04
+- Keywords: C7-06, route_to_metric, choose_governed_metric, cascade, cutover, G-err, G-abs, DMS_C7_RETIRE_CASCADE
+- Main idea: `answer()` uses `choose_governed_metric`. The 27-regex cascade still serves. Retirement requires L2-as-L1-replacement beating L1 on G-err with G-abs holding plus `DMS_C7_RETIRE_CASCADE=1`. A flag or JSON `cutover: true` cannot invent-green. 25 `_metric_plan` branches not deleted.
+- Path: this file
+
+## PREFLIGHT
+
+PARTIAL. reuse: `docs/design/2026-09-04_C7_ROUTE_TO_METRIC_REPLACEMENT.md` C7-06, `2026-09-04_c7-design-and-shadow-mode.md`, `2026-09-04_c7-04-heldout-harness.md`. spawn: skip (executor). C7-05 PR #126 left untouched.
+
+## Golden rules
+
+1. Do not delete the 25 `_metric_plan` branches without held-out numbers in the commit body.
+2. `DMS_C7_RETIRE_CASCADE=1` is necessary and not sufficient.
+3. L2-on-miss reports (`cascade_skipped` false) cannot retire the chooser.
+4. `cutover` stays false in this module. C7-05 owns serve-on-miss cutover.
+5. Keyword slot helpers stay. L0 certified still serves when the cascade is skipped.
+
+## Verify
+
+```
+python -m pytest tests/dms/test_c7_06_retire_cascade.py tests/dms/test_q2_answer_engine.py tests/dms/test_c7_l2_shadow.py tests/dms/test_c7_full_generation.py -q
+```
+
+Does not prove: live FreeRoute L2-as-L1-replacement, G-sh >= 500, or that the cascade can be deleted.

--- a/docs/subagents_findings/INDEX.md
+++ b/docs/subagents_findings/INDEX.md
@@ -2,6 +2,7 @@
 
 | Date | Topic | Keywords | Main idea | Path |
 |------|-------|----------|-----------|------|
+| 2026-09-04 | c7-06-retire-cascade | C7-06, route_to_metric, choose_governed_metric, cutover, G-err, G-abs | Serve chooser is `choose_governed_metric`. Cascade stays until L2-as-L1-replacement beats L1 on G-err with G-abs holding. Flag alone cannot retire. cutover stays false. | `2026-09-04_c7-06-retire-cascade.md` |
 | 2026-09-07 | crew-insights | crew, insights, ontology, where, importance, certify, refuse, #196 | Intent then ontology where+importance then constrained DMS ask. CERTIFIED envelopes carry include/exclude/unsure. | `2026-09-07_crew-insights.md` |
 | 2026-09-06 | cortex-appshell | appshell, crew, control, f-0030, apps, audit, cmd-k | Operator shell wraps Crew: nav + Apps launcher + Control/Audit GET deep-links. No Control spawn. Honest RSF statuses. | `2026-09-06_cortex-appshell.md` |
 | 2026-09-06 | crew-assign-router | crew, assign, destinations, openvault, unarmed, human_stop, airgpt, epic-116 | Assign router POST /crew/assign. OpenVault-only creds. Unarmed refuse. Control display-only map. Preview != live SSH/cloud. | `2026-09-06_crew-assign-router.md` |

--- a/tests/dms/test_c7_06_retire_cascade.py
+++ b/tests/dms/test_c7_06_retire_cascade.py
@@ -1,0 +1,280 @@
+"""C7-06 — route_to_metric is not the serve chooser until L2 beats L1.
+
+Cutover flags stay honest: a flag, DMS_L2_ENABLED, or JSON cutover:true
+cannot invent-green. Keyword slot helpers remain. The 25 _metric_plan
+branches are not deleted in this ticket.
+"""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from CortexOS.dms.c7_cutover import (
+    cascade_retired,
+    cutover_flags,
+    l2_replaces_l1,
+)
+
+L1_Q = "Which suppliers have a risk score above 0.7?"
+L0_Q = "How many SKUs do we have in inventory?"
+
+
+def _l1_report(**overrides) -> dict:
+    row = {
+        "totals": {"total": 28, "correct": 1, "abstained": 17, "incorrect": 10},
+        "incorrect_rate": 10 / 28,
+        "g_abs_recall": 1.0,
+        "gates": {"g_abs": True, "g_err": False},
+    }
+    row.update(overrides)
+    return row
+
+
+def _l2_replacement(**overrides) -> dict:
+    row = {
+        "totals": {"total": 28, "correct": 26, "abstained": 2, "incorrect": 0},
+        "incorrect_rate": 0.0,
+        "g_abs_recall": 1.0,
+        "cascade_skipped": True,
+        "gates": {"g_abs": True, "g_err": True},
+    }
+    row.update(overrides)
+    return row
+
+
+def _write_report(tmp_path: Path, *, l1: dict, l2: dict, extra: dict | None = None) -> Path:
+    payload = {"l1": l1, "l2_as_l1_replacement": l2, "cutover": True}
+    if extra:
+        payload.update(extra)
+    path = tmp_path / "c7_cutover.json"
+    path.write_text(json.dumps(payload), encoding="utf-8")
+    return path
+
+
+@pytest.fixture(autouse=True)
+def _clear_c7_env(monkeypatch):
+    monkeypatch.delenv("DMS_L2_ENABLED", raising=False)
+    monkeypatch.delenv("DMS_C7_RETIRE_CASCADE", raising=False)
+    monkeypatch.delenv("DMS_C7_CUTOVER_REPORT", raising=False)
+    yield
+
+
+def test_default_flags_are_not_cutover():
+    flags = cutover_flags()
+    assert flags["l2_enabled"] is False
+    assert flags["retire_cascade_requested"] is False
+    assert flags["l2_replaces_l1"] is False
+    assert flags["cascade_retired"] is False
+    assert flags["cutover"] is False
+    assert cascade_retired() is False
+
+
+def test_retire_flag_alone_does_not_retire(monkeypatch):
+    monkeypatch.setenv("DMS_C7_RETIRE_CASCADE", "1")
+    flags = cutover_flags()
+    assert flags["retire_cascade_requested"] is True
+    assert flags["cascade_retired"] is False
+    assert flags["cutover"] is False
+
+
+def test_l2_enabled_alone_does_not_retire_cascade(monkeypatch):
+    monkeypatch.setenv("DMS_L2_ENABLED", "1")
+    flags = cutover_flags()
+    assert flags["l2_enabled"] is True
+    assert flags["cascade_retired"] is False
+    assert flags["cutover"] is False
+
+
+def test_json_cutover_true_is_ignored(tmp_path, monkeypatch):
+    path = _write_report(tmp_path, l1=_l1_report(), l2=_l2_replacement())
+    monkeypatch.setenv("DMS_C7_CUTOVER_REPORT", str(path))
+    flags = cutover_flags()
+    assert flags["l2_replaces_l1"] is True
+    assert flags["cutover"] is False
+    assert flags["cascade_retired"] is False
+
+
+def test_beating_report_plus_flag_retires_cascade(tmp_path, monkeypatch):
+    path = _write_report(tmp_path, l1=_l1_report(), l2=_l2_replacement())
+    monkeypatch.setenv("DMS_C7_CUTOVER_REPORT", str(path))
+    monkeypatch.setenv("DMS_C7_RETIRE_CASCADE", "1")
+    flags = cutover_flags()
+    assert flags["l2_replaces_l1"] is True
+    assert flags["cascade_retired"] is True
+    assert flags["cutover"] is False
+
+
+def test_g_err_fail_does_not_replace_l1():
+    l2 = _l2_replacement(
+        totals={"total": 28, "correct": 10, "abstained": 10, "incorrect": 8},
+        incorrect_rate=8 / 28,
+        gates={"g_abs": True, "g_err": False},
+    )
+    assert l2_replaces_l1(_l1_report(), l2) is False
+
+
+def test_g_abs_fail_does_not_replace_l1():
+    l2 = _l2_replacement(
+        g_abs_recall=0.5,
+        gates={"g_abs": False, "g_err": True},
+    )
+    assert l2_replaces_l1(_l1_report(), l2) is False
+
+
+def test_l2_on_miss_report_cannot_retire_cascade():
+    l2 = _l2_replacement(cascade_skipped=False)
+    assert l2_replaces_l1(_l1_report(), l2) is False
+    l2.pop("cascade_skipped")
+    assert l2_replaces_l1(_l1_report(), l2) is False
+
+
+def test_l2_worse_than_l1_does_not_replace():
+    l1 = _l1_report(
+        totals={"total": 28, "correct": 26, "abstained": 2, "incorrect": 0},
+        incorrect_rate=0.0,
+        gates={"g_abs": True, "g_err": True},
+    )
+    l2 = _l2_replacement(
+        totals={"total": 28, "correct": 20, "abstained": 7, "incorrect": 1},
+        incorrect_rate=1 / 28,
+        gates={"g_abs": True, "g_err": True},
+    )
+    assert l2_replaces_l1(l1, l2) is False
+
+
+def test_missing_report_file_fails_closed(tmp_path, monkeypatch):
+    monkeypatch.setenv("DMS_C7_RETIRE_CASCADE", "1")
+    monkeypatch.setenv("DMS_C7_CUTOVER_REPORT", str(tmp_path / "missing.json"))
+    assert cascade_retired() is False
+
+
+def test_choose_governed_metric_uses_cascade_by_default():
+    from CortexOS.dms.answer_engine import choose_governed_metric, route_to_metric
+
+    plan = choose_governed_metric(L1_Q)
+    assert plan is not None
+    assert plan == route_to_metric(L1_Q)
+    assert plan.metric_id == "suppliers_by_risk"
+
+
+def test_choose_governed_metric_skips_cascade_when_retired(monkeypatch):
+    from CortexOS.dms import answer_engine as ae
+
+    monkeypatch.setattr(ae, "cascade_retired", lambda: True)
+    assert ae.choose_governed_metric(L1_Q) is None
+    assert ae.route_to_metric(L1_Q) is not None
+
+
+def test_slot_helpers_remain_for_l0_and_skills():
+    from CortexOS.dms.answer_engine import _days, _explicit_limit, _sales_rank_slots
+
+    assert _days("last 14 days", 30) == 14
+    assert _explicit_limit("top 3 skus") == 3
+    slots = _sales_rank_slots("top 5 sku by revenue")
+    assert slots.get("limit") == 5
+
+
+@pytest.fixture(scope="module")
+def ensure_db():
+    from bench.accuracy import _ensure_db_loaded
+    from packs.dms.semantic.loader import reload
+
+    _ensure_db_loaded()
+    reload()
+    yield
+
+
+def test_default_serve_still_uses_l1_cascade(ensure_db):
+    from CortexOS.dms.answer_engine import answer
+
+    body = answer(L1_Q)
+    assert body["layer"] == "governed_metric"
+    assert body["badge"] == "governed_metric"
+    rows = body.get("rows") or []
+    assert rows
+    assert "supplier" in (body.get("answer") or "").lower() or "risk" in (
+        body.get("answer") or ""
+    ).lower()
+
+
+def test_retired_l1_miss_abstains_honestly(ensure_db, monkeypatch):
+    from CortexOS.dms import answer_engine as ae
+    from packs.dms.semantic import query_skills
+
+    monkeypatch.setattr(ae, "cascade_retired", lambda: True)
+    monkeypatch.setattr(query_skills, "find", lambda _q: None)
+    body = ae.answer(L1_Q)
+    assert body["layer"] != "governed_metric"
+    assert body["badge"] in {"abstain", "needs_clarification"}
+    assert body.get("rows") == []
+    text = (body.get("answer") or "").lower()
+    assert text.strip()
+    assert "supplier" not in (body.get("sql_used") or "").lower()
+
+
+def test_retired_l0_certified_still_serves(ensure_db, monkeypatch):
+    from CortexOS.dms import answer_engine as ae
+
+    monkeypatch.setattr(ae, "cascade_retired", lambda: True)
+    body = ae.answer(L0_Q)
+    assert body["layer"] == "certified"
+    assert body["badge"] == "certified"
+    assert body.get("rows")
+    assert (body.get("answer") or "").strip()
+
+
+def test_l2_on_does_not_skip_cascade_without_retirement(ensure_db, monkeypatch):
+    from CortexOS.dms.answer_engine import answer
+
+    monkeypatch.setenv("DMS_L2_ENABLED", "1")
+    body = answer(L1_Q)
+    assert body["layer"] == "governed_metric"
+    assert body.get("rows")
+
+
+def test_c7_05_score_engine_report_cannot_retire_cascade():
+    """L2-on-miss (C7-05) reports have no cascade_skipped; they cannot retire L1."""
+    from bench.heldout import HeldoutItem, score_engine
+
+    item = HeldoutItem(
+        id="must_abs",
+        split="must_abstain",
+        provenance="different_model_abstain",
+        question="esg plus berlin weather 1997",
+        expect="abstain",
+    )
+
+    def ask(question: str) -> dict:
+        del question
+        return {
+            "answer": "I can't answer that.",
+            "rows": [],
+            "badge": "abstain",
+            "route": "needs_clarification",
+        }
+
+    report = score_engine([item], ask=ask, count_shadow=False)
+    assert report["cutover"] is False
+    assert not report.get("cascade_skipped")
+    assert l2_replaces_l1(report, report) is False
+    assert cutover_flags({"l1": report, "l2_as_l1_replacement": report})[
+        "cascade_retired"
+    ] is False
+
+
+def test_c7_cutover_does_not_import_packs() -> None:
+    import ast
+    from pathlib import Path
+
+    src = Path(__file__).resolve().parents[2] / "CortexOS" / "dms" / "c7_cutover.py"
+    tree = ast.parse(src.read_text(encoding="utf-8"), filename=str(src))
+    mods: list[str] = []
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            mods.extend(alias.name for alias in node.names)
+        elif isinstance(node, ast.ImportFrom) and node.module:
+            mods.append(node.module)
+    leaked = [m for m in mods if m == "packs" or m.startswith("packs.")]
+    assert not leaked, f"c7_cutover.py must not import packs: {leaked}"

--- a/tests/dms/test_q2_answer_engine.py
+++ b/tests/dms/test_q2_answer_engine.py
@@ -238,6 +238,25 @@ def test_l2_disabled_by_default(monkeypatch):
     assert r["route"] == "needs_clarification"  # no L2 model wired → abstain, not guess
 
 
+def test_l1_chooser_is_still_the_cascade_until_c7_06_gates(monkeypatch):
+    """C7-06: answer() uses choose_governed_metric; default is still route_to_metric."""
+    from CortexOS.dms.answer_engine import choose_governed_metric, route_to_metric
+    from CortexOS.dms.c7_cutover import cutover_flags
+
+    monkeypatch.delenv("DMS_C7_RETIRE_CASCADE", raising=False)
+    monkeypatch.delenv("DMS_C7_CUTOVER_REPORT", raising=False)
+    flags = cutover_flags()
+    assert flags["cascade_retired"] is False
+    assert flags["cutover"] is False
+    q = "Which suppliers have a risk score above 0.7?"
+    plan = choose_governed_metric(q)
+    assert plan is not None
+    assert plan == route_to_metric(q)
+    r = answer_question(q)
+    assert r["layer"] == "governed_metric"
+    assert r.get("rows")
+
+
 def _assert_exclusion_visible(r: dict, excluded: list[str], *, n: int = 5) -> None:
     """Customer-visible exclusion: non-empty ranking rows, text lists them, omitted SKUs stay out."""
     rows = r.get("rows") or []


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Parent **EPIC-006 / Cortex#17**. Ticket **Cortex#105**. Does **not** touch Cortex#4 / #41 / #42 / #43 / #44. Did not mint a Space grant.
- Rebased onto current `origin/main` (2026-09-09, includes CREW-INSIGHTS #201). Staying **draft**. Not merging. Rebase is not permission to undraft.
- `answer()` picks L1 via `choose_governed_metric`. Default serve path is still the keyword cascade.
- Cascade skip requires **both** `DMS_C7_RETIRE_CASCADE=1` **and** a held-out report that L2-as-L1-replacement beats L1 on G-err with G-abs holding (`cascade_skipped` true). A C7-05 L2-on-miss `score_engine` report cannot retire.
- A flag, `DMS_L2_ENABLED=1`, or JSON `cutover: true` cannot invent-green. `cutover` stays **false**.
- The 25 `_metric_plan` branches are **not** deleted. No L2-as-L1-replacement numbers in the commit body.

## Held-out (gate not met)
Published L1 report on PR #126: G-err false, incorrect=10 of 28, G-abs true. That is not L2-as-L1-replacement beating L1. Do not close #105.

## Test plan
- [x] `pytest tests/dms/test_c7_06_retire_cascade.py tests/dms/test_q2_answer_engine.py tests/dms/test_c7_heldout.py tests/dms/test_c7_l2_shadow.py tests/dms/test_c7_full_generation.py tests/contract/test_import_boundaries.py tests/dms/test_ans02_aggregate_over_ranking.py -q` (105 passed after rebase; C2 allowlist not expanded)
- [ ] Wait for GitHub CI on `54c494b8`
- [ ] Do not merge. Do not undraft.

Made with [Cursor](https://cursor.com)

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-c947b92e-b91e-4c57-8621-ef63d32a22c3?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c947b92e-b91e-4c57-8621-ef63d32a22c3&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

