### PR TITLE
Crew dual-path runtime: laptop local-exec or Cloudflare Computer isolate

### DIFF
--- a/CortexOS/crew/config.py
+++ b/CortexOS/crew/config.py
@@ -39,6 +39,27 @@ class Provider:
         }
 
 
+def _flag(name: str, default: str = "") -> bool:
+    return os.environ.get(name, default).strip().lower() in {"1", "true", "yes", "on"}
+
+
+# Operator-chosen exec plane. Distinct from CREW_RUNTIME (path to RUNTIME.md).
+BACKEND_LAPTOP = "laptop"
+BACKEND_CF_COMPUTER = "cloudflare-computer"
+RUNTIME_BACKENDS = frozenset({BACKEND_LAPTOP, BACKEND_CF_COMPUTER})
+# Isolate path is PREVIEW-only (https://github.com/cloudflare/computer). Off by default.
+FLAG_CF_COMPUTER = "CREW_CF_COMPUTER"
+
+
+def parse_runtime_backend(raw: str | None) -> str:
+    value = (raw or "").strip().lower().replace("_", "-")
+    if value in {"cf", "cf-computer", "cloudflare", "isolate", "computer"}:
+        value = BACKEND_CF_COMPUTER
+    if value in RUNTIME_BACKENDS:
+        return value
+    return BACKEND_LAPTOP
+
+
 @dataclass
 class CrewSettings:
     port: int
@@ -52,6 +73,11 @@ class CrewSettings:
     max_steps_per_agent: int = 12
     confirm_timeout_s: int = 300
     llm_timeout_s: int = 180
+    runtime_backend: str = BACKEND_LAPTOP
+    cf_computer_enabled: bool = False
+    cf_computer_url: str = ""
+    cf_computer_token: str = ""
+    cf_computer_forward_host_env: bool = False
 
     @property
     def db_path(self) -> Path:
@@ -75,8 +101,12 @@ def load_settings() -> CrewSettings:
         # by design (ANS work), and crew renders that abstention honestly.
         engine_session=os.environ.get("CREW_ENGINE_SESSION", "demo"),
         data_dir=data_dir,
-        master_computer_control=os.environ.get("CORTEX_COMPUTER_CONTROL", "").strip()
-        in {"1", "true", "TRUE", "yes", "on"},
+        master_computer_control=_flag("CORTEX_COMPUTER_CONTROL"),
+        runtime_backend=parse_runtime_backend(os.environ.get("CREW_RUNTIME_BACKEND")),
+        cf_computer_enabled=_flag(FLAG_CF_COMPUTER),
+        cf_computer_url=os.environ.get("CREW_CF_COMPUTER_URL", "").strip(),
+        cf_computer_token=os.environ.get("CREW_CF_COMPUTER_TOKEN", "").strip(),
+        cf_computer_forward_host_env=_flag("CREW_CF_COMPUTER_FORWARD_HOST_ENV"),
     )
 
 

--- a/CortexOS/crew/policy.py
+++ b/CortexOS/crew/policy.py
@@ -12,6 +12,8 @@ refuses silently would read as a hang (KB R-0011).
 
 from __future__ import annotations
 
+from CortexOS.crew.config import BACKEND_CF_COMPUTER, BACKEND_LAPTOP, FLAG_CF_COMPUTER
+
 # Windows-MCP capture/timing tools that observe but do not act. Everything not
 # listed here is treated as mutating - fail closed on unknown tools.
 READ_ONLY_TOOLS = frozenset(
@@ -69,6 +71,31 @@ CONFIRM = "confirm"
 DENY = "deny"
 TAKEOVER = "takeover"
 
+# Existing approved local exec (github.py / estate gh). Unknown binaries fail closed.
+LOCAL_SHELL_ALLOWLIST = frozenset({"gh"})
+# gh verbs that change remote state. list/view/status stay allow after argv[0] match.
+MUTATING_GH_VERBS = frozenset(
+    {
+        "create",
+        "close",
+        "merge",
+        "delete",
+        "edit",
+        "ready",
+        "review",
+        "comment",
+        "release",
+        "workflow",
+        "api",
+        "gist",
+        "secret",
+        "auth",
+        "login",
+    }
+)
+# `gh auth status` is a probe, not a login. Allow that exact shape.
+GH_AUTH_STATUS = ("gh", "auth", "status")
+
 # Arg keys / tool names that mean the operator should type, not the agent.
 _AUTH_KEYS = frozenset({"password", "passwd", "pass", "secret", "token", "otp", "totp", "pin"})
 _AUTH_HINTS = ("password", "passwd", "login", "signin", "sign-in", "otp", "2fa", "totp", "auth")
@@ -123,3 +150,47 @@ def decide(
     if tool in READ_ONLY_TOOLS:
         return ALLOW, "read-only capture tool on an armed server"
     return CONFIRM, "mutating computer-control tool needs operator approval"
+
+
+def _argv0(argv: list[str]) -> str:
+    if not argv:
+        return ""
+    name = argv[0].replace("\\", "/").rsplit("/", 1)[-1]
+    if name.lower().endswith(".exe"):
+        name = name[:-4]
+    return name.lower()
+
+
+def decide_runtime(
+    argv: list[str],
+    *,
+    backend: str,
+    isolate_enabled: bool,
+    approved: bool = False,
+) -> tuple[str, str]:
+    """Gate one dual-path exec. Laptop uses the existing gh allowlist; isolate
+    additionally requires CREW_CF_COMPUTER=1. Unknown binaries never run."""
+    if not argv or not str(argv[0]).strip():
+        return DENY, "empty argv"
+    backend = (backend or "").strip().lower().replace("_", "-")
+    if backend not in {BACKEND_LAPTOP, BACKEND_CF_COMPUTER}:
+        return DENY, f"unknown runtime backend '{backend}'"
+    if backend == BACKEND_CF_COMPUTER and not isolate_enabled:
+        return DENY, (
+            f"cloudflare-computer isolate is off: set {FLAG_CF_COMPUTER}=1 "
+            "(PREVIEW only, not production)"
+        )
+    binary = _argv0(argv)
+    if binary not in LOCAL_SHELL_ALLOWLIST:
+        return DENY, f"local tool '{binary or argv[0]}' is not on the approved allowlist"
+    tokens = [str(p).lower() for p in argv]
+    mutating = [t for t in tokens[1:] if t in MUTATING_GH_VERBS]
+    if tuple(tokens[:3]) == GH_AUTH_STATUS:
+        mutating = [t for t in mutating if t != "auth"]
+    if mutating:
+        if approved:
+            return ALLOW, "operator approved mutating local tool"
+        return CONFIRM, (
+            "mutating local tool needs operator approval: " + ", ".join(dict.fromkeys(mutating))
+        )
+    return ALLOW, f"approved local tool on {backend}"

--- a/CortexOS/crew/server.py
+++ b/CortexOS/crew/server.py
@@ -27,6 +27,7 @@ from CortexOS.crew.keys import status as keys_status
 from CortexOS.crew.mcp_client import MCPManager
 from CortexOS.crew.queue import JobQueue
 from CortexOS.crew.runtime import CrewRuntime
+from CortexOS.crew.shell import CrewShell
 from CortexOS.crew.store import CrewStore
 from CortexOS.crew.wakes import WakeBoard, conveyor
 
@@ -71,6 +72,7 @@ class CrewApp:
         self.runtime = CrewRuntime(
             self.store, self.bus, self.settings, self.mcp, self.bridge, llm_chat=llm_chat
         )
+        self.shell = CrewShell(self.settings)
         self.wakes = WakeBoard()
         self.queue = JobQueue()
 
@@ -139,6 +141,10 @@ class ComputerIn(BaseModel):
     host: str  # this-pc | off
 
 
+class RuntimeIn(BaseModel):
+    backend: str  # laptop | cloudflare-computer
+
+
 class SkillIn(BaseModel):
     title: str
     body: str
@@ -179,6 +185,7 @@ def build_router(crew: CrewApp) -> APIRouter:
             "engine": await crew.bridge.health(),
             "openvault": healthz(),
             "computer_control": crew.settings.master_computer_control,
+            "runtime": crew.shell.public(),
             "grok_offloaded": True,
             "grok_autostart": False,
             "mcp": mcp,
@@ -355,6 +362,19 @@ def build_router(crew: CrewApp) -> APIRouter:
         except PermissionError as exc:
             raise HTTPException(403, str(exc)) from exc
         return {"ok": True, "host": "this-pc", "mcp": crew.mcp.status()}
+
+    @router.get("/runtime")
+    async def runtime_status() -> dict[str, Any]:
+        """Dual-path exec plane. Isolate is PREVIEW only; never returns secrets."""
+        return crew.shell.public()
+
+    @router.post("/runtime")
+    async def runtime_choose(body: RuntimeIn) -> dict[str, Any]:
+        try:
+            status = crew.shell.set_backend(body.backend)
+        except ValueError as exc:
+            raise HTTPException(400, str(exc)) from exc
+        return {"ok": True, **status}
 
     @router.post("/skills")
     async def save_skill(body: SkillIn) -> dict[str, Any]:

--- a/CortexOS/crew/shell.py
+++ b/CortexOS/crew/shell.py
@@ -1,0 +1,390 @@
+"""Crew dual-path exec: laptop local-exec or Cloudflare Computer isolate.
+
+Laptop reuses the existing approved ``gh`` tools (github.py) behind
+``policy.decide_runtime``. The isolate path is an adapter toward
+``workspace.runtime.exec`` from https://github.com/cloudflare/computer —
+PREVIEW only, not production. Feature flag ``CREW_CF_COMPUTER`` is off by
+default. Host credentials are never copied into isolate env unless the
+operator sets ``CREW_CF_COMPUTER_FORWARD_HOST_ENV=1``, and even then
+secret-shaped keys (and the CF token itself) are stripped.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+import shlex
+import subprocess
+import urllib.error
+import urllib.request
+from collections.abc import Callable
+from dataclasses import dataclass, field
+from typing import Any, Protocol
+
+from CortexOS.crew import policy
+from CortexOS.crew.config import (
+    BACKEND_CF_COMPUTER,
+    BACKEND_LAPTOP,
+    FLAG_CF_COMPUTER,
+    CrewSettings,
+    parse_runtime_backend,
+)
+
+CF_COMPUTER_SOURCE = "https://github.com/cloudflare/computer"
+# Matches workspace.runtime.exec command backends in the preview package.
+CF_PREVIEW_RUNTIME_BACKEND = "worker-shell"
+
+_SECRET_KEY_RE = re.compile(
+    r"(API_KEY|ACCESS_KEY|SECRET|TOKEN|PASSWORD|PASSWD|AUTHORIZATION|CREDENTIAL|PRIVATE_KEY)$",
+    re.I,
+)
+
+RunFn = Callable[..., subprocess.CompletedProcess[str]]
+PostFn = Callable[[str, dict[str, Any], str, float], dict[str, Any]]
+
+
+class RuntimeAdapter(Protocol):
+    """One exec plane. Tests inject fakes; production uses laptop or CF preview."""
+
+    name: str
+
+    def exec(
+        self,
+        argv: list[str],
+        *,
+        cwd: str | None = None,
+        env: dict[str, str] | None = None,
+        timeout: float = 20.0,
+    ) -> ExecResult: ...
+
+
+@dataclass(frozen=True)
+class ExecResult:
+    ok: bool
+    backend: str
+    argv: tuple[str, ...]
+    stdout: str = ""
+    stderr: str = ""
+    exit_code: int = 1
+    denied: bool = False
+    confirm: bool = False
+    reason: str = ""
+    preview: bool = False
+    production: bool = False
+    isolate_env_keys: tuple[str, ...] = ()
+
+    def public(self) -> dict[str, Any]:
+        return {
+            "ok": self.ok,
+            "backend": self.backend,
+            "argv": list(self.argv),
+            "stdout": self.stdout[:8000],
+            "stderr": self.stderr[:2000],
+            "exit_code": self.exit_code,
+            "denied": self.denied,
+            "confirm": self.confirm,
+            "reason": self.reason,
+            "preview": self.preview,
+            "production": self.production,
+            "isolate_env_keys": list(self.isolate_env_keys),
+        }
+
+
+def _is_secret_key(name: str) -> bool:
+    if name.upper() in {FLAG_CF_COMPUTER, "CREW_CF_COMPUTER_TOKEN", "CREW_CF_COMPUTER_URL"}:
+        return True
+    return bool(_SECRET_KEY_RE.search(name))
+
+
+def isolate_env(
+    explicit: dict[str, str] | None,
+    *,
+    forward_host: bool,
+    extra_block: frozenset[str] | None = None,
+) -> dict[str, str]:
+    """Build isolate env. Default is empty. Never copies host secrets."""
+    blocked = extra_block or frozenset()
+    out: dict[str, str] = {}
+    if forward_host:
+        for key, value in os.environ.items():
+            if key in blocked or _is_secret_key(key):
+                continue
+            out[key] = value
+    for key, value in (explicit or {}).items():
+        if key in blocked or _is_secret_key(key):
+            continue
+        out[key] = value
+    out.pop("CREW_CF_COMPUTER_TOKEN", None)
+    return out
+
+
+def _run_local(argv: list[str], timeout: float = 20.0, cwd: str | None = None) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(argv, capture_output=True, text=True, timeout=timeout, cwd=cwd)
+
+
+def _post_json(url: str, body: dict[str, Any], token: str, timeout: float) -> dict[str, Any]:
+    data = json.dumps(body).encode("utf-8")
+    headers = {"Content-Type": "application/json", "Accept": "application/json"}
+    if token:
+        headers["Authorization"] = "Bearer " + token
+    req = urllib.request.Request(url, data=data, headers=headers, method="POST")
+    with urllib.request.urlopen(req, timeout=timeout) as resp:
+        raw = resp.read().decode("utf-8", "replace")
+    if not raw.strip():
+        return {}
+    parsed = json.loads(raw)
+    if not isinstance(parsed, dict):
+        return {"ok": False, "detail": "non-object response"}
+    return parsed
+
+
+@dataclass
+class LaptopAdapter:
+    """Host subprocess of allowlisted argv. Same shape as github.py ``_run``."""
+
+    runner: RunFn = field(default=_run_local)
+    name: str = BACKEND_LAPTOP
+
+    def exec(
+        self,
+        argv: list[str],
+        *,
+        cwd: str | None = None,
+        env: dict[str, str] | None = None,
+        timeout: float = 20.0,
+    ) -> ExecResult:
+        del env  # laptop keeps host env; isolate path is the leak boundary
+        try:
+            result = self.runner(argv, timeout=timeout, cwd=cwd)
+        except TypeError:
+            result = self.runner(argv, timeout=timeout)
+        except FileNotFoundError:
+            return ExecResult(
+                ok=False,
+                backend=self.name,
+                argv=tuple(argv),
+                reason=f"{argv[0]} not installed",
+            )
+        except (OSError, subprocess.TimeoutExpired) as exc:
+            return ExecResult(
+                ok=False,
+                backend=self.name,
+                argv=tuple(argv),
+                reason=f"{type(exc).__name__}: {exc}",
+            )
+        stdout = result.stdout or ""
+        stderr = result.stderr or ""
+        return ExecResult(
+            ok=result.returncode == 0,
+            backend=self.name,
+            argv=tuple(argv),
+            stdout=stdout,
+            stderr=stderr,
+            exit_code=int(result.returncode),
+            reason="" if result.returncode == 0 else (stderr or stdout or "nonzero exit")[:400],
+        )
+
+
+@dataclass
+class CloudflareComputerAdapter:
+    """HTTP adapter toward a preview ``workspace.runtime.exec`` gateway.
+
+    Cloudflare Computer is a Workers library, not a public production API.
+    This posts the documented runtime.exec JSON. Missing URL/token is a
+    preview-unavailable result, not a silent host fallback.
+    """
+
+    endpoint: str
+    token: str = ""
+    forward_host_env: bool = False
+    post: PostFn = field(default=_post_json)
+    name: str = BACKEND_CF_COMPUTER
+
+    def exec(
+        self,
+        argv: list[str],
+        *,
+        cwd: str | None = None,
+        env: dict[str, str] | None = None,
+        timeout: float = 20.0,
+    ) -> ExecResult:
+        blocked = frozenset({k for k, v in os.environ.items() if v and v == self.token} if self.token else [])
+        sent_env = isolate_env(
+            env,
+            forward_host=self.forward_host_env,
+            extra_block=blocked,
+        )
+        if not self.endpoint:
+            return ExecResult(
+                ok=False,
+                backend=self.name,
+                argv=tuple(argv),
+                preview=True,
+                production=False,
+                isolate_env_keys=tuple(sorted(sent_env)),
+                reason=(
+                    "Cloudflare Computer preview gateway not configured "
+                    "(set CREW_CF_COMPUTER_URL). PREVIEW only, not production. "
+                    f"Source: {CF_COMPUTER_SOURCE}"
+                ),
+            )
+        url = self.endpoint.rstrip("/")
+        if not url.endswith("/runtime/exec"):
+            url = url + "/runtime/exec"
+        body = {
+            "source": shlex.join(argv),
+            "backend": CF_PREVIEW_RUNTIME_BACKEND,
+            "timeoutMs": int(timeout * 1000),
+            "env": sent_env,
+        }
+        if cwd:
+            body["cwd"] = cwd
+        try:
+            payload = self.post(url, body, self.token, timeout)
+        except (OSError, urllib.error.URLError, TimeoutError, ValueError, json.JSONDecodeError) as exc:
+            return ExecResult(
+                ok=False,
+                backend=self.name,
+                argv=tuple(argv),
+                preview=True,
+                production=False,
+                isolate_env_keys=tuple(sorted(sent_env)),
+                reason=f"preview gateway error: {type(exc).__name__}: {exc}",
+            )
+        stdout = str(payload.get("stdout") or "")
+        stderr = str(payload.get("stderr") or payload.get("detail") or "")
+        status = str(payload.get("status") or "")
+        raw_code = payload.get("exitCode", payload.get("exit_code", 1))
+        try:
+            exit_code = int(raw_code) if isinstance(raw_code, (int, str)) else 1
+        except (TypeError, ValueError):
+            exit_code = 1
+        ok = bool(payload.get("ok", status == "completed" or exit_code == 0))
+        return ExecResult(
+            ok=ok,
+            backend=self.name,
+            argv=tuple(argv),
+            stdout=stdout,
+            stderr=stderr,
+            exit_code=exit_code,
+            preview=True,
+            production=False,
+            isolate_env_keys=tuple(sorted(sent_env)),
+            reason="" if ok else (stderr or status or "preview exec failed")[:400],
+        )
+
+
+class CrewShell:
+    """Operator-selected dual path. Policy runs before either adapter."""
+
+    def __init__(
+        self,
+        settings: CrewSettings,
+        *,
+        runner: RunFn | None = None,
+        transport: PostFn | None = None,
+    ) -> None:
+        self.settings = settings
+        self.laptop = LaptopAdapter(runner=runner or _run_local)
+        self.isolate = CloudflareComputerAdapter(
+            endpoint=settings.cf_computer_url,
+            token=settings.cf_computer_token,
+            forward_host_env=settings.cf_computer_forward_host_env,
+            post=transport or _post_json,
+        )
+
+    def set_backend(self, name: str) -> dict[str, Any]:
+        raw = (name or "").strip().lower().replace("_", "-")
+        aliases = {
+            "local": BACKEND_LAPTOP,
+            "host": BACKEND_LAPTOP,
+            "this-pc": BACKEND_LAPTOP,
+            "cf": BACKEND_CF_COMPUTER,
+            "cf-computer": BACKEND_CF_COMPUTER,
+            "cloudflare": BACKEND_CF_COMPUTER,
+            "isolate": BACKEND_CF_COMPUTER,
+            "computer": BACKEND_CF_COMPUTER,
+        }
+        backend = aliases.get(raw, raw)
+        if backend not in {BACKEND_LAPTOP, BACKEND_CF_COMPUTER}:
+            raise ValueError(f"backend must be {BACKEND_LAPTOP} or {BACKEND_CF_COMPUTER}")
+        self.settings.runtime_backend = backend
+        return self.public()
+
+    def public(self) -> dict[str, Any]:
+        token_set = bool(self.settings.cf_computer_token)
+        return {
+            "backend": self.settings.runtime_backend,
+            "backends": [BACKEND_LAPTOP, BACKEND_CF_COMPUTER],
+            "flag": FLAG_CF_COMPUTER,
+            "cf_computer": self.settings.cf_computer_enabled,
+            "preview": True,
+            "production": False,
+            "endpoint_configured": bool(self.settings.cf_computer_url),
+            "token_configured": token_set,
+            "forward_host_env": self.settings.cf_computer_forward_host_env,
+            "source": CF_COMPUTER_SOURCE,
+            "laptop_allow": sorted(policy.LOCAL_SHELL_ALLOWLIST),
+        }
+
+    def exec(
+        self,
+        argv: list[str],
+        *,
+        approved: bool = False,
+        cwd: str | None = None,
+        env: dict[str, str] | None = None,
+        timeout: float = 20.0,
+        backend: str | None = None,
+    ) -> ExecResult:
+        chosen = parse_runtime_backend(backend or self.settings.runtime_backend)
+        decision, reason = policy.decide_runtime(
+            argv,
+            backend=chosen,
+            isolate_enabled=self.settings.cf_computer_enabled,
+            approved=approved,
+        )
+        if decision == policy.DENY:
+            return ExecResult(
+                ok=False,
+                backend=chosen,
+                argv=tuple(argv),
+                denied=True,
+                reason=reason,
+                preview=chosen == BACKEND_CF_COMPUTER,
+                production=False,
+            )
+        if decision == policy.CONFIRM:
+            return ExecResult(
+                ok=False,
+                backend=chosen,
+                argv=tuple(argv),
+                confirm=True,
+                reason=reason,
+                preview=chosen == BACKEND_CF_COMPUTER,
+                production=False,
+            )
+        adapter: RuntimeAdapter = self.isolate if chosen == BACKEND_CF_COMPUTER else self.laptop
+        result = adapter.exec(argv, cwd=cwd, env=env, timeout=timeout)
+        if chosen == BACKEND_CF_COMPUTER:
+            # Belt-and-suspenders: isolate results never claim production.
+            return ExecResult(
+                ok=result.ok,
+                backend=result.backend,
+                argv=result.argv,
+                stdout=result.stdout,
+                stderr=result.stderr,
+                exit_code=result.exit_code,
+                denied=result.denied,
+                confirm=result.confirm,
+                reason=result.reason,
+                preview=True,
+                production=False,
+                isolate_env_keys=result.isolate_env_keys,
+            )
+        return result
+
+
+def public_status(settings: CrewSettings) -> dict[str, Any]:
+    return CrewShell(settings).public()

--- a/tests/test_crew/test_server.py
+++ b/tests/test_crew/test_server.py
@@ -239,3 +239,26 @@ def test_tickets_skills_and_voice(client, tmp_path, monkeypatch) -> None:
     voice = client.http.get("/crew/voice").json()
     assert voice["available"] is False
     assert "fake speech" in voice["reason"]
+
+
+def test_operator_can_choose_runtime_backend(client) -> None:
+    health = client.http.get("/crew/health").json()
+    runtime = health["runtime"]
+    assert runtime["backend"] == "laptop"
+    assert runtime["flag"] == "CREW_CF_COMPUTER"
+    assert runtime["cf_computer"] is False
+    assert runtime["production"] is False
+    assert runtime["preview"] is True
+    assert "token" not in runtime
+    listed = client.http.get("/crew/runtime").json()
+    assert listed == runtime
+    switched = client.http.post("/crew/runtime", json={"backend": "cloudflare-computer"}).json()
+    assert switched["ok"] is True
+    assert switched["backend"] == "cloudflare-computer"
+    assert switched["production"] is False
+    assert client.http.get("/crew/runtime").json()["backend"] == "cloudflare-computer"
+    back = client.http.post("/crew/runtime", json={"backend": "laptop"}).json()
+    assert back["backend"] == "laptop"
+    bad = client.http.post("/crew/runtime", json={"backend": "firecracker"})
+    assert bad.status_code == 400
+

--- a/tests/test_crew/test_shell.py
+++ b/tests/test_crew/test_shell.py
@@ -1,0 +1,232 @@
+"""Dual-path crew exec: laptop allowlist vs Cloudflare Computer isolate (preview)."""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from CortexOS.crew import config, policy
+from CortexOS.crew.config import (
+    BACKEND_CF_COMPUTER,
+    BACKEND_LAPTOP,
+    FLAG_CF_COMPUTER,
+    CrewSettings,
+)
+from CortexOS.crew.shell import CrewShell, isolate_env
+
+
+def _settings(tmp_path: Path, **kwargs: Any) -> CrewSettings:
+    data = tmp_path / "crew"
+    data.mkdir(parents=True, exist_ok=True)
+    values: dict[str, Any] = {
+        "port": 0,
+        "engine_url": "http://127.0.0.1:9",
+        "engine_session": "demo",
+        "data_dir": data,
+        "master_computer_control": False,
+    }
+    values.update(kwargs)
+    return CrewSettings(**values)
+
+
+def _ok_run(
+    argv: list[str], timeout: float = 20.0, cwd: str | None = None
+) -> subprocess.CompletedProcess[str]:
+    return subprocess.CompletedProcess(argv, 0, stdout="ok " + " ".join(argv), stderr="")
+
+
+def test_load_settings_defaults_laptop_and_flag_off(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    monkeypatch.setenv("CREW_DATA_DIR", str(tmp_path / "crew"))
+    monkeypatch.delenv("CREW_RUNTIME_BACKEND", raising=False)
+    monkeypatch.delenv(FLAG_CF_COMPUTER, raising=False)
+    monkeypatch.delenv("CREW_CF_COMPUTER_TOKEN", raising=False)
+    monkeypatch.delenv("CREW_CF_COMPUTER_URL", raising=False)
+    monkeypatch.delenv("CREW_CF_COMPUTER_FORWARD_HOST_ENV", raising=False)
+    settings = config.load_settings()
+    assert settings.runtime_backend == BACKEND_LAPTOP
+    assert settings.cf_computer_enabled is False
+    assert settings.cf_computer_forward_host_env is False
+    assert settings.cf_computer_token == ""
+
+
+def test_operator_env_selects_isolate_backend(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    monkeypatch.setenv("CREW_DATA_DIR", str(tmp_path / "crew"))
+    monkeypatch.setenv("CREW_RUNTIME_BACKEND", "cloudflare-computer")
+    monkeypatch.setenv(FLAG_CF_COMPUTER, "1")
+    settings = config.load_settings()
+    assert settings.runtime_backend == BACKEND_CF_COMPUTER
+    assert settings.cf_computer_enabled is True
+
+
+def test_decide_runtime_allowlist_and_mutating() -> None:
+    allow, reason = policy.decide_runtime(
+        ["gh", "pr", "list", "--limit", "5"],
+        backend=BACKEND_LAPTOP,
+        isolate_enabled=False,
+    )
+    assert allow == policy.ALLOW and "laptop" in reason
+
+    auth, _ = policy.decide_runtime(
+        ["gh", "auth", "status"], backend=BACKEND_LAPTOP, isolate_enabled=False
+    )
+    assert auth == policy.ALLOW
+
+    denied, why = policy.decide_runtime(
+        ["bash", "-c", "id"], backend=BACKEND_LAPTOP, isolate_enabled=False
+    )
+    assert denied == policy.DENY and "allowlist" in why
+
+    confirm, cwhy = policy.decide_runtime(
+        ["gh", "pr", "merge", "1"], backend=BACKEND_LAPTOP, isolate_enabled=False
+    )
+    assert confirm == policy.CONFIRM and "merge" in cwhy
+
+    after, _ = policy.decide_runtime(
+        ["gh", "pr", "merge", "1"],
+        backend=BACKEND_LAPTOP,
+        isolate_enabled=False,
+        approved=True,
+    )
+    assert after == policy.ALLOW
+
+    off, flag_why = policy.decide_runtime(
+        ["gh", "pr", "list"],
+        backend=BACKEND_CF_COMPUTER,
+        isolate_enabled=False,
+    )
+    assert off == policy.DENY and FLAG_CF_COMPUTER in flag_why and "not production" in flag_why
+
+
+def test_laptop_exec_uses_injected_runner(tmp_path: Path) -> None:
+    seen: list[list[str]] = []
+
+    def runner(
+        argv: list[str], timeout: float = 20.0, cwd: str | None = None
+    ) -> subprocess.CompletedProcess[str]:
+        seen.append(argv)
+        return _ok_run(argv, timeout=timeout, cwd=cwd)
+
+    crew_shell = CrewShell(_settings(tmp_path), runner=runner)
+    result = crew_shell.exec(["gh", "pr", "list", "--limit", "5"])
+    assert result.ok is True
+    assert result.backend == BACKEND_LAPTOP
+    assert result.production is False
+    assert seen == [["gh", "pr", "list", "--limit", "5"]]
+    assert "gh pr list" in result.stdout
+
+
+def test_laptop_unknown_binary_never_runs(tmp_path: Path) -> None:
+    def boom(*_a: Any, **_k: Any) -> subprocess.CompletedProcess[str]:
+        raise AssertionError("runner must not run a denied argv")
+
+    crew_shell = CrewShell(_settings(tmp_path), runner=boom)
+    result = crew_shell.exec(["bash", "-c", "cat /etc/passwd"])
+    assert result.denied is True
+    assert result.ok is False
+    assert "allowlist" in result.reason
+
+
+def test_isolate_flag_off_does_not_post(tmp_path: Path) -> None:
+    def boom(*_a: Any, **_k: Any) -> dict[str, Any]:
+        raise AssertionError("must not call preview gateway when flag is off")
+
+    settings = _settings(
+        tmp_path, runtime_backend=BACKEND_CF_COMPUTER, cf_computer_enabled=False
+    )
+    crew_shell = CrewShell(settings, transport=boom)
+    result = crew_shell.exec(["gh", "pr", "list"])
+    assert result.denied is True
+    assert FLAG_CF_COMPUTER in result.reason
+    assert result.preview is True
+    assert result.production is False
+
+
+def test_isolate_without_url_is_preview_unavailable(tmp_path: Path) -> None:
+    settings = _settings(
+        tmp_path, runtime_backend=BACKEND_CF_COMPUTER, cf_computer_enabled=True
+    )
+    crew_shell = CrewShell(settings)
+    result = crew_shell.exec(["gh", "repo", "list", "Netie-AI"])
+    assert result.ok is False
+    assert result.preview is True
+    assert result.production is False
+    assert "not production" in result.reason
+    assert "CREW_CF_COMPUTER_URL" in result.reason
+
+
+def test_isolate_mock_does_not_forward_host_secrets(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    monkeypatch.setenv("OPENAI_API_KEY", "sk-host-must-not-leak")
+    monkeypatch.setenv("GH_TOKEN", "ghp-host-must-not-leak")
+    monkeypatch.setenv("PATH", "/usr/bin")
+    posted: dict[str, Any] = {}
+
+    def transport(url: str, body: dict[str, Any], token: str, timeout: float) -> dict[str, Any]:
+        posted["url"] = url
+        posted["body"] = body
+        posted["token"] = token
+        return {
+            "ok": True,
+            "status": "completed",
+            "exitCode": 0,
+            "stdout": "isolated",
+            "stderr": "",
+        }
+
+    settings = _settings(
+        tmp_path,
+        runtime_backend=BACKEND_CF_COMPUTER,
+        cf_computer_enabled=True,
+        cf_computer_url="https://preview.example/computer",
+        cf_computer_token="cf-preview-token",
+        cf_computer_forward_host_env=False,
+    )
+    crew_shell = CrewShell(settings, transport=transport)
+    result = crew_shell.exec(
+        ["gh", "pr", "list"],
+        env={"OPENAI_API_KEY": "sk-explicit", "CI": "1", "GH_TOKEN": "nope"},
+    )
+    assert result.ok is True
+    assert result.preview is True
+    assert result.production is False
+    env = posted["body"]["env"]
+    assert env.get("CI") == "1"
+    assert "OPENAI_API_KEY" not in env
+    assert "GH_TOKEN" not in env
+    assert "sk-host-must-not-leak" not in str(posted["body"])
+    assert "cf-preview-token" not in str(posted["body"]["env"])
+    assert posted["token"] == "cf-preview-token"
+    assert posted["url"].endswith("/runtime/exec")
+    assert posted["body"]["backend"] == "worker-shell"
+    assert "OPENAI_API_KEY" not in result.isolate_env_keys
+
+
+def test_forward_host_env_still_strips_secrets(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    monkeypatch.setenv("OPENAI_API_KEY", "sk-still-blocked")
+    monkeypatch.setenv("LANG", "C")
+    out = isolate_env(None, forward_host=True)
+    assert out.get("LANG") == "C"
+    assert "OPENAI_API_KEY" not in out
+    assert "CREW_CF_COMPUTER_TOKEN" not in out
+
+
+def test_public_status_never_includes_token(tmp_path: Path) -> None:
+    settings = _settings(tmp_path, cf_computer_token="super-secret-token")
+    status = CrewShell(settings).public()
+    blob = str(status)
+    assert "super-secret-token" not in blob
+    assert status["flag"] == FLAG_CF_COMPUTER
+    assert status["production"] is False
+    assert status["preview"] is True
+    assert status["token_configured"] is True
+    assert status["source"] == "https://github.com/cloudflare/computer"


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Fixes #133
Parent epic: #116

CREW-RUNTIME dual path on `CortexOS/crew`. Does not touch #4 / #41 / #42 / #43 / #44.

## What

Operator-chosen exec plane for Crew:

1. **Laptop (default)** — existing approved local `gh` tools behind `policy.decide_runtime` (allowlist + mutating confirm). Same shape as `github.py`.
2. **Cloudflare Computer isolate** — feature-flagged adapter toward [`workspace.runtime.exec`](https://github.com/cloudflare/computer) (`worker-shell`). **PREVIEW only. Not production.** Flag `CREW_CF_COMPUTER` is off by default.

## Flags

- `CREW_CF_COMPUTER` — isolate adapter, **off by default** (preview feature-flag only)
- `CREW_RUNTIME_BACKEND=laptop|cloudflare-computer` — operator choice (distinct from `CREW_RUNTIME`, which is still the RUNTIME.md path)
- `CREW_CF_COMPUTER_URL` / `CREW_CF_COMPUTER_TOKEN` — optional preview gateway; missing creds fail closed with a mock-friendly preview-unavailable result
- `CREW_CF_COMPUTER_FORWARD_HOST_ENV` — opt-in host env copy; **secret-shaped keys and the CF token are still stripped**

`GET/POST /crew/runtime` and `GET /crew/health` expose the plane. Token values never appear in JSON.

## Tests

`python3 -m pytest tests/test_crew -q` — 126 passed, mocks only, no CF creds required.

## Honesty

Cloudflare Computer is a Workers preview library, not a hosted production runtime. Isolate stays behind `CREW_CF_COMPUTER`. This PR does not claim otherwise.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-1dd8609e-aaa4-4741-afa5-edb9737802aa?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-1dd8609e-aaa4-4741-afa5-edb9737802aa&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

