### PR TITLE
CREW-CMD: slash autocomplete and @ mentions in Crew chat

### DIFF
--- a/CortexOS/crew/commands.py
+++ b/CortexOS/crew/commands.py
@@ -1,0 +1,302 @@
+"""Slash commands and @mentions for Crew chat.
+
+Slash maps onto skills, routines, and desk tools already in this tree.
+Mentions resolve to a live teammate or a capability template. Delivery
+goes through the A2A Switchboard, not a second inbox.
+
+Netie-native: no Grok Bot / mybot renderer, no analog CSS.
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+from CortexOS.crew import roles
+from CortexOS.crew.board import PACKS_DIR, list_skills
+from CortexOS.crew.routines import catalog as routine_catalog
+
+_SLASH = re.compile(r"^/([A-Za-z][A-Za-z0-9_-]*)(?:\s+(.*))?$", re.DOTALL)
+_MENTION = re.compile(r"(?:^|[\s])@([A-Za-z][A-Za-z0-9_-]{0,63})")
+
+# Desk tools the runtime already owns. Aliases are extra slashes, not new actions.
+_DESK: tuple[dict[str, Any], ...] = (
+    {
+        "slash": "desk",
+        "aliases": ("desk_status",),
+        "kind": "desk",
+        "action": "desk_status",
+        "title": "Desk status",
+        "hint": "PRs, mail, connectors, Cursor key. Do not auto-merge.",
+    },
+    {
+        "slash": "board",
+        "aliases": ("tickets", "netie_board"),
+        "kind": "desk",
+        "action": "netie_board",
+        "title": "Ticket board",
+        "hint": "CLAIMS seated vs unseated. Ticket Runner seats writers.",
+    },
+    {
+        "slash": "estate",
+        "aliases": ("estate_status",),
+        "kind": "desk",
+        "action": "estate_status",
+        "title": "Estate status",
+        "hint": "Netie-AI repos and production domains.",
+    },
+    {
+        "slash": "ship_gate",
+        "aliases": ("gate",),
+        "kind": "desk",
+        "action": "ship_gate",
+        "title": "Ship-gate",
+        "hint": "Deterministic production gate. Arg: repo slug or all.",
+    },
+)
+
+
+def _slug(name: str) -> str:
+    return re.sub(r"[^a-z0-9]+", "-", (name or "").lower()).strip("-")[:60] or "cmd"
+
+
+def _public_cmd(
+    *,
+    slash: str,
+    kind: str,
+    action: str,
+    title: str,
+    hint: str,
+    aliases: tuple[str, ...] = (),
+) -> dict[str, Any]:
+    return {
+        "slash": slash,
+        "kind": kind,
+        "action": action,
+        "title": title,
+        "hint": hint,
+        "aliases": list(aliases),
+    }
+
+
+def catalog(skills_dir: Path | None = None) -> list[dict[str, Any]]:
+    """Real Crew commands: desk tools, routines, then taught/shipped skills."""
+    out: list[dict[str, Any]] = []
+    taken: set[str] = set()
+
+    def take(slash: str) -> bool:
+        key = slash.lower()
+        if key in taken:
+            return False
+        taken.add(key)
+        return True
+
+    for row in _DESK:
+        slash = str(row["slash"])
+        if not take(slash):
+            continue
+        aliases = tuple(a for a in row["aliases"] if take(a))
+        out.append(
+            _public_cmd(
+                slash=slash,
+                kind="desk",
+                action=str(row["action"]),
+                title=str(row["title"]),
+                hint=str(row["hint"]),
+                aliases=aliases,
+            )
+        )
+
+    for row in routine_catalog():
+        name = str(row.get("name") or "")
+        slash = _slug(name)
+        if not take(slash):
+            continue
+        out.append(
+            _public_cmd(
+                slash=slash,
+                kind="routine",
+                action=name,
+                title=name,
+                hint=str(row.get("instruction") or row.get("when") or "standing routine"),
+            )
+        )
+
+    seen_skills: set[str] = set()
+    folders = [p for p in (skills_dir, PACKS_DIR) if p is not None]
+    for folder in folders:
+        for skill in list_skills(folder):
+            title = str(skill.get("title") or "")
+            slash = _slug(title)
+            if slash in seen_skills or not take(slash):
+                continue
+            seen_skills.add(slash)
+            out.append(
+                _public_cmd(
+                    slash=slash,
+                    kind="skill",
+                    action=title,
+                    title=title,
+                    hint=str(skill.get("head") or "taught skill"),
+                )
+            )
+    return out
+
+
+def filter_commands(rows: list[dict[str, Any]], prefix: str) -> list[dict[str, Any]]:
+    needle = (prefix or "").strip().lstrip("/").lower()
+    if not needle:
+        return list(rows)
+    hits: list[dict[str, Any]] = []
+    for row in rows:
+        aliases = [str(a).lower() for a in (row.get("aliases") or [])]
+        blob = " ".join(
+            [
+                str(row.get("slash") or ""),
+                str(row.get("title") or ""),
+                str(row.get("action") or ""),
+                *aliases,
+            ]
+        ).lower()
+        if str(row.get("slash") or "").lower().startswith(needle) or any(
+            a.startswith(needle) for a in aliases
+        ):
+            hits.append(row)
+        elif needle in blob:
+            hits.append(row)
+    return hits
+
+
+def mention_targets(agents: list[dict[str, Any]] | None = None) -> list[dict[str, Any]]:
+    """Live teammates first, then capability templates the Manager may spawn."""
+    out: list[dict[str, Any]] = []
+    seen = set()
+
+    def add(name: str, kind: str, hint: str, agent_id: str | None = None) -> None:
+        key = name.lower()
+        if key in seen:
+            return
+        seen.add(key)
+        row: dict[str, Any] = {"name": name, "kind": kind, "hint": hint}
+        if agent_id:
+            row["id"] = agent_id
+        out.append(row)
+
+    add("Manager", "teammate", "Coordinates the crew")
+    for agent in agents or []:
+        name = str(agent.get("name") or "").strip()
+        if not name:
+            continue
+        hint = str(agent.get("capability") or agent.get("status") or "teammate")
+        add(name, "teammate", hint, str(agent.get("id") or "") or None)
+    for role in roles.catalog():
+        add(str(role["name"]), "role", str(role.get("blurb") or "capability template"))
+    return out
+
+
+def filter_mentions(rows: list[dict[str, Any]], prefix: str) -> list[dict[str, Any]]:
+    needle = (prefix or "").strip().lstrip("@").lower()
+    if not needle:
+        return list(rows)
+    return [
+        row
+        for row in rows
+        if str(row.get("name") or "").lower().startswith(needle)
+        or needle in str(row.get("hint") or "").lower()
+    ]
+
+
+@dataclass(frozen=True)
+class Mention:
+    raw: str
+    name: str
+    kind: str  # teammate | role | unknown
+    agent_id: str | None = None
+
+    def public(self) -> dict[str, Any]:
+        row: dict[str, Any] = {"raw": self.raw, "name": self.name, "kind": self.kind}
+        if self.agent_id:
+            row["id"] = self.agent_id
+        return row
+
+
+@dataclass(frozen=True)
+class Parsed:
+    text: str
+    command: dict[str, Any] | None
+    rest: str
+    mentions: tuple[Mention, ...]
+
+    def public(self) -> dict[str, Any]:
+        return {
+            "text": self.text,
+            "command": self.command,
+            "rest": self.rest,
+            "mentions": [m.public() for m in self.mentions],
+        }
+
+
+def parse_mentions(text: str) -> tuple[str, ...]:
+    return tuple(m.group(1) for m in _MENTION.finditer(text or ""))
+
+
+def resolve_mentions(
+    names: tuple[str, ...],
+    agents: list[dict[str, Any]] | None = None,
+) -> tuple[Mention, ...]:
+    by_agent = {str(a.get("name") or "").lower(): a for a in (agents or []) if a.get("name")}
+    out: list[Mention] = []
+    seen: set[str] = set()
+    for raw in names:
+        key = raw.lower()
+        if key in seen:
+            continue
+        seen.add(key)
+        agent = by_agent.get(key)
+        if agent is not None:
+            out.append(
+                Mention(
+                    raw=raw,
+                    name=str(agent["name"]),
+                    kind="teammate",
+                    agent_id=str(agent.get("id") or "") or None,
+                )
+            )
+            continue
+        role = roles.by_name(raw)
+        if role is not None:
+            out.append(Mention(raw=raw, name=role.name, kind="role"))
+            continue
+        out.append(Mention(raw=raw, name=raw, kind="unknown"))
+    return tuple(out)
+
+
+def match_command(slash: str, skills_dir: Path | None = None) -> dict[str, Any] | None:
+    key = (slash or "").strip().lstrip("/").lower()
+    if not key:
+        return None
+    for row in catalog(skills_dir):
+        aliases = {str(a).lower() for a in (row.get("aliases") or [])}
+        if str(row.get("slash") or "").lower() == key or key in aliases:
+            return row
+    return None
+
+
+def parse(
+    text: str,
+    skills_dir: Path | None = None,
+    agents: list[dict[str, Any]] | None = None,
+) -> Parsed:
+    raw = text or ""
+    command = None
+    rest = raw
+    matched = _SLASH.match(raw.strip())
+    if matched:
+        hit = match_command(matched.group(1), skills_dir)
+        if hit is not None:
+            command = hit
+            rest = (matched.group(2) or "").strip()
+    mentions = resolve_mentions(parse_mentions(raw), agents=agents)
+    return Parsed(text=raw, command=command, rest=rest, mentions=mentions)

--- a/CortexOS/crew/runtime.py
+++ b/CortexOS/crew/runtime.py
@@ -166,12 +166,49 @@ class CrewRuntime:
         provider: str | None = None,
         model: str | None = None,
     ) -> dict[str, Any]:
-        msg = self.store.add_message(space_id, "user", text)
-        self.bus.emit(space_id, "message", {"message": msg})
+        from CortexOS.crew.commands import parse
 
         space = self.store.get_space(space_id)
         if space is None:
             return {"error": "unknown space"}
+
+        manager = self.ensure_manager(space_id)
+        agents = self.store.list_agents(space_id)
+        skills_dir = self.settings.data_dir / "skills"
+        parsed = parse(text, skills_dir=skills_dir, agents=agents)
+
+        to_name, to_id = self._mention_target(parsed.mentions, manager)
+        meta: dict[str, Any] = {
+            "a2a": {"kind": a2a.USER, "from": "operator", "to": to_name},
+        }
+        if parsed.mentions:
+            meta["mentions"] = [m.public() for m in parsed.mentions]
+        if parsed.command:
+            meta["command"] = {
+                "slash": parsed.command.get("slash"),
+                "kind": parsed.command.get("kind"),
+                "action": parsed.command.get("action"),
+            }
+
+        msg = self.store.add_message(
+            space_id, "user", text, to_agent_id=to_id, meta=meta
+        )
+        self.bus.emit(space_id, "message", {"message": msg})
+
+        if parsed.command and parsed.command.get("kind") == "desk":
+            self._run_slash_desk(space_id, manager, parsed.command, parsed.rest)
+        elif parsed.command and parsed.command.get("kind") in {"skill", "routine"}:
+            self._load_slash_pack(space_id, parsed.command, parsed.rest)
+
+        desk_only = bool(
+            parsed.command
+            and parsed.command.get("kind") == "desk"
+            and not parsed.rest.strip()
+            and not parsed.mentions
+        )
+        if desk_only:
+            return {"ok": True, "command": parsed.command.get("slash"), "run_id": None}
+
         turn_provider = (provider or "").strip() or None
         turn_model = (model or "").strip() or None
         if turn_provider or turn_model:
@@ -191,29 +228,167 @@ class CrewRuntime:
             self.bus.emit(space_id, "message", {"message": sysmsg})
             return {"error": note}
 
+        env = a2a.Envelope(
+            id=msg["id"],
+            kind=a2a.USER,
+            from_id="operator",
+            from_name="operator",
+            to_id=to_id,
+            to_name=to_name,
+            text=text,
+            seq=int(msg["seq"]),
+        )
         active_run = self._space_run.get(space_id)
         if active_run:
-            manager = self.ensure_manager(space_id)
-            self.switch.mailbox(manager["id"]).put(
-                a2a.Envelope(
-                    id=msg["id"],
-                    kind=a2a.USER,
-                    from_id="operator",
-                    from_name="operator",
-                    to_id=manager["id"],
-                    to_name="Manager",
-                    text=text,
-                    seq=int(msg["seq"]),
-                )
-            )
+            self._route_operator(space_id, manager, env, to_id)
             return {"run_id": active_run, "queued": True}
 
-        manager = self.ensure_manager(space_id)
-        return {
-            "run_id": self._start_run(
-                space_id, manager, provider=turn_provider, model=turn_model
+        run_id = self._start_run(
+            space_id, manager, provider=turn_provider, model=turn_model
+        )
+        if to_id != manager["id"]:
+            self._route_operator(space_id, manager, env, to_id, notify_manager=False)
+        return {"run_id": run_id, "command": (parsed.command or {}).get("slash")}
+
+    def _mention_target(
+        self,
+        mentions: tuple[Any, ...],
+        manager: dict[str, Any],
+    ) -> tuple[str, str]:
+        """Primary recipient for an operator line. Teammate wins; role stamps name."""
+        for hit in mentions:
+            if getattr(hit, "kind", "") == "teammate" and getattr(hit, "agent_id", None):
+                name = str(hit.name)
+                if name.lower() == "manager":
+                    return manager["name"], manager["id"]
+                return name, str(hit.agent_id)
+        for hit in mentions:
+            if getattr(hit, "kind", "") == "role":
+                return str(hit.name), manager["id"]
+        return manager["name"], manager["id"]
+
+    def _route_operator(
+        self,
+        space_id: str,
+        manager: dict[str, Any],
+        env: a2a.Envelope,
+        to_id: str,
+        *,
+        notify_manager: bool = True,
+    ) -> None:
+        """Put the operator line on the Switchboard. No second inbox."""
+        self.switch.deliver(env)
+        if notify_manager and to_id != manager["id"]:
+            self.switch.deliver(
+                a2a.Envelope(
+                    id=env.id,
+                    kind=a2a.USER,
+                    from_id=env.from_id,
+                    from_name=env.from_name,
+                    to_id=manager["id"],
+                    to_name=manager["name"],
+                    text=env.text,
+                    seq=env.seq,
+                )
             )
-        }
+        target = self.store.get_agent(to_id)
+        run_id = self._space_run.get(space_id)
+        ctx = self._runs.get(run_id) if run_id else None
+        if ctx is not None and target is not None and target["id"] != manager["id"]:
+            self._wake_if_idle(ctx, target)
+
+    def _run_slash_desk(
+        self,
+        space_id: str,
+        manager: dict[str, Any],
+        command: dict[str, Any],
+        rest: str,
+    ) -> None:
+        action = str(command.get("action") or "")
+        text = ""
+        args: dict[str, Any] = {}
+        if action == "desk_status":
+            from CortexOS.crew.desk import render, snapshot
+
+            mcp_rows = self.mcp.status()
+            uacc = next((row for row in mcp_rows if row.get("name") == "uacc"), {})
+            text = render(
+                snapshot(
+                    uacc_enabled=bool(uacc.get("enabled")),
+                    uacc_armed=bool(uacc.get("armed")),
+                )
+            )
+        elif action == "netie_board":
+            from CortexOS.crew.board import snapshot
+
+            board = snapshot()
+            lines = [
+                f"{len(board['tickets'])} tickets, seated={board['seated']} unseated={board['unseated']}. {board['law']}"
+            ]
+            for item in board["tickets"][:30]:
+                lines.append(
+                    f"- {item.get('ticket')} {item.get('role')} write={item.get('may_write')} pr={item.get('owner_pr')}"
+                )
+            text = "\n".join(lines)
+        elif action == "estate_status":
+            from CortexOS.crew.estate import render as estate_render
+            from CortexOS.crew.estate import snapshot as estate_snapshot
+
+            text = estate_render(estate_snapshot())
+        elif action == "ship_gate":
+            from CortexOS.crew.ship_gate import render_slug
+
+            repo = rest.strip() or "all"
+            args = {"repo": repo}
+            text = render_slug(repo)
+        else:
+            text = f"Unknown desk action {action}"
+        msg = self.store.add_message(
+            space_id,
+            "tool",
+            text[:4000],
+            agent_id=manager["id"],
+            to_agent_id=manager["id"],
+            meta={
+                "tool": action,
+                "args": args,
+                "slash": True,
+                "a2a": {"kind": a2a.USER, "from": "operator", "to": manager["name"]},
+            },
+        )
+        self.bus.emit(space_id, "message", {"message": msg})
+
+    def _load_slash_pack(
+        self, space_id: str, command: dict[str, Any], rest: str
+    ) -> None:
+        kind = str(command.get("kind") or "")
+        action = str(command.get("action") or "")
+        slash = str(command.get("slash") or "")
+        body = ""
+        if kind == "skill":
+            from CortexOS.crew.board import read_skill
+
+            body = read_skill(self.settings.data_dir / "skills", action).strip()
+        elif kind == "routine":
+            from CortexOS.crew.routines import catalog as routine_catalog
+
+            hit = next((r for r in routine_catalog() if r.get("name") == action), None)
+            if hit:
+                body = (
+                    f"{hit.get('name')}: {hit.get('instruction')}\n"
+                    f"when={hit.get('when')} layer={hit.get('layer')}"
+                )
+        head = f"Skill /{slash} loaded." if kind == "skill" else f"Routine /{slash} loaded."
+        if rest:
+            head += f" Brief: {rest}"
+        content = head if not body else f"{head}\n\n{body[:4000]}"
+        msg = self.store.add_message(
+            space_id,
+            "system",
+            content,
+            meta={"slash": True, "command": {"slash": slash, "kind": kind, "action": action}},
+        )
+        self.bus.emit(space_id, "message", {"message": msg})
 
     def _start_run(
         self,
@@ -1321,9 +1496,16 @@ class CrewRuntime:
         out: list[dict[str, Any]] = []
         for m in rows:
             if m["role"] == "user":
-                out.append({"role": "user", "content": m["content"]})
+                wire = (m.get("meta") or {}).get("a2a") or {}
+                to = wire.get("to")
+                body = str(m["content"] or "")
+                if to and to != "Manager":
+                    body = f"[operator -> {to}] {body}"
+                out.append({"role": "user", "content": body})
             elif m["role"] == "assistant":
                 out.append({"role": "assistant", "content": m["content"]})
+            elif m["role"] in {"tool", "system"} and (m.get("meta") or {}).get("slash"):
+                out.append({"role": "user", "content": str(m["content"] or "")[:4000]})
             elif m["role"] == "agent":
                 frm = agents.get(m["agent_id"], "agent")
                 to = agents.get(m["to_agent_id"], "space")
@@ -1351,7 +1533,14 @@ class CrewRuntime:
         owed: dict[str, str] = {}
         for m in self.store.list_messages(space_id, limit=10_000):
             meta = m.get("meta") or {}
-            if m["role"] == "agent":
+            if m["role"] == "user" and m.get("to_agent_id") == me:
+                out.append(
+                    {
+                        "role": "user",
+                        "content": f"[operator to {row['name']}] {m['content']}",
+                    }
+                )
+            elif m["role"] == "agent":
                 if m["to_agent_id"] == me:
                     kind = (meta.get("a2a") or {}).get("kind") or a2a.TELL
                     frm = agents.get(m["agent_id"], "someone")

--- a/CortexOS/crew/server.py
+++ b/CortexOS/crew/server.py
@@ -339,6 +339,28 @@ def build_router(crew: CrewApp) -> APIRouter:
 
         return catalog()
 
+    @router.get("/commands")
+    async def list_commands(q: str = "", space_id: str = "") -> dict[str, Any]:
+        """Slash catalog plus @ targets. Autocomplete source for the composer."""
+        from CortexOS.crew.commands import (
+            catalog,
+            filter_commands,
+            filter_mentions,
+            mention_targets,
+        )
+
+        skills_dir = crew.settings.data_dir / "skills"
+        cmds = catalog(skills_dir)
+        agents = crew.store.list_agents(space_id) if space_id else []
+        mentions = mention_targets(agents)
+        needle = (q or "").strip()
+        if needle.startswith("@"):
+            mentions = filter_mentions(mentions, needle)
+            cmds = filter_commands(cmds, "")
+        elif needle:
+            cmds = filter_commands(cmds, needle)
+        return {"commands": cmds, "mentions": mentions}
+
     @router.get("/detect")
     async def detect_plan(q: str = "") -> dict[str, Any]:
         from CortexOS.crew.detect import plan

--- a/CortexOS/crew/ui/crew.css
+++ b/CortexOS/crew/ui/crew.css
@@ -349,8 +349,16 @@ button { cursor: pointer; }
   border: 1px solid var(--line);
   background: var(--pane);
   flex: none;
+  position: relative;
 }
 .composer:focus-within { border-color: var(--live); }
+.composer__suggest {
+  border-bottom: 1px solid var(--line);
+  max-height: 12rem;
+  overflow: auto;
+  background: var(--well);
+}
+.composer__suggest .palette__hit.on { background: var(--pane); color: var(--live); }
 .composer__row {
   display: flex;
   align-items: flex-end;

--- a/CortexOS/crew/ui/index.html
+++ b/CortexOS/crew/ui/index.html
@@ -57,9 +57,10 @@
       </div>
       <div class="composer">
         <div id="roles" class="role-chips"></div>
+        <div class="composer__suggest" id="suggest" hidden role="listbox" aria-label="Command and mention autocomplete"></div>
         <div class="composer__row">
           <select class="route-pick" id="routePick" title="Provider for this turn"></select>
-          <textarea class="composer__input" id="input" rows="1" placeholder="Ask the Manager. Auto-detect who to spawn."></textarea>
+          <textarea class="composer__input" id="input" rows="1" placeholder="Ask the Manager. Type / for commands, @ for a teammate."></textarea>
           <button class="composer__send" id="send" title="Send">^</button>
         </div>
       </div>
@@ -227,6 +228,7 @@
       agents: [], confirms: [], mcp: [], plugins: [],
       source: null, seq: 0, runId: null, draft: "", keyFields: [],
       plan: null, skills: [], roles: [],
+      commands: [], mentions: [], suggest: [], suggestAt: -1, suggestKind: null,
       activityOnly: false, focusAgent: null,
       stick: true, unread: 0, retry: null, live: false,
       belt: null, memScope: "space", claimBusy: null,
@@ -390,7 +392,11 @@
     function whoLine(m) {
       const t = clock(m.created_at);
       const time = t ? `<span class="stamp">${esc(t)}</span>` : "";
-      if (m.role === "user") return `<span>You</span>${time}`;
+      if (m.role === "user") {
+        const wire = (m.meta && m.meta.a2a) || {};
+        const to = wire.to || nameOf(m.to_agent_id) || "Manager";
+        return `<span>You -&gt; ${esc(to)}</span>${time}`;
+      }
       if (m.role === "assistant") return `<span>Manager</span>${time}`;
       if (m.role === "agent") {
         const wire = (m.meta && m.meta.a2a) || {};
@@ -890,15 +896,18 @@
     }
 
     async function boot() {
-      const [prov, spaces, mcp, health, roles, keys, plugs, routines, tickets, desk, skills, belt] = await Promise.all([
+      const [prov, spaces, mcp, health, roles, keys, plugs, routines, tickets, desk, skills, belt, composer] = await Promise.all([
         api("/crew/providers"), api("/crew/spaces"), api("/crew/mcp"), api("/crew/health"),
         api("/crew/roles").catch(() => []), api("/crew/keys").catch(() => ({ fields: [], status: {} })),
         api("/crew/connectors").catch(() => []), api("/crew/routines").catch(() => []),
         api("/crew/tickets").catch(() => ({ tickets: [] })),
         api("/crew/desk").catch(() => null),
         api("/crew/skills").catch(() => []),
-        api("/v1/belt").catch(() => api("/crew/belt").catch(() => null))
+        api("/v1/belt").catch(() => api("/crew/belt").catch(() => null)),
+        api("/crew/commands").catch(() => ({ commands: [], mentions: [] }))
       ]);
+      state.commands = composer.commands || [];
+      state.mentions = composer.mentions || [];
       renderRoles(roles || []);
       state.skills = skills || [];
       renderSkills(state.skills);
@@ -956,6 +965,7 @@
       state.agents = agents;
       state.confirms = confirms;
       renderFocus(); renderAgents(); renderConfirms(); renderLog(); renderMemory();
+      loadComposer(id);
       listen(id);
     }
     async function catchUp(id) {
@@ -996,6 +1006,7 @@
             const i = state.agents.findIndex((a) => a.id === data.agent.id);
             if (i >= 0) state.agents[i] = data.agent; else state.agents.push(data.agent);
             renderAgents(); renderGraph(wireRows());
+            loadComposer(id);
           }
           if (data.confirm) {
             const i = state.confirms.findIndex((c) => c.id === data.confirm.id);
@@ -1028,7 +1039,87 @@
       open();
     }
 
+    async function loadComposer(spaceId) {
+      const q = spaceId ? ("?space_id=" + encodeURIComponent(spaceId)) : "";
+      try {
+        const body = await api("/crew/commands" + q);
+        state.commands = body.commands || state.commands || [];
+        state.mentions = body.mentions || state.mentions || [];
+      } catch (err) { /* catalog is optional for a send */ }
+    }
+    function tokenAtCaret(value, caret) {
+      const head = value.slice(0, caret);
+      const slash = head.match(/(^|\s)(\/[A-Za-z0-9_-]*)$/);
+      if (slash) return { kind: "slash", prefix: slash[2].slice(1), start: caret - slash[2].length, token: slash[2] };
+      const at = head.match(/(^|\s)(@[A-Za-z0-9_-]*)$/);
+      if (at) return { kind: "at", prefix: at[2].slice(1), start: caret - at[2].length, token: at[2] };
+      return null;
+    }
+    function matchSuggest(kind, prefix) {
+      const needle = (prefix || "").toLowerCase();
+      if (kind === "slash") {
+        return (state.commands || []).filter((c) => {
+          const aliases = (c.aliases || []).join(" ");
+          const blob = (c.slash + " " + (c.title || "") + " " + aliases).toLowerCase();
+          return !needle || c.slash.toLowerCase().startsWith(needle) || blob.indexOf(needle) >= 0;
+        }).slice(0, 12);
+      }
+      return (state.mentions || []).filter((m) => {
+        const blob = (m.name + " " + (m.hint || "")).toLowerCase();
+        return !needle || m.name.toLowerCase().startsWith(needle) || blob.indexOf(needle) >= 0;
+      }).slice(0, 12);
+    }
+    function hideSuggest() {
+      state.suggest = [];
+      state.suggestAt = -1;
+      state.suggestKind = null;
+      const box = $("suggest");
+      box.hidden = true;
+      box.innerHTML = "";
+    }
+    function renderSuggest() {
+      const box = $("suggest");
+      if (!state.suggest.length) { hideSuggest(); return; }
+      box.hidden = false;
+      box.innerHTML = state.suggest.map((row, i) => {
+        const on = i === state.suggestAt ? " on" : "";
+        if (state.suggestKind === "slash") {
+          return `<button class="palette__hit${on}" type="button" role="option" data-i="${i}"><b>/${esc(row.slash)}</b> ${esc(row.title)}<small>${esc(row.kind)} - ${esc(row.hint || "")}</small></button>`;
+        }
+        return `<button class="palette__hit${on}" type="button" role="option" data-i="${i}"><b>@${esc(row.name)}</b> ${esc(row.kind)}<small>${esc(row.hint || "")}</small></button>`;
+      }).join("");
+      box.querySelectorAll("[data-i]").forEach((el) => {
+        el.onmousedown = (e) => { e.preventDefault(); applySuggest(Number(el.dataset.i)); };
+      });
+    }
+    function refreshSuggest() {
+      const node = $("input");
+      const tok = tokenAtCaret(node.value, node.selectionStart || 0);
+      if (!tok) { hideSuggest(); return; }
+      state.suggestKind = tok.kind;
+      state.suggest = matchSuggest(tok.kind, tok.prefix);
+      if (!state.suggest.length) { hideSuggest(); return; }
+      if (state.suggestAt < 0 || state.suggestAt >= state.suggest.length) state.suggestAt = 0;
+      renderSuggest();
+    }
+    function applySuggest(i) {
+      const row = state.suggest[i];
+      if (!row) return;
+      const node = $("input");
+      const caret = node.selectionStart || 0;
+      const tok = tokenAtCaret(node.value, caret);
+      if (!tok) { hideSuggest(); return; }
+      const insert = state.suggestKind === "slash" ? ("/" + row.slash + " ") : ("@" + row.name + " ");
+      node.value = node.value.slice(0, tok.start) + insert + node.value.slice(caret);
+      const next = tok.start + insert.length;
+      node.setSelectionRange(next, next);
+      hideSuggest();
+      growInput();
+      node.focus();
+    }
+
     async function send() {
+      hideSuggest();
       const text = $("input").value.trim();
       if (!text || !state.spaceId) return;
       $("input").value = ""; growInput();
@@ -1110,8 +1201,14 @@
       const id = $("takeover").dataset.id;
       if (id) decide(id, false, false);
     };
-    $("input").addEventListener("input", growInput);
+    $("input").addEventListener("input", () => { growInput(); refreshSuggest(); });
     $("input").addEventListener("keydown", (e) => {
+      if (! $("suggest").hidden && state.suggest.length) {
+        if (e.key === "ArrowDown") { e.preventDefault(); state.suggestAt = (state.suggestAt + 1) % state.suggest.length; renderSuggest(); return; }
+        if (e.key === "ArrowUp") { e.preventDefault(); state.suggestAt = (state.suggestAt - 1 + state.suggest.length) % state.suggest.length; renderSuggest(); return; }
+        if (e.key === "Tab" || (e.key === "Enter" && !e.shiftKey)) { e.preventDefault(); applySuggest(state.suggestAt < 0 ? 0 : state.suggestAt); return; }
+        if (e.key === "Escape") { e.preventDefault(); hideSuggest(); return; }
+      }
       if (e.key === "Enter" && !e.shiftKey) { e.preventDefault(); send(); }
     });
     $("log").addEventListener("scroll", () => {

--- a/tests/test_crew/test_commands.py
+++ b/tests/test_crew/test_commands.py
@@ -1,0 +1,134 @@
+"""Slash catalog, @ resolution, and Switchboard delivery. Operator-visible."""
+
+from __future__ import annotations
+
+import pytest
+
+from CortexOS.crew.commands import (
+    catalog,
+    filter_commands,
+    filter_mentions,
+    match_command,
+    mention_targets,
+    parse,
+    parse_mentions,
+    resolve_mentions,
+)
+from CortexOS.crew.llm import LLMResult
+from tests.test_crew.conftest import wait_run_done
+
+
+def test_catalog_lists_desk_routines_and_skills(settings) -> None:
+    rows = catalog(settings.data_dir / "skills")
+    slashes = {r["slash"] for r in rows}
+    assert {"desk", "board", "estate", "ship_gate"} <= slashes
+    assert "pr-check" in slashes
+    assert "build" in slashes
+    desk = match_command("desk_status", settings.data_dir / "skills")
+    assert desk is not None and desk["action"] == "desk_status"
+    assert filter_commands(rows, "ship")[0]["slash"] in {"ship_gate", "ship"}
+
+
+def test_parse_slash_and_mentions() -> None:
+    parsed = parse("/desk")
+    assert parsed.command is not None
+    assert parsed.command["action"] == "desk_status"
+    assert parsed.rest == ""
+    hit = parse("/ship_gate Cortex")
+    assert hit.command is not None and hit.command["action"] == "ship_gate"
+    assert hit.rest == "Cortex"
+    names = parse_mentions("@PRD check the brief with @Gate")
+    assert names == ("PRD", "Gate")
+    resolved = resolve_mentions(names)
+    kinds = {m.name: m.kind for m in resolved}
+    assert kinds["PRD"] == "role"
+    assert kinds["Gate"] == "role"
+    mixed = parse("@Scout ping")
+    assert mixed.command is None
+    assert [m.name for m in mixed.mentions] == ["Scout"]
+    assert mixed.mentions[0].kind == "unknown"
+
+
+def test_mention_targets_prefer_live_teammates() -> None:
+    agents = [{"id": "a1", "name": "Scout", "capability": "PRD", "status": "idle"}]
+    rows = mention_targets(agents)
+    names = [r["name"] for r in rows]
+    assert names[0] == "Manager"
+    assert "Scout" in names
+    assert "PRD" in names
+    scout = next(r for r in rows if r["name"] == "Scout")
+    assert scout["kind"] == "teammate" and scout["id"] == "a1"
+    hits = filter_mentions(rows, "pr")
+    assert any(h["name"] == "PRD" for h in hits)
+
+
+@pytest.mark.asyncio
+async def test_slash_desk_writes_tool_without_a_run(rig) -> None:
+    space = rig.store.create_space("HQ")
+    posted = await rig.runtime.on_user_message(space["id"], "/desk")
+    assert posted.get("run_id") is None
+    assert posted.get("command") == "desk"
+    msgs = rig.store.list_messages(space["id"])
+    assert [m["role"] for m in msgs] == ["user", "tool"]
+    user, tool = msgs
+    assert user["content"] == "/desk"
+    assert user["meta"]["a2a"]["from"] == "operator"
+    assert user["meta"]["a2a"]["to"] == "Manager"
+    assert tool["meta"]["tool"] == "desk_status"
+    assert tool["meta"]["slash"] is True
+    assert "Human is money" in tool["content"] or "Cursor key" in tool["content"]
+    assert not rig.runtime._space_run.get(space["id"])
+
+
+@pytest.mark.asyncio
+async def test_at_teammate_routes_through_switchboard(rig) -> None:
+    space = rig.store.create_space("HQ")
+    manager = rig.runtime.ensure_manager(space["id"])
+    scout = rig.store.upsert_agent(space["id"], "Scout", role_prompt="Scout the brief.")
+    rig.llm.manager.append(LLMResult(text="Noted."))
+    rig.llm.teammate.append(LLMResult(text="Scout has the ping."))
+    posted = await rig.runtime.on_user_message(space["id"], "@Scout ping the board")
+    assert posted.get("run_id")
+    user = rig.store.list_messages(space["id"])[0]
+    assert user["role"] == "user"
+    assert user["to_agent_id"] == scout["id"]
+    assert user["meta"]["a2a"]["from"] == "operator"
+    assert user["meta"]["a2a"]["to"] == "Scout"
+    assert user["meta"]["mentions"][0]["kind"] == "teammate"
+    waiting = rig.runtime.switch.mailbox(scout["id"]).snapshot()
+    # New run rebuilds teammate history from the transcript; the envelope may
+    # already have been drained. Either the mailbox or history must show it.
+    history = " ".join(
+        str(m.get("content") or "")
+        for m in rig.runtime._teammate_history(space["id"], scout, None)
+    )
+    assert waiting or "[operator to Scout]" in history
+    if waiting:
+        assert waiting[0].kind == "user"
+        assert waiting[0].from_name == "operator"
+        assert waiting[0].to_name == "Scout"
+        assert waiting[0].to_id == scout["id"]
+    await wait_run_done(rig.runtime, space["id"])
+    # Manager still ran; transcript keeps sender/recipient on the user line.
+    assert user["meta"]["a2a"]["from"] == "operator"
+    assert manager["name"] == "Manager"
+
+
+@pytest.mark.asyncio
+async def test_at_role_stamps_recipient_without_a_teammate(rig) -> None:
+    space = rig.store.create_space("HQ")
+    rig.llm.manager.append(LLMResult(text="I will spawn PRD."))
+    await rig.runtime.on_user_message(space["id"], "@PRD write the spec")
+    await wait_run_done(rig.runtime, space["id"])
+    user = [m for m in rig.store.list_messages(space["id"]) if m["role"] == "user"][0]
+    assert user["meta"]["a2a"]["from"] == "operator"
+    assert user["meta"]["a2a"]["to"] == "PRD"
+    assert user["meta"]["mentions"][0]["kind"] == "role"
+    manager = rig.store.get_agent_by_name(space["id"], "Manager")
+    assert manager is not None
+    assert user["to_agent_id"] == manager["id"]
+    env_text = " ".join(
+        str(m.get("content") or "")
+        for m in rig.runtime._manager_history(space["id"])
+    )
+    assert "[operator -> PRD]" in env_text

--- a/tests/test_crew/test_server.py
+++ b/tests/test_crew/test_server.py
@@ -115,7 +115,10 @@ def test_ui_index_is_served(client) -> None:
     assert "Tickets" in page.text
     assert "Auto-detect" in page.text
     assert "Spawn the " not in page.text
-    assert "Ask the Manager. Auto-detect who to spawn." in page.text
+    assert "Ask the Manager. Type / for commands, @ for a teammate." in page.text
+    assert 'id="suggest"' in page.text
+    assert "/crew/commands" in page.text
+    assert "composer__suggest" in page.text
     assert "Login or 2FA. Take over this computer." in page.text
     assert "Done, I logged in" in page.text
     assert "class=\"takeover\"" in page.text or 'class="takeover"' in page.text
@@ -137,6 +140,7 @@ def test_ui_index_is_served(client) -> None:
     assert b"drop-veil" in css.content
     assert b".orb" in css.content
     assert b"scope-chip" in css.content
+    assert b"composer__suggest" in css.content
     assert b"--rail-ground" not in css.content
     assert b"--rk-page" not in css.content
     desk = client.http.get("/crew/desk").json()
@@ -287,3 +291,34 @@ def test_operator_can_choose_runtime_backend(client) -> None:
     bad = client.http.post("/crew/runtime", json={"backend": "firecracker"})
     assert bad.status_code == 400
 
+
+def test_commands_autocomplete_and_mention_targets(client) -> None:
+    body = client.http.get("/crew/commands").json()
+    slashes = {c["slash"] for c in body["commands"]}
+    assert {"desk", "board", "estate", "ship_gate"} <= slashes
+    assert any(c["kind"] == "skill" and c["slash"] == "build" for c in body["commands"])
+    assert any(c["kind"] == "routine" for c in body["commands"])
+    names = {m["name"] for m in body["mentions"]}
+    assert "Manager" in names
+    assert "PRD" in names
+    desk = client.http.get("/crew/commands", params={"q": "/desk"}).json()
+    assert desk["commands"][0]["action"] == "desk_status"
+    space = client.http.post("/crew/spaces", json={"title": "Mentions"}).json()
+    posted = client.http.post(
+        f"/crew/spaces/{space['id']}/messages", json={"text": "/desk"}
+    ).json()
+    assert posted.get("run_id") is None
+    assert posted.get("command") == "desk"
+    msgs = client.http.get(f"/crew/spaces/{space['id']}/messages").json()
+    assert [m["role"] for m in msgs] == ["user", "tool"]
+    assert msgs[0]["meta"]["a2a"]["from"] == "operator"
+    assert msgs[0]["meta"]["a2a"]["to"] == "Manager"
+    assert msgs[1]["meta"]["tool"] == "desk_status"
+    role_hit = client.http.post(
+        f"/crew/spaces/{space['id']}/messages", json={"text": "@PRD draft it"}
+    ).json()
+    assert "run_id" in role_hit
+    lined = client.http.get(f"/crew/spaces/{space['id']}/messages").json()
+    users = [m for m in lined if m["role"] == "user"]
+    assert users[-1]["meta"]["a2a"]["to"] == "PRD"
+    assert users[-1]["meta"]["mentions"][0]["kind"] == "role"


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Fixes #130
Parent: #116

Rebased onto origin/main after #140 RUNTIME and #141 ROUTER. Kept both: per-turn provider pick + `/` `@` composer. Do not merge until CI is green.

Grok-Bot-class `/` and `@` in `CortexOS/crew` chat, Netie-native (no Grok Bot/mybot renderer, no Guaca/Rakazo CSS paste). Composer autocomplete reuses landed chrome tokens (`.palette__hit`, `--line`/`--well`/`--live`).

## What shipped

1. **`/` autocomplete** of real Crew commands: desk tools (`/desk`, `/board`, `/estate`, `/ship_gate`), standing routines, taught/shipped skills. Catalog: `GET /crew/commands`. Desk slashes run the existing snapshot into the transcript without a model turn.
2. **`@` teammate or role.** Live agents win; capability templates (PRD, Gate, ...) remain mentionable before spawn. Delivery goes through the existing A2A Switchboard. Transcript stamps `meta.a2a.from` / `to` (`You -> Scout`).
3. Scope is `CortexOS/crew` + `tests/test_crew` only. :8020 not touched. Off #4/#41-#44.

## Verify

`python -m pytest tests/test_crew -q` -- 143 passed (includes ROUTER/RUNTIME tests on this tree).

## Out of scope

No analog CSS. No second inbox. No merge.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-2077a900-d002-4b71-826f-4ef1a3f7d79e?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-2077a900-d002-4b71-826f-4ef1a3f7d79e&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

