### PR TITLE
CREW-ROUTER: per-turn provider/model + usage HUD

### DIFF
--- a/CortexOS/crew/config.py
+++ b/CortexOS/crew/config.py
@@ -2,8 +2,12 @@
 
 The crew layer never requires one specific model host. Resolution walks a
 chain (explicit ``CREW_MODEL``, then live OpenVault FreeRoute, then Anthropic,
-Cursor, OpenRouter, DeepSeek, any OpenAI-compatible endpoint, and last a
-locally reachable Ollama). The winner is stamped on every reply envelope.
+Cursor, OpenRouter, DeepSeek, any OpenAI-compatible endpoint, Groq / Google /
+Cerebras / Mistral, and last a locally reachable Ollama).
+
+``CREW_PROVIDER`` pins one label. A pin does not fall through to the next
+configured host if that label is unset or down. The winner is stamped on
+every reply envelope.
 """
 
 from __future__ import annotations
@@ -107,7 +111,11 @@ def _ollama_first_model(base_url: str, timeout: float = 0.8) -> str | None:
 
 
 def resolve_providers() -> list[Provider]:
-    """Build the provider chain; exactly the first configured entry is active."""
+    """Build the provider chain.
+
+    Default: the first configured entry is active. When ``CREW_PROVIDER`` is
+    set, only that label may be active; a miss stays inactive (no fallback).
+    """
     env = os.environ
     chain: list[Provider] = []
 
@@ -128,7 +136,7 @@ def resolve_providers() -> list[Provider]:
     chain.append(
         Provider(
             label="openvault",
-            model="openvault/auto",
+            model="openvault/" + (env.get("CREW_OPENVAULT_MODEL", "").strip() or "auto"),
             source="OpenVault FreeRoute (loopback, keys stay in the vault)",
             configured=ov_ok,
             api_base=env.get("CREW_OPENVAULT_URL", "http://127.0.0.1:5000"),
@@ -186,6 +194,38 @@ def resolve_providers() -> list[Provider]:
             api_base=openai_base,
         )
     )
+    chain.append(
+        Provider(
+            label="groq",
+            model="groq/" + env.get("CREW_GROQ_MODEL", "llama-3.3-70b-versatile"),
+            source="GROQ_API_KEY",
+            configured=bool(env.get("GROQ_API_KEY")),
+        )
+    )
+    chain.append(
+        Provider(
+            label="google",
+            model="gemini/" + env.get("CREW_GOOGLE_MODEL", "gemini-2.0-flash"),
+            source="GOOGLE_API_KEY",
+            configured=bool(env.get("GOOGLE_API_KEY")),
+        )
+    )
+    chain.append(
+        Provider(
+            label="cerebras",
+            model="cerebras/" + env.get("CREW_CEREBRAS_MODEL", "llama3.1-8b"),
+            source="CEREBRAS_API_KEY",
+            configured=bool(env.get("CEREBRAS_API_KEY")),
+        )
+    )
+    chain.append(
+        Provider(
+            label="mistral",
+            model="mistral/" + env.get("CREW_MISTRAL_MODEL", "mistral-small-latest"),
+            source="MISTRAL_API_KEY",
+            configured=bool(env.get("MISTRAL_API_KEY")),
+        )
+    )
     ollama_model: str | None = None
     if env.get("CREW_ALLOW_OLLAMA", "1") != "0":
         ollama_model = _ollama_first_model(
@@ -200,7 +240,33 @@ def resolve_providers() -> list[Provider]:
         )
     )
 
+    pin = env.get("CREW_PROVIDER", "").strip().lower()
+    if pin in {"openai", "ov", "vault", "gemini"}:
+        pin = {"openai": "openai-compatible", "ov": "openvault", "vault": "openvault", "gemini": "google"}[pin]
+
     out: list[Provider] = []
+    if pin:
+        matched = False
+        for p in chain:
+            if p.label.lower() == pin:
+                matched = True
+                if p.configured:
+                    out.append(Provider(p.label, p.model, p.source, True, True, p.api_base))
+                else:
+                    out.append(p)
+            else:
+                out.append(
+                    Provider(p.label, p.model, p.source, p.configured, False, p.api_base)
+                    if p.active
+                    else p
+                )
+        if not matched:
+            return [
+                Provider(p.label, p.model, p.source, p.configured, False, p.api_base)
+                for p in chain
+            ]
+        return out
+
     activated = False
     for p in chain:
         if p.configured and not activated:

--- a/CortexOS/crew/connectors.py
+++ b/CortexOS/crew/connectors.py
@@ -1,7 +1,10 @@
 """Grok Bot plugins -> Netie layers. Stolen catalog shape from rakazo composio-emulator.
 
 Crew does not invent a second OAuth broker. Each row names the Netie owner and
-whether it is live on this machine (short HTTP probe, no secrets).
+whether it is live on this machine (short HTTP probe, no secrets). API hosts
+are first-class rows so the operator can see which inference connector is
+actually up. A selected connector that is down refuses with a reason; callers
+must not walk to another host (KB R-0011).
 """
 
 from __future__ import annotations
@@ -22,45 +25,146 @@ _ROWS: tuple[dict[str, str], ...] = (
     {"slug": "notion", "name": "Notion", "layer": "operator paste", "probe": ""},
     {"slug": "cursor", "name": "Cursor", "layer": "this IDE; no infinite cloud swarm", "probe": ""},
     {"slug": "grok", "name": "Grok Bot", "layer": "OFFLOADED to Crew :8020; watchdog must not auto-start", "probe": ""},
+    {"slug": "mcp", "name": "MCP", "layer": "lazy tools; arm per server", "probe": ""},
+)
+
+# Inference APIs the router can pin. Presence of the env key is the probe;
+# secrets never leave this process in the catalog payload.
+_API_ROWS: tuple[dict[str, str], ...] = (
+    {"slug": "anthropic", "name": "Anthropic", "layer": "API / inference", "env": "ANTHROPIC_API_KEY"},
+    {"slug": "openrouter", "name": "OpenRouter", "layer": "API / inference", "env": "OPENROUTER_API_KEY"},
+    {"slug": "openai", "name": "OpenAI / compatible", "layer": "API / inference", "env": "OPENAI_API_KEY"},
+    {"slug": "deepseek", "name": "DeepSeek", "layer": "API / inference", "env": "DEEPSEEK_API_KEY"},
+    {"slug": "xai", "name": "xAI / Grok", "layer": "API / inference", "env": "XAI_API_KEY"},
+    {"slug": "groq", "name": "Groq", "layer": "API / inference", "env": "GROQ_API_KEY"},
+    {"slug": "google", "name": "Google AI", "layer": "API / inference", "env": "GOOGLE_API_KEY"},
+    {"slug": "cerebras", "name": "Cerebras", "layer": "API / inference", "env": "CEREBRAS_API_KEY"},
+    {"slug": "mistral", "name": "Mistral", "layer": "API / inference", "env": "MISTRAL_API_KEY"},
 )
 
 
-def _up(url: str, timeout: float = 1.2) -> bool:
-    if not url or os.environ.get("CREW_LIVE_PROBES", "1") == "0":
-        return False
+class ConnectorError(RuntimeError):
+    """Selected connector is down or unset. Do not silently pick another."""
+
+
+def _probe(url: str, timeout: float = 1.2) -> tuple[bool, str]:
+    if not url:
+        return False, "no probe url"
+    if os.environ.get("CREW_LIVE_PROBES", "1") == "0":
+        return False, "CREW_LIVE_PROBES=0"
     try:
         with urllib.request.urlopen(url, timeout=timeout) as resp:
-            return 200 <= int(resp.status) < 400
-    except Exception:
-        return False
+            code = int(resp.status)
+            if 200 <= code < 400:
+                return True, f"HTTP {code}"
+            return False, f"HTTP {code}"
+    except Exception as exc:  # noqa: BLE001 - probe must never raise into a turn
+        return False, f"{type(exc).__name__}: {exc}"[:200]
+
+
+def _up(url: str, timeout: float = 1.2) -> bool:
+    ok, _detail = _probe(url, timeout=timeout)
+    return ok
+
+
+def _row(
+    *,
+    slug: str,
+    name: str,
+    layer: str,
+    connected: bool,
+    detail: str,
+) -> dict[str, Any]:
+    return {
+        "slug": slug,
+        "name": name,
+        "layer": layer,
+        "connected": connected,
+        "detail": detail,
+        "ok": connected,
+        "noAuth": True,
+        "logo": None,
+    }
 
 
 def catalog(*, uacc_enabled: bool = False, uacc_armed: bool = False) -> list[dict[str, Any]]:
     out: list[dict[str, Any]] = []
     for row in _ROWS:
         connected = False
+        detail = ""
         if row["slug"] == "uacc":
             connected = bool(uacc_enabled and uacc_armed)
+            detail = "UACC armed" if connected else "UACC not armed"
         elif row["slug"] == "github":
             from CortexOS.crew import github as github_mod
 
-            connected = github_mod.available()
+            if os.environ.get("CREW_LIVE_PROBES", "1") == "0":
+                connected, detail = False, "CREW_LIVE_PROBES=0"
+            else:
+                connected = github_mod.available()
+                detail = "gh auth ok" if connected else "gh auth failed or missing"
         elif row["slug"] == "gmail":
             from CortexOS.crew import inbox as inbox_mod
 
             connected = inbox_mod.configured()
+            detail = "IMAP configured" if connected else "IMAP unset; drop .eml"
+        elif row["slug"] == "mcp":
+            connected = bool(uacc_enabled and uacc_armed)
+            detail = "MCP master+UACC armed" if connected else "MCP not armed"
         elif row["probe"]:
-            connected = _up(row["probe"])
+            connected, detail = _probe(row["probe"])
         elif row["slug"] == "cursor":
             connected = True
+            detail = "this IDE"
+        elif row["slug"] == "grok":
+            connected = False
+            detail = "OFFLOADED; watchdog must not auto-start"
+        else:
+            connected = False
+            detail = "mapped; no live probe"
         out.append(
-            {
-                "slug": row["slug"],
-                "name": row["name"],
-                "layer": row["layer"],
-                "connected": connected,
-                "noAuth": True,
-                "logo": None,
-            }
+            _row(
+                slug=row["slug"],
+                name=row["name"],
+                layer=row["layer"],
+                connected=connected,
+                detail=detail,
+            )
+        )
+    for row in _API_ROWS:
+        env_key = row["env"]
+        connected = bool(os.environ.get(env_key, "").strip())
+        if row["slug"] == "openai" and not connected:
+            connected = bool(os.environ.get("CREW_OPENAI_BASE_URL", "").strip())
+        detail = f"{env_key} configured" if connected else f"{env_key} unset"
+        out.append(
+            _row(
+                slug=row["slug"],
+                name=row["name"],
+                layer=row["layer"],
+                connected=connected,
+                detail=detail,
+            )
         )
     return out
+
+
+def get(slug: str, **catalog_kwargs: Any) -> dict[str, Any] | None:
+    needle = (slug or "").strip().lower()
+    if needle == "openai-compatible":
+        needle = "openai"
+    for row in catalog(**catalog_kwargs):
+        if str(row.get("slug") or "") == needle:
+            return row
+    return None
+
+
+def require(slug: str, **catalog_kwargs: Any) -> dict[str, Any]:
+    """Return the connector row or refuse with a reason. No silent fallback."""
+    row = get(slug, **catalog_kwargs)
+    if row is None:
+        raise ConnectorError(f"unknown connector '{slug}' (no silent fallback)")
+    if not row.get("connected"):
+        reason = str(row.get("detail") or "not connected")
+        raise ConnectorError(f"connector {slug} refused: {reason} (no silent fallback)")
+    return row

--- a/CortexOS/crew/desk.py
+++ b/CortexOS/crew/desk.py
@@ -8,12 +8,20 @@ from CortexOS.crew import connectors, estate, github, inbox
 from CortexOS.crew.openvault import cursor_key_status
 
 
-def snapshot(*, uacc_enabled: bool = False, uacc_armed: bool = False) -> dict[str, Any]:
+def snapshot(
+    *,
+    uacc_enabled: bool = False,
+    uacc_armed: bool = False,
+    usage: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    from CortexOS.crew.llm import usage_view
+
     plugs = connectors.catalog(uacc_enabled=uacc_enabled, uacc_armed=uacc_armed)
     prs = github.list_prs()
     mail = inbox.status()
     cursor = cursor_key_status()
     estate_snap = estate.snapshot()
+    usage_payload = usage_view(usage)
     return {
         "ok": True,
         "connectors": plugs,
@@ -22,6 +30,7 @@ def snapshot(*, uacc_enabled: bool = False, uacc_armed: bool = False) -> dict[st
         "inbox": mail,
         "cursor": cursor,
         "estate": estate_snap,
+        "usage": usage_payload,
         "law": (
             "Ask in chat to check PRs or mail. Drop files to import. "
             "Human is money and decision authority. Do not auto-merge or auto-send. "
@@ -39,6 +48,11 @@ def render(snap: dict[str, Any] | None = None) -> str:
         f"Cursor key: {'set' if cursor.get('configured') else 'missing'} "
         f"model={cursor.get('model') or 'grok-4.6'} chars={cursor.get('chars') or 0}"
     )
+    usage = data.get("usage") or {}
+    lines.append(
+        f"Usage: calls={usage.get('llm_calls') or 0} "
+        f"tokens={usage.get('tokens') or 0} cost_usd={usage.get('cost_usd') or 0}"
+    )
     prs = (data.get("prs") or {}).get("prs") or []
     detail = (data.get("prs") or {}).get("detail") or ""
     lines.append(f"PRs: {len(prs)}" + (f" ({detail})" if detail else ""))
@@ -54,7 +68,10 @@ def render(snap: dict[str, Any] | None = None) -> str:
     lines.append("Connectors:")
     for plug in data.get("connectors") or []:
         state = "connected" if plug.get("connected") else "mapped"
-        lines.append(f"- {plug.get('slug')}: {state} ({plug.get('layer')})")
+        extra = ""
+        if not plug.get("connected") and plug.get("detail"):
+            extra = f" refused: {plug.get('detail')}"
+        lines.append(f"- {plug.get('slug')}: {state} ({plug.get('layer')}){extra}")
     estate_snap = data.get("estate") or {}
     n_estate = estate_snap.get("n") or 0
     lines.append(

--- a/CortexOS/crew/keys.py
+++ b/CortexOS/crew/keys.py
@@ -24,6 +24,7 @@ KNOWN = (
     "CEREBRAS_API_KEY",
     "MISTRAL_API_KEY",
     "CREW_MODEL",
+    "CREW_PROVIDER",
     "CREW_OPENAI_BASE_URL",
     "CREW_CURSOR_BASE_URL",
     "CREW_ANTHROPIC_MODEL",
@@ -119,5 +120,18 @@ def public_fields() -> list[dict[str, str]]:
         {"key": "CEREBRAS_API_KEY", "label": "Cerebras", "hint": "csk-..."},
         {"key": "MISTRAL_API_KEY", "label": "Mistral", "hint": "vaulted via OpenVault"},
         {"key": "XAI_API_KEY", "label": "xAI / Grok", "hint": "xai-..."},
+        {"key": "CREW_PROVIDER", "label": "Pinned provider", "hint": "openvault | anthropic | groq | openrouter | ..."},
         {"key": "CREW_MODEL", "label": "Explicit model override", "hint": "openrouter/deepseek/deepseek-chat"},
     ]
+
+
+def pin_provider(
+    data_dir: Path, provider: str | None, model: str | None = None
+) -> dict[str, Any]:
+    """Persist the operator's host pick. Empty unpins. Never stores secrets."""
+    updates: dict[str, str | None] = {}
+    if provider is not None:
+        updates["CREW_PROVIDER"] = (provider or "").strip() or None
+    if model is not None:
+        updates["CREW_MODEL"] = (model or "").strip() or None
+    return save(data_dir, updates)

--- a/CortexOS/crew/llm.py
+++ b/CortexOS/crew/llm.py
@@ -10,6 +10,10 @@ module and never pay its import, and the server only pays it on first use.
 Failures raise :class:`LLMError` with a human-readable reason; the runtime
 persists that reason into the transcript instead of retrying another provider
 behind the operator's back (KB R-0011: a silent fallback is a lie).
+
+:func:`resolve_route` is the operator-visible router: a per-turn provider/model
+pick wins, then a pinned ``CREW_PROVIDER``, then the configured chain. A miss
+or a dead connector refuses with a reason. There is no walk to the next host.
 """
 
 from __future__ import annotations
@@ -40,6 +44,215 @@ class LLMResult:
     completion_tokens: int | None = None
     cost_usd: float | None = None
     model: str = ""
+
+
+@dataclass(frozen=True)
+class Route:
+    """One turn's host. ``connector`` is openvault or litellm; never both."""
+
+    label: str
+    model: str
+    api_base: str | None
+    source: str
+    connector: str
+
+
+_PROVIDER_ALIASES = {
+    "openai": "openai-compatible",
+    "ov": "openvault",
+    "vault": "openvault",
+    "google": "google",
+    "gemini": "google",
+}
+
+
+def _empty_usage() -> dict[str, Any]:
+    return {
+        "llm_calls": 0,
+        "prompt_tokens": 0,
+        "completion_tokens": 0,
+        "cost_usd": 0.0,
+        "by_route": {},
+    }
+
+
+_USAGE: dict[str, Any] = _empty_usage()
+
+
+def reset_usage() -> None:
+    """Test hook. Production HUD reads the live process totals."""
+    global _USAGE
+    _USAGE = _empty_usage()
+
+
+def usage_snapshot() -> dict[str, Any]:
+    routes = {
+        name: dict(slot) for name, slot in (_USAGE.get("by_route") or {}).items()
+    }
+    return {
+        "llm_calls": int(_USAGE.get("llm_calls") or 0),
+        "prompt_tokens": int(_USAGE.get("prompt_tokens") or 0),
+        "completion_tokens": int(_USAGE.get("completion_tokens") or 0),
+        "cost_usd": float(_USAGE.get("cost_usd") or 0.0),
+        "by_route": routes,
+    }
+
+
+def usage_view(stored: dict[str, Any] | None = None) -> dict[str, Any]:
+    """HUD payload: durable store totals win; session fills a fresh process."""
+    session = usage_snapshot()
+    stored = dict(stored or {})
+    calls = int(stored.get("llm_calls") or 0) or session["llm_calls"]
+    prompt = int(stored.get("prompt_tokens") or 0) or session["prompt_tokens"]
+    completion = int(stored.get("completion_tokens") or 0) or session["completion_tokens"]
+    cost = float(stored.get("cost_usd") or 0.0) or session["cost_usd"]
+    by_route = stored.get("by_route") or session["by_route"]
+    return {
+        "llm_calls": calls,
+        "prompt_tokens": prompt,
+        "completion_tokens": completion,
+        "cost_usd": cost,
+        "tokens": prompt + completion,
+        "by_route": by_route,
+        "session": session,
+        "stored": stored,
+    }
+
+
+def record_usage(result: LLMResult, *, route: str = "") -> dict[str, Any]:
+    name = (route or result.model or "unknown").strip() or "unknown"
+    _USAGE["llm_calls"] = int(_USAGE.get("llm_calls") or 0) + 1
+    _USAGE["prompt_tokens"] = int(_USAGE.get("prompt_tokens") or 0) + int(result.prompt_tokens or 0)
+    _USAGE["completion_tokens"] = int(_USAGE.get("completion_tokens") or 0) + int(
+        result.completion_tokens or 0
+    )
+    _USAGE["cost_usd"] = round(
+        float(_USAGE.get("cost_usd") or 0.0) + float(result.cost_usd or 0.0), 6
+    )
+    slots: dict[str, Any] = _USAGE.setdefault("by_route", {})
+    slot = slots.setdefault(
+        name,
+        {"llm_calls": 0, "prompt_tokens": 0, "completion_tokens": 0, "cost_usd": 0.0},
+    )
+    slot["llm_calls"] += 1
+    slot["prompt_tokens"] += int(result.prompt_tokens or 0)
+    slot["completion_tokens"] += int(result.completion_tokens or 0)
+    slot["cost_usd"] = round(float(slot["cost_usd"] or 0.0) + float(result.cost_usd or 0.0), 6)
+    return usage_snapshot()
+
+
+def _rewrite_grok_fast(model: str) -> str:
+    raw = (model or "").strip()
+    if "grok" in raw.lower() and "fast" in raw.lower():
+        return "openai/grok-4.6"
+    return raw
+
+
+def _norm_provider(label: str) -> str:
+    raw = (label or "").strip().lower()
+    return _PROVIDER_ALIASES.get(raw, raw)
+
+
+def _connector_for(label: str) -> str:
+    return "openvault" if label == "openvault" else "litellm"
+
+
+def _refuse_unconfigured(row: Any, pick: str) -> None:
+    if row.configured:
+        return
+    if row.label == "openvault":
+        from CortexOS.crew.openvault import healthz
+
+        detail = str(healthz().get("detail") or "not live")
+        raise LLMError(f"OpenVault connector refused: {detail} (no silent fallback)")
+    raise LLMError(
+        f"provider '{pick}' is not configured ({row.source}); no silent fallback"
+    )
+
+
+def _assert_connector(row: Any) -> None:
+    if row.label == "openvault":
+        from CortexOS.crew.openvault import require_live
+
+        require_live()
+        return
+    from CortexOS.crew.connectors import ConnectorError
+    from CortexOS.crew.connectors import require as require_connector
+
+    slug = "openai" if row.label == "openai-compatible" else row.label
+    if slug in {"explicit", "ollama", "cursor"}:
+        return
+    try:
+        require_connector(slug)
+    except ConnectorError as exc:
+        raise LLMError(str(exc)) from exc
+
+
+def resolve_route(*, provider: str | None = None, model: str | None = None) -> Route:
+    """Pick the host for this turn. Operator input wins. Never falls through.
+
+    ``provider`` is a chain label (anthropic, openvault, groq, ...). ``model`` is
+    an optional litellm / OpenVault model string. A selected host that is unset
+    or whose connector is down raises :class:`LLMError` with the reason.
+    """
+    from CortexOS.crew.config import active_provider, resolve_providers
+
+    pick = _norm_provider(provider or "")
+    model_s = _rewrite_grok_fast(model or "")
+    chain = resolve_providers()
+
+    if pick:
+        row = next((p for p in chain if p.label.lower() == pick), None)
+        if row is None:
+            known = ", ".join(p.label for p in chain)
+            raise LLMError(f"unknown provider '{provider}' (known: {known}); no silent fallback")
+        _refuse_unconfigured(row, pick)
+        _assert_connector(row)
+        chosen = model_s or row.model
+        if row.label == "openvault" and not chosen.startswith("openvault/"):
+            chosen = "openvault/" + chosen.removeprefix("openvault/")
+        return Route(
+            label=row.label,
+            model=chosen,
+            api_base=row.api_base,
+            source=row.source,
+            connector=_connector_for(row.label),
+        )
+
+    if model_s:
+        if model_s.startswith("openvault/"):
+            from CortexOS.crew.openvault import require_live
+
+            require_live()
+            return Route(
+                label="openvault",
+                model=model_s,
+                api_base=None,
+                source="turn-override",
+                connector="openvault",
+            )
+        return Route(
+            label="turn-override",
+            model=model_s,
+            api_base=None,
+            source="turn-override",
+            connector="litellm",
+        )
+
+    active = active_provider(chain)
+    if active is None:
+        raise LLMError(
+            "no model provider configured (set CREW_PROVIDER / CREW_MODEL, an *_API_KEY,"
+            " start OpenVault on :5000, or run Ollama); no silent fallback"
+        )
+    _assert_connector(active)
+    return Route(
+        label=active.label,
+        model=active.model,
+        api_base=active.api_base,
+        source=active.source,
+        connector=_connector_for(active.label),
+    )
 
 
 _configured = False

--- a/CortexOS/crew/openvault.py
+++ b/CortexOS/crew/openvault.py
@@ -73,6 +73,18 @@ def healthz(timeout: float = 1.5) -> dict[str, Any]:
         return {"ok": False, "url": base_url(), "detail": f"{type(exc).__name__}"}
 
 
+def require_live(timeout: float = 1.5) -> dict[str, Any]:
+    """OpenVault must be up for this turn. Never fall through to another host."""
+    st = healthz(timeout=timeout)
+    if not st.get("ok"):
+        raise LLMError(
+            "OpenVault connector refused: "
+            + str(st.get("detail") or "unreachable")
+            + " (no silent fallback)"
+        )
+    return st
+
+
 def _tools_from_choice(message: dict[str, Any]) -> list[ToolCall]:
     calls: list[ToolCall] = []
     for i, tc in enumerate(message.get("tool_calls") or []):
@@ -116,12 +128,18 @@ async def chat(
     choice = (data.get("choices") or [{}])[0]
     message = choice.get("message") or {}
     usage = data.get("usage") or {}
+    cost = usage.get("cost") or usage.get("total_cost") or usage.get("cost_usd")
+    try:
+        cost_usd = float(cost) if cost is not None else None
+    except (TypeError, ValueError):
+        cost_usd = None
     return LLMResult(
         text=str(message.get("content") or ""),
         tool_calls=_tools_from_choice(message),
         finish_reason=str(choice.get("finish_reason") or ""),
         prompt_tokens=usage.get("prompt_tokens"),
         completion_tokens=usage.get("completion_tokens"),
+        cost_usd=cost_usd,
         model=str(data.get("model") or "openvault/auto"),
     )
 

--- a/CortexOS/crew/runtime.py
+++ b/CortexOS/crew/runtime.py
@@ -108,8 +108,11 @@ class RunContext:
             "prompt_tokens": 0,
             "completion_tokens": 0,
             "cost_usd": 0.0,
+            "by_route": {},
         }
     )
+    turn_provider: str | None = None
+    turn_model: str | None = None
     tasks: set[asyncio.Task[None]] = field(default_factory=set)
 
 
@@ -155,14 +158,31 @@ class CrewRuntime:
             color=MANAGER_COLOR,
         )
 
-    async def on_user_message(self, space_id: str, text: str) -> dict[str, Any]:
+    async def on_user_message(
+        self,
+        space_id: str,
+        text: str,
+        *,
+        provider: str | None = None,
+        model: str | None = None,
+    ) -> dict[str, Any]:
         msg = self.store.add_message(space_id, "user", text)
         self.bus.emit(space_id, "message", {"message": msg})
 
         space = self.store.get_space(space_id)
         if space is None:
             return {"error": "unknown space"}
-        if active_provider() is None and not (space.get("model") or "").strip():
+        turn_provider = (provider or "").strip() or None
+        turn_model = (model or "").strip() or None
+        if turn_provider or turn_model:
+            try:
+                llm_mod.resolve_route(provider=turn_provider, model=turn_model)
+            except LLMError as exc:
+                note = str(exc)
+                sysmsg = self.store.add_message(space_id, "system", note)
+                self.bus.emit(space_id, "message", {"message": sysmsg})
+                return {"error": note}
+        elif active_provider() is None and not (space.get("model") or "").strip():
             note = (
                 "No model provider is configured. Start OpenVault on :5000 (keys stay there),"
                 " paste a key in Providers, or set CREW_MODEL / an *_API_KEY, then retry."
@@ -189,11 +209,27 @@ class CrewRuntime:
             return {"run_id": active_run, "queued": True}
 
         manager = self.ensure_manager(space_id)
-        return {"run_id": self._start_run(space_id, manager)}
+        return {
+            "run_id": self._start_run(
+                space_id, manager, provider=turn_provider, model=turn_model
+            )
+        }
 
-    def _start_run(self, space_id: str, manager: dict[str, Any]) -> str:
+    def _start_run(
+        self,
+        space_id: str,
+        manager: dict[str, Any],
+        *,
+        provider: str | None = None,
+        model: str | None = None,
+    ) -> str:
         run = self.store.create_run(space_id)
-        ctx = RunContext(id=run["id"], space_id=space_id)
+        ctx = RunContext(
+            id=run["id"],
+            space_id=space_id,
+            turn_provider=provider,
+            turn_model=model,
+        )
         self._runs[run["id"]] = ctx
         self._space_run[space_id] = run["id"]
         task = asyncio.create_task(self._manager_run(ctx, manager))
@@ -334,7 +370,7 @@ class CrewRuntime:
         brief: str | None = None,
     ) -> None:
         space = self.store.get_space(ctx.space_id) or {}
-        model, api_base, label = self._provider(space, row)
+        model, api_base, label = self._provider(ctx, space, row)
         self._set_status(row["id"], "thinking")
         last_user = ""
         for m in reversed(self.store.list_messages(ctx.space_id, limit=10_000)):
@@ -472,6 +508,9 @@ class CrewRuntime:
                     "provider": label,
                     "run_id": ctx.id,
                     "cost_usd": ctx.stats.get("cost_usd"),
+                    "prompt_tokens": ctx.stats.get("prompt_tokens"),
+                    "completion_tokens": ctx.stats.get("completion_tokens"),
+                    "llm_calls": ctx.stats.get("llm_calls"),
                 },
             )
             self.bus.emit(ctx.space_id, "message", {"message": msg})
@@ -983,23 +1022,29 @@ class CrewRuntime:
     # -- helpers -----------------------------------------------------------
 
     def _provider(
-        self, space: dict[str, Any], row: dict[str, Any] | None = None
+        self,
+        ctx: RunContext,
+        space: dict[str, Any],
+        row: dict[str, Any] | None = None,
     ) -> tuple[str, str | None, str]:
         agent_model = str((row or {}).get("model") or "").strip()
         if agent_model:
             if "grok" in agent_model.lower() and "fast" in agent_model.lower():
                 agent_model = "openai/grok-4.6"
             return agent_model, None, "agent-override"
+        turn_p = (ctx.turn_provider or "").strip()
+        turn_m = (ctx.turn_model or "").strip()
+        if turn_p or turn_m:
+            route = llm_mod.resolve_route(provider=turn_p or None, model=turn_m or None)
+            return route.model, route.api_base, route.label
         override = (space.get("model") or "").strip()
         if override:
+            if override.startswith("openvault/"):
+                route = llm_mod.resolve_route(provider="openvault", model=override)
+                return route.model, route.api_base, route.label
             return override, None, "space-override"
-        provider = active_provider()
-        if provider is None:
-            raise LLMError(
-                "no model provider configured (set ANTHROPIC_API_KEY, OPENROUTER_API_KEY,"
-                " DEEPSEEK_API_KEY, OPENAI_API_KEY, or run Ollama)"
-            )
-        return provider.model, provider.api_base, provider.label
+        route = llm_mod.resolve_route()
+        return route.model, route.api_base, route.label
 
     def _handle(self, row: dict[str, Any]) -> AgentHandle:
         handle = self._handles.get(row["id"])
@@ -1225,6 +1270,17 @@ class CrewRuntime:
         ctx.stats["prompt_tokens"] += result.prompt_tokens or 0
         ctx.stats["completion_tokens"] += result.completion_tokens or 0
         ctx.stats["cost_usd"] = round(ctx.stats["cost_usd"] + (result.cost_usd or 0.0), 6)
+        route_name = (result.model or "").strip() or "unknown"
+        routes = ctx.stats.setdefault("by_route", {})
+        slot = routes.setdefault(
+            route_name,
+            {"llm_calls": 0, "prompt_tokens": 0, "completion_tokens": 0, "cost_usd": 0.0},
+        )
+        slot["llm_calls"] += 1
+        slot["prompt_tokens"] += result.prompt_tokens or 0
+        slot["completion_tokens"] += result.completion_tokens or 0
+        slot["cost_usd"] = round(float(slot["cost_usd"] or 0.0) + float(result.cost_usd or 0.0), 6)
+        llm_mod.record_usage(result, route=route_name)
         self.store.update_run(ctx.id, stats=ctx.stats)
         self.bus.emit(
             ctx.space_id, "run", {"run_id": ctx.id, "status": "running", "stats": ctx.stats}

--- a/CortexOS/crew/server.py
+++ b/CortexOS/crew/server.py
@@ -124,6 +124,13 @@ class SpacePatch(BaseModel):
 
 class MessageIn(BaseModel):
     text: str
+    provider: str | None = None
+    model: str | None = None
+
+
+class ProviderPin(BaseModel):
+    provider: str | None = None
+    model: str | None = None
 
 
 class ConfirmIn(BaseModel):
@@ -173,6 +180,8 @@ def build_router(crew: CrewApp) -> APIRouter:
         chain = resolve_providers()
         active = next((p for p in chain if p.active), None)
         mcp = crew.mcp.status()
+        from CortexOS.crew.llm import usage_view
+
         return {
             "ok": True,
             "provider": active.public() if active else None,
@@ -182,6 +191,7 @@ def build_router(crew: CrewApp) -> APIRouter:
             "grok_offloaded": True,
             "grok_autostart": False,
             "mcp": mcp,
+            "usage": usage_view(crew.store.usage_totals()),
         }
 
     @router.get("/providers")
@@ -192,6 +202,34 @@ def build_router(crew: CrewApp) -> APIRouter:
             "active": active.public() if active else None,
             "chain": [p.public() for p in chain],
         }
+
+    @router.post("/providers")
+    async def pin_provider(body: ProviderPin) -> dict[str, Any]:
+        from CortexOS.crew.keys import pin_provider as save_pin
+        from CortexOS.crew.llm import LLMError as RouteError
+        from CortexOS.crew.llm import resolve_route
+
+        save_pin(crew.settings.data_dir, body.provider, body.model)
+        chain = resolve_providers()
+        active = next((p for p in chain if p.active), None)
+        refused: str | None = None
+        if (body.provider or "").strip() or (body.model or "").strip():
+            try:
+                resolve_route(provider=body.provider, model=body.model)
+            except RouteError as exc:
+                refused = str(exc)
+        return {
+            "ok": refused is None,
+            "active": active.public() if active else None,
+            "chain": [p.public() for p in chain],
+            "refused": refused,
+        }
+
+    @router.get("/usage")
+    async def usage() -> dict[str, Any]:
+        from CortexOS.crew.llm import usage_view
+
+        return usage_view(crew.store.usage_totals())
 
     @router.get("/spaces")
     async def list_spaces() -> list[dict[str, Any]]:
@@ -226,7 +264,12 @@ def build_router(crew: CrewApp) -> APIRouter:
     async def post_message(space_id: str, body: MessageIn) -> dict[str, Any]:
         if crew.store.get_space(space_id) is None:
             raise HTTPException(404, "unknown space")
-        return await crew.runtime.on_user_message(space_id, body.text)
+        return await crew.runtime.on_user_message(
+            space_id,
+            body.text,
+            provider=body.provider,
+            model=body.model,
+        )
 
     @router.get("/spaces/{space_id}/agents")
     async def agents(space_id: str) -> list[dict[str, Any]]:
@@ -398,6 +441,7 @@ def build_router(crew: CrewApp) -> APIRouter:
         return desk_snapshot(
             uacc_enabled=bool(uacc.get("enabled")),
             uacc_armed=bool(uacc.get("armed")),
+            usage=crew.store.usage_totals(),
         )
 
     @router.get("/voice")

--- a/CortexOS/crew/store.py
+++ b/CortexOS/crew/store.py
@@ -473,6 +473,50 @@ class CrewStore:
             self._db.commit()
         return self.get_run(run_id)
 
+    def usage_totals(self) -> dict[str, Any]:
+        """Sum run stats for the HUD. Missing JSON is zero, never a crash."""
+        with self._lock:
+            rows = self._db.execute("SELECT stats FROM runs").fetchall()
+        totals: dict[str, Any] = {
+            "llm_calls": 0,
+            "prompt_tokens": 0,
+            "completion_tokens": 0,
+            "cost_usd": 0.0,
+            "by_route": {},
+        }
+        routes: dict[str, dict[str, Any]] = {}
+        for row in rows:
+            stats = _loads(row[0]) or {}
+            if not isinstance(stats, dict):
+                continue
+            totals["llm_calls"] += int(stats.get("llm_calls") or 0)
+            totals["prompt_tokens"] += int(stats.get("prompt_tokens") or 0)
+            totals["completion_tokens"] += int(stats.get("completion_tokens") or 0)
+            try:
+                totals["cost_usd"] = round(
+                    float(totals["cost_usd"]) + float(stats.get("cost_usd") or 0.0), 6
+                )
+            except (TypeError, ValueError):
+                pass
+            by_route = stats.get("by_route") or {}
+            if isinstance(by_route, dict):
+                for name, slot in by_route.items():
+                    if not isinstance(slot, dict):
+                        continue
+                    acc = routes.setdefault(
+                        str(name),
+                        {"llm_calls": 0, "prompt_tokens": 0, "completion_tokens": 0, "cost_usd": 0.0},
+                    )
+                    acc["llm_calls"] += int(slot.get("llm_calls") or 0)
+                    acc["prompt_tokens"] += int(slot.get("prompt_tokens") or 0)
+                    acc["completion_tokens"] += int(slot.get("completion_tokens") or 0)
+                    acc["cost_usd"] = round(
+                        float(acc["cost_usd"]) + float(slot.get("cost_usd") or 0.0), 6
+                    )
+        totals["by_route"] = routes
+        totals["tokens"] = int(totals["prompt_tokens"]) + int(totals["completion_tokens"])
+        return totals
+
     # -- confirms ----------------------------------------------------------
 
     def create_confirm(

--- a/CortexOS/crew/ui/crew.css
+++ b/CortexOS/crew/ui/crew.css
@@ -118,6 +118,15 @@ button { cursor: pointer; }
   text-overflow: ellipsis;
   white-space: nowrap;
 }
+.route-pick {
+  flex: none;
+  max-width: 7.5rem;
+  border: 0;
+  background: var(--well);
+  color: var(--ink);
+  font: 0.62rem var(--mono);
+  padding: 0.35rem 0.3rem;
+}
 .tool {
   display: block;
   width: 100%;
@@ -629,6 +638,19 @@ button { cursor: pointer; }
 }
 .chain { font: 0.62rem/1.45 var(--mono); color: var(--mute); margin-top: 0.5rem; }
 .chain .on { color: var(--claim); }
+.chain-pick {
+  display: block;
+  width: 100%;
+  text-align: left;
+  border: 0;
+  background: transparent;
+  color: inherit;
+  font: inherit;
+  padding: 0.15rem 0;
+  cursor: pointer;
+}
+.chain-pick:disabled { opacity: 0.55; cursor: not-allowed; }
+.chain-pick.on { color: var(--claim); }
 
 .plugins {
   position: fixed;

--- a/CortexOS/crew/ui/index.html
+++ b/CortexOS/crew/ui/index.html
@@ -15,6 +15,7 @@
       </div>
       <div class="spaces__tools spaces__hide">
         <div class="chip" id="providerChip">no provider</div>
+        <div class="chip" id="usageChip">usage 0</div>
         <button class="spaces__search" id="openSearch" type="button">Search<span class="spaces__key">Ctrl K</span></button>
         <button class="tool" id="openSettings">Providers / API keys</button>
         <button class="tool" id="openPlugins">Plugins</button>
@@ -57,6 +58,7 @@
       <div class="composer">
         <div id="roles" class="role-chips"></div>
         <div class="composer__row">
+          <select class="route-pick" id="routePick" title="Provider for this turn"></select>
           <textarea class="composer__input" id="input" rows="1" placeholder="Ask the Manager. Auto-detect who to spawn."></textarea>
           <button class="composer__send" id="send" title="Send">^</button>
         </div>
@@ -228,7 +230,8 @@
       activityOnly: false, focusAgent: null,
       stick: true, unread: 0, retry: null, live: false,
       belt: null, memScope: "space", claimBusy: null,
-      sessionAllow: {}, denyStreak: {}, runStarted: 0
+      sessionAllow: {}, denyStreak: {}, runStarted: 0,
+      routeProvider: "", usage: null
     };
     const $ = (id) => document.getElementById(id);
     const api = (path, opts) => fetch(path, Object.assign({ headers: { "Content-Type": "application/json" } }, opts)).then(async (r) => {
@@ -537,13 +540,46 @@
       $("graph").innerHTML = `<svg viewBox="0 0 ${W} ${H}" role="img" aria-label="agent to agent traffic">${lines}${dots}</svg>`;
     }
 
+    function paintUsage(usage) {
+      if (usage) state.usage = usage;
+      const u = state.usage || {};
+      const calls = u.llm_calls || 0;
+      const tokens = u.tokens || ((u.prompt_tokens || 0) + (u.completion_tokens || 0));
+      const cost = u.cost_usd || 0;
+      const chip = $("usageChip");
+      if (!chip) return;
+      chip.textContent = "usage " + calls + " calls / " + tokens + " tok / $" + Number(cost).toFixed(4);
+    }
     function setProvider(active, chain) {
       $("providerChip").textContent = active ? (active.label + " / " + active.model) : "no provider configured";
+      const pick = $("routePick");
+      const rows = chain || [];
+      if (pick) {
+        const current = state.routeProvider || (active && active.label) || "";
+        pick.innerHTML = `<option value="">default</option>` + rows.map((p) =>
+          `<option value="${esc(p.label)}" ${p.label === current ? "selected" : ""} ${p.configured ? "" : "disabled"}>${esc(p.label)}${p.configured ? "" : " (unset)"}</option>`
+        ).join("");
+        if (current) pick.value = current;
+        pick.onchange = () => { state.routeProvider = pick.value || ""; };
+      }
       if (chain) {
         $("providerChain").innerHTML = chain.map((p) =>
-          `<div class="${p.active ? "on" : ""}">${esc(p.label)} ${p.configured ? "ready" : "unset"} - ${esc(p.model)}</div>`
+          `<button type="button" class="chain-pick${p.active ? " on" : ""}" data-label="${esc(p.label)}" ${p.configured ? "" : "disabled"}>`
+          + `${esc(p.label)} ${p.configured ? "ready" : "unset"} - ${esc(p.model)}</button>`
         ).join("");
+        $("providerChain").querySelectorAll(".chain-pick").forEach((el) => {
+          el.onclick = () => pinProvider(el.dataset.label);
+        });
       }
+    }
+    async function pinProvider(label) {
+      try {
+        const saved = await api("/crew/providers", { method: "POST", body: JSON.stringify({ provider: label }) });
+        setProvider(saved.active, saved.chain);
+        state.routeProvider = label;
+        if (saved.refused) toast(saved.refused, "bad");
+        else toast("Route pinned: " + label + ". No silent fallback.");
+      } catch (err) { toast(err.message, "bad"); }
     }
     function renderSpaces() {
       $("spaces").innerHTML = state.spaces.map((s, i) =>
@@ -703,7 +739,7 @@
       $("pluginList").innerHTML = rows.map((p) =>
         `<div class="plugin-row"><div class="plugin-mark">${esc((p.name || "?")[0])}</div>
          <div style="flex:1;min-width:0">${esc(p.name)}<small style="display:block;color:#8b91a3">${esc(p.slug)} - ${esc(p.layer)}</small></div>
-         <div class="${p.connected ? "on" : "empty"}">${p.connected ? "connected" : "mapped"}</div></div>`
+         <div class="${p.connected ? "on" : "empty"}">${p.connected ? "connected" : esc(p.detail || "mapped")}</div></div>`
       ).join("");
     }
     function renderTickets(board) {
@@ -777,11 +813,13 @@
       const prs = (desk.prs && desk.prs.prs) || [];
       const mail = desk.inbox || {};
       const cursor = desk.cursor || {};
+      const usage = desk.usage || {};
       const prLines = prs.length
         ? prs.slice(0, 8).map((p) => `<div class="row">#${esc(p.number)} ${esc(p.title)}<small>${esc(p.repo)} - ${esc(p.review || "open")}</small></div>`).join("")
         : `<div class="empty">${esc((desk.prs && desk.prs.detail) || "No open PRs (or gh not in this folder). Ask in chat.")}</div>`;
       $("desk").innerHTML =
         `<div class="empty">${esc(desk.law || "")}</div>` +
+        `<div class="row">Usage <small>${esc(usage.llm_calls || 0)} calls / ${esc(usage.tokens || 0)} tok / $${esc(Number(usage.cost_usd || 0).toFixed(4))}</small></div>` +
         `<div class="row">Cursor key ${cursor.configured ? "set" : "missing"}<small>model=${esc(cursor.model || "grok-4.6")} chars=${esc(cursor.chars || 0)}</small></div>` +
         `<div class="row">Mail ${mail.connected ? "IMAP" : "drop-file"}<small>${esc(mail.detail || "")}</small></div>` +
         prLines;
@@ -867,6 +905,7 @@
       state.keyFields = keys.fields || [];
       renderKeyForm(state.keyFields, keys.status || {});
       setProvider(prov.active, prov.chain);
+      paintUsage((health && health.usage) || (desk && desk.usage));
       const ov = health.openvault || {};
       const eng = health.engine || {};
       $("engine").textContent = [
@@ -970,6 +1009,7 @@
             $("cancelRun").hidden = data.status !== "running";
             if (data.status === "running") state.runStarted = Date.now();
             if (data.status !== "running") { state.draft = ""; paintDraft(); }
+            if (data.stats) paintUsage(data.stats);
           }
         };
         ["message", "agent", "confirm", "run", "detect"].forEach((name) => src.addEventListener(name, apply));
@@ -994,7 +1034,12 @@
       $("input").value = ""; growInput();
       state.stick = true;
       try {
-        const posted = await api("/crew/spaces/" + state.spaceId + "/messages", { method: "POST", body: JSON.stringify({ text }) });
+        const pick = $("routePick");
+        const provider = pick && pick.value ? pick.value : "";
+        const posted = await api("/crew/spaces/" + state.spaceId + "/messages", {
+          method: "POST",
+          body: JSON.stringify({ text, provider: provider || undefined })
+        });
         if (posted.queued) toast("Queued for the running crew.");
         state.runId = posted.run_id || state.runId;
         $("cancelRun").hidden = !state.runId;

--- a/tests/test_crew/conftest.py
+++ b/tests/test_crew/conftest.py
@@ -41,12 +41,16 @@ def crew_env(monkeypatch: pytest.MonkeyPatch) -> None:
         "GOOGLE_API_KEY",
         "CEREBRAS_API_KEY",
         "MISTRAL_API_KEY",
+        "CREW_PROVIDER",
     ):
         monkeypatch.delenv(var, raising=False)
     monkeypatch.setenv("CREW_MODEL", "test/fake-model")
     monkeypatch.setenv("CREW_ALLOW_OLLAMA", "0")
     monkeypatch.setenv("CREW_OPENVAULT", "0")
     monkeypatch.setenv("CREW_LIVE_PROBES", "0")
+    from CortexOS.crew.llm import reset_usage
+
+    reset_usage()
 
 
 @pytest.fixture()

--- a/tests/test_crew/test_config_policy.py
+++ b/tests/test_crew/test_config_policy.py
@@ -22,6 +22,7 @@ def clean_env(monkeypatch: pytest.MonkeyPatch) -> pytest.MonkeyPatch:
         "GOOGLE_API_KEY",
         "CEREBRAS_API_KEY",
         "MISTRAL_API_KEY",
+        "CREW_PROVIDER",
     ):
         monkeypatch.delenv(var, raising=False)
     monkeypatch.setenv("CREW_ALLOW_OLLAMA", "0")
@@ -43,6 +44,10 @@ def test_no_keys_means_no_active_provider_and_says_so(clean_env: pytest.MonkeyPa
         "xai",
         "deepseek",
         "openai-compatible",
+        "groq",
+        "google",
+        "cerebras",
+        "mistral",
         "ollama",
     }
 
@@ -126,4 +131,18 @@ def test_cursor_key_defaults_to_grok_46_not_fast(clean_env: pytest.MonkeyPatch) 
     assert active.label == "cursor"
     assert active.model == "openai/grok-4.6"
     assert "fast" not in active.model
+
+
+def test_provider_pin_does_not_fall_through(clean_env: pytest.MonkeyPatch) -> None:
+    clean_env.setenv("DEEPSEEK_API_KEY", "x")
+    clean_env.setenv("OPENAI_API_KEY", "y")
+    clean_env.setenv("CREW_PROVIDER", "openai")
+    active = config.active_provider()
+    assert active is not None
+    assert active.label == "openai-compatible"
+
+    clean_env.setenv("CREW_PROVIDER", "anthropic")
+    chain = config.resolve_providers()
+    assert config.active_provider(chain) is None
+    assert all(not p.active for p in chain)
 

--- a/tests/test_crew/test_openvault.py
+++ b/tests/test_crew/test_openvault.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import pytest
+
 from CortexOS.crew import config, openvault
 
 
@@ -186,3 +188,9 @@ def test_ingest_csv_drop_refuses_when_vault_off(monkeypatch, tmp_path) -> None:
     assert result["ok"] is False
     assert "CREW_OPENVAULT" in str(result.get("detail"))
     assert "super-secret" not in str(result)
+
+
+def test_require_live_refuses_when_disabled(monkeypatch) -> None:
+    monkeypatch.setenv("CREW_OPENVAULT", "0")
+    with pytest.raises(openvault.LLMError, match="no silent fallback"):
+        openvault.require_live()

--- a/tests/test_crew/test_router.py
+++ b/tests/test_crew/test_router.py
@@ -1,0 +1,120 @@
+"""CREW-ROUTER: per-turn host pick, usage totals, fail-closed connectors."""
+
+from __future__ import annotations
+
+import pytest
+
+from CortexOS.crew import connectors, llm, openvault
+from CortexOS.crew.llm import LLMError, LLMResult, resolve_route
+from tests.test_crew.conftest import wait_run_done
+
+
+@pytest.fixture()
+def clean_env(monkeypatch: pytest.MonkeyPatch) -> pytest.MonkeyPatch:
+    for var in (
+        "CREW_MODEL",
+        "CREW_PROVIDER",
+        "ANTHROPIC_API_KEY",
+        "OPENROUTER_API_KEY",
+        "DEEPSEEK_API_KEY",
+        "OPENAI_API_KEY",
+        "CREW_OPENAI_BASE_URL",
+        "CURSOR_API_KEY",
+        "XAI_API_KEY",
+        "GROQ_API_KEY",
+        "GOOGLE_API_KEY",
+        "CEREBRAS_API_KEY",
+        "MISTRAL_API_KEY",
+    ):
+        monkeypatch.delenv(var, raising=False)
+    monkeypatch.setenv("CREW_ALLOW_OLLAMA", "0")
+    monkeypatch.setenv("CREW_OPENVAULT", "0")
+    monkeypatch.setenv("CREW_LIVE_PROBES", "0")
+    return monkeypatch
+
+
+def test_resolve_route_uses_operator_pick(clean_env: pytest.MonkeyPatch) -> None:
+    clean_env.setenv("ANTHROPIC_API_KEY", "x")
+    clean_env.setenv("DEEPSEEK_API_KEY", "y")
+    route = resolve_route(provider="deepseek")
+    assert route.label == "deepseek"
+    assert route.model.startswith("deepseek/")
+    assert route.connector == "litellm"
+
+
+def test_resolve_route_refuses_unset_provider_without_fallback(
+    clean_env: pytest.MonkeyPatch,
+) -> None:
+    clean_env.setenv("DEEPSEEK_API_KEY", "y")
+    with pytest.raises(LLMError, match="no silent fallback"):
+        resolve_route(provider="anthropic")
+    with pytest.raises(LLMError, match="unknown provider"):
+        resolve_route(provider="not-a-host")
+
+
+def test_openvault_pin_refuses_when_vault_is_down(clean_env: pytest.MonkeyPatch) -> None:
+    clean_env.setenv("CREW_OPENVAULT", "0")
+    clean_env.setenv("ANTHROPIC_API_KEY", "x")
+    with pytest.raises(LLMError, match="OpenVault connector refused"):
+        resolve_route(provider="openvault")
+    with pytest.raises(LLMError, match="CREW_OPENVAULT=0"):
+        openvault.require_live()
+
+
+def test_connector_require_names_the_reason() -> None:
+    rows = connectors.catalog()
+    ov = next(r for r in rows if r["slug"] == "openvault")
+    assert ov["connected"] is False
+    assert ov["detail"]
+    with pytest.raises(connectors.ConnectorError, match="no silent fallback"):
+        connectors.require("openvault")
+    with pytest.raises(connectors.ConnectorError, match="unknown connector"):
+        connectors.require("not-a-plug")
+
+
+def test_usage_ledger_is_visible() -> None:
+    llm.reset_usage()
+    llm.record_usage(
+        LLMResult(text="ok", model="deepseek/deepseek-chat", prompt_tokens=11, completion_tokens=7, cost_usd=0.01),
+        route="deepseek/deepseek-chat",
+    )
+    snap = llm.usage_snapshot()
+    assert snap["llm_calls"] == 1
+    assert snap["prompt_tokens"] == 11
+    assert snap["completion_tokens"] == 7
+    assert snap["cost_usd"] == 0.01
+    assert snap["by_route"]["deepseek/deepseek-chat"]["llm_calls"] == 1
+    view = llm.usage_view({"llm_calls": 4, "prompt_tokens": 20, "completion_tokens": 5, "cost_usd": 0.2})
+    assert view["llm_calls"] == 4
+    assert view["tokens"] == 25
+    llm.reset_usage()
+
+
+@pytest.mark.asyncio
+async def test_per_turn_provider_is_stamped_and_usage_lands(rig, monkeypatch) -> None:
+    monkeypatch.setenv("DEEPSEEK_API_KEY", "x")
+    space = rig.store.create_space("HQ")
+    rig.llm.manager.append(
+        LLMResult(text="Via deepseek.", model="deepseek/deepseek-chat", prompt_tokens=3, completion_tokens=2)
+    )
+    await rig.runtime.on_user_message(space["id"], "hello", provider="deepseek")
+    await wait_run_done(rig.runtime, space["id"])
+    msgs = rig.store.list_messages(space["id"])
+    assert msgs[-1]["content"] == "Via deepseek."
+    assert msgs[-1]["meta"]["provider"] == "deepseek"
+    assert msgs[-1]["meta"]["route"].startswith("deepseek/")
+    assert msgs[-1]["meta"]["llm_calls"] == 1
+    assert msgs[-1]["meta"]["prompt_tokens"] == 3
+    totals = rig.store.usage_totals()
+    assert totals["llm_calls"] == 1
+    assert totals["tokens"] == 5
+
+
+@pytest.mark.asyncio
+async def test_per_turn_miss_is_a_visible_refuse(rig) -> None:
+    space = rig.store.create_space("HQ")
+    result = await rig.runtime.on_user_message(space["id"], "hello", provider="anthropic")
+    assert "error" in result
+    assert "no silent fallback" in result["error"]
+    sysmsgs = [m for m in rig.store.list_messages(space["id"]) if m["role"] == "system"]
+    assert sysmsgs and "anthropic" in sysmsgs[0]["content"]

--- a/tests/test_crew/test_runtime.py
+++ b/tests/test_crew/test_runtime.py
@@ -90,6 +90,7 @@ async def test_desk_status_lands_in_transcript(rig, monkeypatch) -> None:
     assert "auto-merge" in tools[0]["content"].lower() or "Do not auto-merge" in tools[0]["content"]
     assert "Estate:" in tools[0]["content"]
     assert "ship_gate" in tools[0]["content"]
+    assert "Usage:" in tools[0]["content"]
     answer = [m for m in rig.store.list_messages(space["id"]) if m["role"] == "assistant"][-1]
     assert "chat" in answer["content"].lower()
 

--- a/tests/test_crew/test_server.py
+++ b/tests/test_crew/test_server.py
@@ -144,6 +144,13 @@ def test_ui_index_is_served(client) -> None:
     assert "auto-merge" in desk["law"]
     assert desk["cursor"]["model"] == "grok-4.6"
     assert desk["prs"]["prs"] == []
+    assert "usage" in desk
+    assert desk["usage"]["llm_calls"] == 0
+    assert "id=\"usageChip\"" in page.text
+    assert "id=\"routePick\"" in page.text
+    usage = client.http.get("/crew/usage").json()
+    assert usage["llm_calls"] == 0
+    assert "tokens" in usage
 
 
 def test_keys_get_never_returns_secrets(client) -> None:
@@ -172,6 +179,24 @@ def test_keys_post_activates_provider(client) -> None:
     active = next(p for p in config.resolve_providers() if p.active)
     assert active.label == "openrouter"
     save(client.crew.settings.data_dir, {k: "" for k in KNOWN})
+
+
+def test_pin_and_per_turn_refuse_without_fallback(client) -> None:
+    pinned = client.http.post("/crew/providers", json={"provider": "anthropic"}).json()
+    assert pinned["ok"] is False
+    assert pinned["refused"]
+    assert "no silent fallback" in pinned["refused"]
+    space = client.http.post("/crew/spaces", json={"title": "HQ"}).json()
+    posted = client.http.post(
+        f"/crew/spaces/{space['id']}/messages",
+        json={"text": "hello", "provider": "anthropic"},
+    ).json()
+    assert "error" in posted
+    assert "no silent fallback" in posted["error"]
+    msgs = client.http.get(f"/crew/spaces/{space['id']}/messages").json()
+    assert msgs[-1]["role"] == "system"
+    assert "anthropic" in msgs[-1]["content"]
+    client.http.post("/crew/providers", json={"provider": ""})
 
 
 def test_computer_control_arm_is_refused(client) -> None:


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Fixes #131
Parent: #116 (EPIC-CREW-01)

Netie-native inference router in `CortexOS/crew` — no mybot paste.

## What the operator gets
- Pick a provider/model **per turn** (composer select, clickable provider chain, `POST /crew/providers`, `provider`/`model` on `POST /crew/spaces/{id}/messages`).
- Route goes through crew `llm.chat` + connectors (OpenVault keys, MCP catalog, Anthropic/OpenRouter/Groq/Google/Cerebras/Mistral/…).
- Usage totals on the HUD chip and Belt desk (`GET /crew/usage`, `/crew/health`, `/crew/desk`).
- Connector/host failure **refuses with a reason**. No silent fallback to the next key (R-0011).

## Out of scope
Does not touch #4 / #41–#44. Does not bind or kill :8020. Draft; do not merge.

## Verify
`python3 -m pytest tests/test_crew -q` → 125 passed. `ruff check CortexOS/crew tests/test_crew` clean.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-667d3841-26e3-4244-871e-eeacd4a9ed58?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-667d3841-26e3-4244-871e-eeacd4a9ed58&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

