### PR TITLE
CREW-LIFE: spawn/kill/stop + smart-idle + goal/active persistence (#129)

### DIFF
--- a/CortexOS/crew/a2a.py
+++ b/CortexOS/crew/a2a.py
@@ -136,10 +136,15 @@ class Mailbox:
         self._ready.clear()
         return out
 
-    async def get(self, timeout: float) -> Envelope | None:
+    async def get(self, timeout: float | None = None) -> Envelope | None:
+        """Take the next envelope. ``timeout is None`` waits until one arrives
+        or the waiter is cancelled - that is smart-idle, not a second loop."""
         if not self._items:
             try:
-                await asyncio.wait_for(self._ready.wait(), timeout=timeout)
+                if timeout is None:
+                    await self._ready.wait()
+                else:
+                    await asyncio.wait_for(self._ready.wait(), timeout=timeout)
             except (TimeoutError, asyncio.TimeoutError):
                 return None
         if not self._items:
@@ -148,6 +153,11 @@ class Mailbox:
         if not self._items:
             self._ready.clear()
         return env
+
+    def unget(self, env: Envelope) -> None:
+        """Put ``env`` back at the front so a parked waiter can re-drain it."""
+        self._items.appendleft(env)
+        self._ready.set()
 
     def empty(self) -> bool:
         return not self._items

--- a/CortexOS/crew/life.py
+++ b/CortexOS/crew/life.py
@@ -1,0 +1,90 @@
+"""Crew teammate life: spawn/kill/stop, smart-idle, goal/active mode.
+
+Netie-native vocabulary for the operator HUD. Not a second orchestrator and
+not a background daemon: parked teammates wait on the existing A2A mailbox
+inside the same run task, and mode/goal text live in :mod:`CortexOS.crew.store`
+so they survive chat clear.
+
+Status the operator reads: ``active`` | ``idle`` | ``waiting`` | ``goal``.
+``failed`` and ``stopped`` are terminal and always carry a visible reason
+(R-0011). Legacy ``thinking`` / ``acting`` / ``done`` collapse to that set.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+MODE_ACTIVE = "active"
+MODE_GOAL = "goal"
+MODES = frozenset({MODE_ACTIVE, MODE_GOAL})
+
+STATUS_ACTIVE = "active"
+STATUS_IDLE = "idle"
+STATUS_WAITING = "waiting"
+STATUS_GOAL = "goal"
+STATUS_FAILED = "failed"
+STATUS_STOPPED = "stopped"
+
+STATUSES = frozenset(
+    {
+        STATUS_ACTIVE,
+        STATUS_IDLE,
+        STATUS_WAITING,
+        STATUS_GOAL,
+        STATUS_FAILED,
+        STATUS_STOPPED,
+    }
+)
+
+#: In-loop work. Parked idle/goal is not busy.
+WORKING = frozenset({STATUS_ACTIVE, STATUS_WAITING, "thinking", "acting"})
+
+_STATUS_ALIAS = {
+    "thinking": STATUS_ACTIVE,
+    "acting": STATUS_ACTIVE,
+    "done": STATUS_IDLE,
+}
+
+
+def canonical_mode(mode: str | None) -> str:
+    text = (mode or MODE_ACTIVE).strip().lower()
+    return text if text in MODES else MODE_ACTIVE
+
+
+def canonical_status(status: str | None) -> str:
+    text = (status or STATUS_IDLE).strip().lower()
+    text = _STATUS_ALIAS.get(text, text)
+    return text if text in STATUSES else STATUS_IDLE
+
+
+def is_alive(row: dict[str, Any] | None) -> bool:
+    if not row:
+        return False
+    if int(row.get("alive") if row.get("alive") is not None else 1) == 0:
+        return False
+    return canonical_status(str(row.get("status") or "")) != STATUS_STOPPED
+
+
+def can_accept(row: dict[str, Any] | None) -> bool:
+    """False when the operator would see a dead/failed teammate."""
+    if not is_alive(row):
+        return False
+    status = canonical_status(str((row or {}).get("status") or ""))
+    return status not in {STATUS_FAILED, STATUS_STOPPED}
+
+
+def dead_reason(row: dict[str, Any] | None, *, name: str = "agent") -> str:
+    who = str((row or {}).get("name") or name).strip() or name
+    reason = str((row or {}).get("stop_reason") or "").strip()
+    if reason:
+        return f"{who} is stopped ({reason})"
+    status = canonical_status(str((row or {}).get("status") or ""))
+    if status == STATUS_FAILED:
+        return f"{who} failed and will not accept work"
+    return f"{who} is stopped and will not accept work"
+
+
+def park_status(row: dict[str, Any] | None) -> str:
+    """Idle unless this teammate is in persisted goal mode."""
+    mode = canonical_mode(str((row or {}).get("mode") or MODE_ACTIVE))
+    return STATUS_GOAL if mode == MODE_GOAL else STATUS_IDLE

--- a/CortexOS/crew/policy.py
+++ b/CortexOS/crew/policy.py
@@ -63,6 +63,9 @@ INTERNAL_TOOLS = frozenset(
         "estate_status",
         "ship_gate",
         "rename_agent",
+        "stop_agent",
+        "kill_agent",
+        "set_agent_mode",
     }
 )
 

--- a/CortexOS/crew/runtime.py
+++ b/CortexOS/crew/runtime.py
@@ -21,7 +21,7 @@ import re
 from dataclasses import dataclass, field
 from typing import Any
 
-from CortexOS.crew import a2a, detect, policy, roles
+from CortexOS.crew import a2a, detect, life, policy, roles
 from CortexOS.crew import llm as llm_mod
 from CortexOS.crew.config import CrewSettings, active_provider
 from CortexOS.crew.engine_bridge import EngineBridge
@@ -46,7 +46,10 @@ Never invent numbers the engine did not return.
 them for THIS job (not a fixed roster). Copy a capability template when one \
 fits; its default skills are copied into the teammate automatically. Restrict \
 shared tools with allow_tools / deny_tools. Rename with \
-rename_agent. For quality-critical work set verify=true with explicit \
+rename_agent. Stop with stop_agent (they park idle/goal and can accept another \
+task). Kill with kill_agent (they refuse later work with a visible reason). \
+Set mode=goal so the assignment survives chat clear; mode=active is the \
+session default. For quality-critical work set verify=true with explicit \
 verify_criteria; skip verify rather than rubber-stamp. \
 Crew A2A is the graph. Do not start LangGraph. Engine gen_cfsm stays on the \
 answer plane. OpenVault holds keys.
@@ -89,10 +92,15 @@ class _AgentFinished(Exception):
 @dataclass
 class AgentHandle:
     """Per-agent bookkeeping. The mailbox lives on the Switchboard, not here,
-    so a restarted agent keeps whatever was queued for it."""
+    so a restarted agent keeps whatever was queued for it.
+
+    ``parked`` is smart-idle: the same task is blocked on the mailbox, not a
+    second daemon. ``wait_for_replies`` must not treat that as still working.
+    """
 
     row: dict[str, Any]
     task: asyncio.Task[None] | None = None
+    parked: bool = False
 
 
 @dataclass
@@ -438,6 +446,145 @@ class CrewRuntime:
             task.cancel()
         return True
 
+    def stop_agent(self, agent_id: str) -> dict[str, Any] | None:
+        """Halt work; park idle/goal so they can accept another task."""
+        row = self.store.get_agent(agent_id)
+        if row is None:
+            return None
+        if row["name"] == "Manager":
+            return {"error": "DENIED: Manager cannot be stopped; cancel the run"}
+        handle = self._handles.get(agent_id)
+        if handle is not None and handle.task is not None and not handle.task.done():
+            handle.task.cancel()
+        else:
+            self._park_life(row)
+        parked = self.store.get_agent(agent_id) or row
+        self.bus.emit(parked["space_id"], "agent", {"agent": parked})
+        return parked
+
+    def kill_agent(self, agent_id: str, *, reason: str = "operator killed") -> dict[str, Any] | None:
+        row = self.store.get_agent(agent_id)
+        if row is None:
+            return None
+        if row["name"] == "Manager":
+            return {"error": "DENIED: Manager cannot be killed"}
+        why = (reason or "").strip() or "operator killed"
+        killed = self.store.kill_agent(agent_id, why)
+        handle = self._handles.get(agent_id)
+        if handle is not None and handle.task is not None and not handle.task.done():
+            handle.task.cancel()
+        else:
+            for asker_id in self.switch.abandon(agent_id, life.dead_reason(killed or row)):
+                ctx_id = self._space_run.get(row["space_id"])
+                ctx = self._runs.get(ctx_id) if ctx_id else None
+                if ctx is not None:
+                    self._note_abandoned(ctx, asker_id, row["name"])
+            self.switch.forget(agent_id)
+        if killed is not None:
+            note = self.store.add_message(
+                killed["space_id"], "system", f"DENIED: {life.dead_reason(killed)}"
+            )
+            self.bus.emit(killed["space_id"], "message", {"message": note})
+            self.bus.emit(killed["space_id"], "agent", {"agent": killed})
+        return killed
+
+    def set_agent_mode(
+        self, agent_id: str, mode: str, *, goal_text: str = ""
+    ) -> dict[str, Any] | None:
+        row = self.store.set_agent_mode(agent_id, mode, goal_text)
+        if row is None:
+            return None
+        if life.can_accept(row) and row.get("status") not in life.WORKING:
+            self._park_life(row)
+            row = self.store.get_agent(agent_id) or row
+        self.bus.emit(row["space_id"], "agent", {"agent": row})
+        return row
+
+    def accept_task(self, agent_id: str, brief: str = "") -> dict[str, Any] | None:
+        """Wake a parked teammate. Same run task if it is still parked."""
+        row = self.store.get_agent(agent_id)
+        if row is None:
+            return {"error": "unknown agent"}
+        if not life.can_accept(row):
+            return {"error": f"DENIED: {life.dead_reason(row)}"}
+        ctx_id = self._space_run.get(row["space_id"])
+        ctx = self._runs.get(ctx_id) if ctx_id else None
+        manager = self.ensure_manager(row["space_id"])
+        if ctx is None:
+            self._park_life(row)
+            parked = self.store.get_agent(agent_id) or row
+            return parked
+        if brief.strip():
+            self._deliver_a2a(ctx, manager, row["name"], brief.strip(), kind=a2a.BRIEF)
+        else:
+            self._wake_if_idle(ctx, row)
+        return self.store.get_agent(agent_id) or row
+
+    def clear_chat(self, space_id: str) -> dict[str, Any]:
+        """Drop the transcript. Goal/active mode stays on the agent row."""
+        ctx_id = self._space_run.get(space_id)
+        if ctx_id:
+            self.cancel_run(ctx_id)
+        self.store.clear_messages(space_id)
+        agents = self.store.reset_life_after_clear(space_id)
+        for row in agents:
+            self.bus.emit(space_id, "agent", {"agent": row})
+        note = self.store.add_message(
+            space_id,
+            "system",
+            "Chat cleared. Goal/active mode persisted on teammates.",
+        )
+        self.bus.emit(space_id, "message", {"message": note})
+        return {"ok": True, "agents": agents, "cleared": True}
+
+    async def operator_spawn(self, space_id: str, args: dict[str, Any]) -> dict[str, Any]:
+        """HUD spawn. Uses the live run when one exists; otherwise persists idle/goal."""
+        manager = self.ensure_manager(space_id)
+        ctx_id = self._space_run.get(space_id)
+        ctx = self._runs.get(ctx_id) if ctx_id else None
+        if ctx is not None:
+            text = await self._spawn(ctx, manager, args)
+            name = _sanitize(str(args.get("name", "")).strip())
+            row = self.store.get_agent_by_name(space_id, name)
+            if row is None:
+                return {"error": text}
+            if text.startswith("DENIED"):
+                return {"error": text, "agent": row}
+            return {"ok": True, "agent": row, "detail": text}
+        live = [
+            a
+            for a in self.store.list_agents(space_id)
+            if life.can_accept(a) or a["name"] == "Manager"
+        ]
+        if len(live) >= self.settings.max_agents_per_space:
+            return {"error": f"DENIED: agent cap reached ({self.settings.max_agents_per_space})"}
+        name = _sanitize(str(args.get("name", "")).strip() or f"agent-{len(live)}")
+        mode = life.canonical_mode(str(args.get("mode") or ""))
+        brief = str(args.get("brief") or "").strip()
+        goal_text = str(args.get("goal") or args.get("goal_text") or "").strip()
+        if mode == life.MODE_GOAL and not goal_text:
+            goal_text = brief
+        cap_name = str(args.get("capability") or "").strip()
+        preset = roles.by_name(cap_name) or roles.by_name(name)
+        role = str(args.get("role") or "").strip()
+        if preset is not None and not role:
+            role = preset.role
+        teammate = self.store.upsert_agent(
+            space_id,
+            name,
+            role_prompt=role,
+            icon=(preset.icon if preset is not None else (name[:1] or "A").upper()),
+            color=AGENT_COLORS[len(live) % len(AGENT_COLORS)],
+            spawned_by=manager["id"],
+            capability=(preset.name if preset is not None else cap_name),
+            mode=mode,
+            goal_text=goal_text,
+        )
+        self._park_life(teammate)
+        teammate = self.store.get_agent(teammate["id"]) or teammate
+        self.bus.emit(space_id, "agent", {"agent": teammate})
+        return {"ok": True, "agent": teammate}
+
     async def shutdown(self) -> None:
         for ctx in list(self._runs.values()):
             for task in list(ctx.tasks):
@@ -466,11 +613,19 @@ class CrewRuntime:
             leftovers = [
                 t for t in list(ctx.tasks) if t is not asyncio.current_task() and not t.done()
             ]
-            if leftovers:
+            parked = [t for t in leftovers if self._task_is_parked(t)]
+            working = [t for t in leftovers if t not in parked]
+            if parked:
+                # Smart-idle waiters are the same run task, not a daemon.
+                # Persist idle/goal via CancelledError and do not grace-wait.
+                for task in parked:
+                    task.cancel()
+                await asyncio.gather(*parked, return_exceptions=True)
+            if working:
                 if status in {"cancelled", "failed"}:
-                    for task in leftovers:
+                    for task in working:
                         task.cancel()
-                    await asyncio.gather(*leftovers, return_exceptions=True)
+                    await asyncio.gather(*working, return_exceptions=True)
                 else:
                     # The Manager already wrote the user-facing answer; teammates
                     # get a beat to land their report in the transcript. Anything
@@ -479,7 +634,7 @@ class CrewRuntime:
                     # run's stats, could no longer be cancelled, and survived
                     # shutdown - all of it invisible to the operator.
                     _done, straggling = await asyncio.wait(
-                        leftovers, timeout=min(30, self.settings.llm_timeout_s)
+                        working, timeout=min(30, self.settings.llm_timeout_s)
                     )
                     if straggling:
                         stuck = self._busy_names(space_id, manager["id"])
@@ -493,6 +648,13 @@ class CrewRuntime:
                         )
                         cut = self.store.add_message(space_id, "system", note)
                         self.bus.emit(space_id, "message", {"message": cut})
+            still = [
+                t for t in list(ctx.tasks) if t is not asyncio.current_task() and not t.done()
+            ]
+            if still:
+                for task in still:
+                    task.cancel()
+                await asyncio.gather(*still, return_exceptions=True)
             ctx.closed = True
             self._space_run.pop(space_id, None)
             run = self.store.update_run(ctx.id, status=status, stats=ctx.stats)
@@ -510,27 +672,48 @@ class CrewRuntime:
 
     async def _teammate_run(self, ctx: RunContext, row: dict[str, Any], brief: str) -> None:
         name = row["name"]
+        handle = self._handle(row)
         try:
-            await self._agent_loop(ctx, row, is_manager=False, brief=brief)
+            first = True
+            while True:
+                handle.parked = False
+                await self._agent_loop(
+                    ctx, row, is_manager=False, brief=(brief if first else "")
+                )
+                first = False
+                fresh = self.store.get_agent(row["id"]) or row
+                if not life.is_alive(fresh):
+                    return
+                if ctx.closed:
+                    self._park_life(fresh)
+                    return
+                # Smart-idle: same task waits on the mailbox. No second loop.
+                handle.parked = True
+                self._park_life(fresh)
+                env = await self.switch.mailbox(row["id"]).get(timeout=None)
+                if env is None:
+                    return
+                self.switch.mailbox(row["id"]).unget(env)
         except asyncio.CancelledError:
-            self._set_status(row["id"], "idle")
+            fresh = self.store.get_agent(row["id"]) or row
+            if life.is_alive(fresh):
+                self._park_life(fresh)
         except LLMError as exc:
-            self._set_status(row["id"], "failed")
+            self._fail_agent(row["id"], str(exc))
             self._deliver_a2a(ctx, row, "Manager", f"I failed: {exc}", kind=a2a.REPORT)
         except Exception as exc:  # noqa: BLE001
-            self._set_status(row["id"], "failed")
+            self._fail_agent(row["id"], f"{type(exc).__name__}: {exc}")
             self._deliver_a2a(
                 ctx, row, "Manager", f"I crashed: {type(exc).__name__}: {exc}", kind=a2a.REPORT
             )
         finally:
-            # Anyone blocked in ask_agent on this teammate is told it stopped,
-            # instead of burning the whole timeout on a task that will never
-            # answer (KB R-0011: a silent stall is a lie).
-            for asker_id in self.switch.abandon(row["id"], f"{name} stopped running"):
-                self._note_abandoned(ctx, asker_id, name)
-            # Backstop for anything delivered after the loop's last drain: a
-            # queued message with nobody left to read it is silently lost work.
-            if not self.switch.mailbox(row["id"]).empty():
+            handle.parked = False
+            fresh = self.store.get_agent(row["id"]) or row
+            if not life.is_alive(fresh) or (fresh.get("status") == life.STATUS_FAILED):
+                why = life.dead_reason(fresh, name=name)
+                for asker_id in self.switch.abandon(row["id"], why):
+                    self._note_abandoned(ctx, asker_id, name)
+            elif not self.switch.mailbox(row["id"]).empty() and not ctx.closed:
                 self._handle(row).task = None
                 self._wake_if_idle(ctx, self.store.get_agent(row["id"]) or row)
 
@@ -546,7 +729,7 @@ class CrewRuntime:
     ) -> None:
         space = self.store.get_space(ctx.space_id) or {}
         model, api_base, label = self._provider(ctx, space, row)
-        self._set_status(row["id"], "thinking")
+        self._set_status(row["id"], life.STATUS_ACTIVE)
         last_user = ""
         for m in reversed(self.store.list_messages(ctx.space_id, limit=10_000)):
             if m["role"] == "user":
@@ -634,7 +817,7 @@ class CrewRuntime:
             self._bump_stats(ctx, result)
 
             if result.tool_calls:
-                self._set_status(row["id"], "acting")
+                self._set_status(row["id"], life.STATUS_ACTIVE)
                 messages.append(_assistant_tool_msg(result))
                 finished: str | None = None
                 for tc in result.tool_calls:
@@ -649,7 +832,7 @@ class CrewRuntime:
                 if finished is not None:
                     final_text = finished
                     break
-                self._set_status(row["id"], "thinking")
+                self._set_status(row["id"], life.STATUS_ACTIVE)
                 continue
 
             text = result.text.strip()
@@ -689,13 +872,13 @@ class CrewRuntime:
                 },
             )
             self.bus.emit(ctx.space_id, "message", {"message": msg})
-            self._set_status(row["id"], "idle")
+            self._park_life(row)
         else:
             from CortexOS.execution.subagent_contract import sanitize_subagent_final
 
             final_text = sanitize_subagent_final(final_text)["content"]
             self._deliver_a2a(ctx, row, "Manager", final_text, kind=a2a.REPORT)
-            self._set_status(row["id"], "done")
+            self._park_life(row)
             if int(row.get("verify") or 0) and str(row.get("verify_criteria") or "").strip():
                 await self._spawn_verifier(ctx, row, final_text)
 
@@ -841,6 +1024,14 @@ class CrewRuntime:
                             "type": "string",
                             "description": "optional OpenVault/FreeRoute model for this teammate; grok-fast is rewritten to grok-4.6",
                         },
+                        "mode": {
+                            "type": "string",
+                            "description": "active (session) or goal (survives chat clear)",
+                        },
+                        "goal": {
+                            "type": "string",
+                            "description": "assignment text stored with mode=goal",
+                        },
                     },
                     ["name", "brief"],
                 )
@@ -851,6 +1042,40 @@ class CrewRuntime:
                     "Rename a teammate in this space. Manager cannot be renamed.",
                     {"old_name": {"type": "string"}, "new_name": {"type": "string"}},
                     ["old_name", "new_name"],
+                )
+            )
+            specs.append(
+                spec(
+                    "stop_agent",
+                    "Stop a teammate. They park idle (or goal) and can accept another task."
+                    " Manager cannot be stopped this way - cancel the run instead.",
+                    {"name": {"type": "string"}},
+                    ["name"],
+                )
+            )
+            specs.append(
+                spec(
+                    "kill_agent",
+                    "Kill a teammate. Later send/ask is refused with this reason."
+                    " Manager cannot be killed.",
+                    {
+                        "name": {"type": "string"},
+                        "reason": {"type": "string", "description": "visible stop reason"},
+                    },
+                    ["name"],
+                )
+            )
+            specs.append(
+                spec(
+                    "set_agent_mode",
+                    "Set a teammate's persistence mode. goal survives chat clear;"
+                    " active is the session default. Optional goal text is stored.",
+                    {
+                        "name": {"type": "string"},
+                        "mode": {"type": "string", "description": "active or goal"},
+                        "goal": {"type": "string", "description": "assignment that survives clear"},
+                    },
+                    ["name", "mode"],
                 )
             )
         else:
@@ -1026,6 +1251,46 @@ class CrewRuntime:
             self.bus.emit(ctx.space_id, "agent", {"agent": renamed})
             return f"renamed {old} -> {renamed['name']}"
 
+        if name == "stop_agent":
+            target_name = str(args.get("name", "")).strip()
+            target = self.store.get_agent_by_name(ctx.space_id, target_name)
+            if target is None:
+                return f"no agent named '{target_name}' here"
+            stopped = self.stop_agent(target["id"])
+            if isinstance(stopped, dict) and stopped.get("error"):
+                return str(stopped["error"])
+            fresh = self.store.get_agent(target["id"]) or target
+            return f"stopped {target_name}; they are {fresh.get('status')} and can accept a task"
+
+        if name == "kill_agent":
+            target_name = str(args.get("name", "")).strip()
+            target = self.store.get_agent_by_name(ctx.space_id, target_name)
+            if target is None:
+                return f"no agent named '{target_name}' here"
+            killed = self.kill_agent(
+                target["id"], reason=str(args.get("reason") or "operator killed")
+            )
+            if isinstance(killed, dict) and killed.get("error"):
+                return str(killed["error"])
+            return f"killed {target_name}: {life.dead_reason(self.store.get_agent(target['id']) or target)}"
+
+        if name == "set_agent_mode":
+            target_name = str(args.get("name", "")).strip()
+            target = self.store.get_agent_by_name(ctx.space_id, target_name)
+            if target is None:
+                return f"no agent named '{target_name}' here"
+            updated = self.set_agent_mode(
+                target["id"],
+                str(args.get("mode") or ""),
+                goal_text=str(args.get("goal") or ""),
+            )
+            if updated is None:
+                return f"DENIED: could not set mode on '{target_name}'"
+            return (
+                f"{updated['name']} mode={updated.get('mode')} status={updated.get('status')}"
+                + (f" goal={updated.get('goal_text')}" if updated.get("goal_text") else "")
+            )
+
         if name == "send_to_agent":
             target_name = str(args.get("name", "")).strip()
             message = str(args.get("message", ""))
@@ -1035,6 +1300,9 @@ class CrewRuntime:
             if target is None:
                 known = ", ".join(a["name"] for a in self.store.list_agents(ctx.space_id))
                 return f"no agent named '{target_name}' here (known: {known})"
+            refused = self._refuse_dead(ctx, target)
+            if refused:
+                return refused
             self._deliver_a2a(ctx, row, target_name, message, kind=a2a.TELL)
             fresh = self.store.get_agent(target["id"]) or target
             return f"delivered to {target_name} (they are {fresh.get('status')})"
@@ -1056,7 +1324,10 @@ class CrewRuntime:
                         "nothing is waiting for you and no teammate is still working."
                         " Do not wait again - act on what you already have."
                     )
+                prev = row.get("status")
+                self._set_status(row["id"], life.STATUS_WAITING)
                 env = await mailbox.get(timeout)
+                self._set_status(row["id"], prev or life.STATUS_ACTIVE)
                 if env is None:
                     return (
                         f"nothing arrived within {timeout}s; still working:"
@@ -1071,10 +1342,14 @@ class CrewRuntime:
         return f"DENIED: unknown tool '{name}'"
 
     async def _spawn(self, ctx: RunContext, row: dict[str, Any], args: dict[str, Any]) -> str:
-        agents = self.store.list_agents(ctx.space_id)
-        if len(agents) >= self.settings.max_agents_per_space:
+        live = [
+            a
+            for a in self.store.list_agents(ctx.space_id)
+            if life.can_accept(a) or a["name"] == "Manager"
+        ]
+        if len(live) >= self.settings.max_agents_per_space:
             return f"DENIED: agent cap reached ({self.settings.max_agents_per_space})"
-        name = _sanitize(str(args.get("name", "")).strip() or f"agent-{len(agents)}")
+        name = _sanitize(str(args.get("name", "")).strip() or f"agent-{len(live)}")
         role = str(args.get("role", "")).strip()
         brief = str(args.get("brief", "")).strip()
         cap_name = str(args.get("capability", "")).strip()
@@ -1099,7 +1374,12 @@ class CrewRuntime:
             if bits:
                 role = (role + "\n\n" if role else "") + "\n\n".join(bits)
         model = str(args.get("model") or "").strip()
-        color = AGENT_COLORS[len(agents) % len(AGENT_COLORS)]
+        mode = life.canonical_mode(str(args.get("mode") or ""))
+        if mode == life.MODE_GOAL:
+            goal_text = str(args.get("goal") or args.get("goal_text") or brief).strip()
+        else:
+            goal_text = str(args.get("goal") or args.get("goal_text") or "").strip()
+        color = AGENT_COLORS[len(live) % len(AGENT_COLORS)]
         teammate = self.store.upsert_agent(
             ctx.space_id,
             name,
@@ -1114,7 +1394,11 @@ class CrewRuntime:
             verify_criteria=criteria,
             model=model,
             skills=skill_names,
+            mode=mode,
+            goal_text=goal_text,
         )
+        self._set_status(teammate["id"], life.STATUS_ACTIVE)
+        teammate = self.store.get_agent(teammate["id"]) or teammate
         self.bus.emit(ctx.space_id, "agent", {"agent": teammate})
         self._deliver_a2a(ctx, row, name, brief, kind=a2a.BRIEF, wake=False)
         task = asyncio.create_task(self._teammate_run(ctx, teammate, brief))
@@ -1122,7 +1406,9 @@ class CrewRuntime:
         # run yet still reads as status 'idle' in the store, so without this
         # a send_to_agent on the very next step would start a second copy of
         # the same teammate.
-        self._handle(teammate).task = task
+        handle = self._handle(teammate)
+        handle.parked = False
+        handle.task = task
         ctx.tasks.add(task)
         task.add_done_callback(ctx.tasks.discard)
         extra = ""
@@ -1130,6 +1416,8 @@ class CrewRuntime:
             extra = "; verifier will run after they finish"
         elif bool(args.get("verify")) and not criteria:
             extra = "; verify skipped (no explicit criteria; refusing rubber-stamp)"
+        if mode == life.MODE_GOAL:
+            extra += "; mode=goal (survives chat clear)"
         return f"spawned {name}; they are working the brief and will report back{extra}"
 
     async def _spawn_verifier(
@@ -1228,10 +1516,36 @@ class CrewRuntime:
             self._handles[row["id"]] = handle
         return handle
 
+    def _task_is_parked(self, task: asyncio.Task[None]) -> bool:
+        return any(h.task is task and h.parked for h in self._handles.values())
+
     def _set_status(self, agent_id: str, status: str) -> None:
         row = self.store.set_agent_status(agent_id, status)
         if row is not None:
             self.bus.emit(row["space_id"], "agent", {"agent": row})
+
+    def _park_life(self, row: dict[str, Any]) -> None:
+        if not life.is_alive(row):
+            return
+        self._set_status(row["id"], life.park_status(row))
+
+    def _fail_agent(self, agent_id: str, reason: str) -> None:
+        row = self.store.mark_agent_failed(agent_id, reason)
+        if row is not None:
+            self.bus.emit(row["space_id"], "agent", {"agent": row})
+
+    def _refuse_dead(self, ctx: RunContext, target: dict[str, Any]) -> str:
+        """Visible refusal when a silent-dead teammate would otherwise hang (R-0011)."""
+        if life.can_accept(target):
+            return ""
+        why = life.dead_reason(target)
+        msg = self.store.add_message(
+            ctx.space_id,
+            "system",
+            f"DENIED: {why}",
+        )
+        self.bus.emit(ctx.space_id, "message", {"message": msg})
+        return f"DENIED: {why}"
 
     def _note_questions(self, agent_id: str, envs: list[a2a.Envelope]) -> list[a2a.Envelope]:
         """Record which questions this agent now owes an answer to.
@@ -1259,8 +1573,13 @@ class CrewRuntime:
             if a["id"] == me:
                 continue
             handle = self._handles.get(a["id"])
-            running = handle is not None and handle.task is not None and not handle.task.done()
-            if running or a["status"] in {"thinking", "acting"}:
+            running = (
+                handle is not None
+                and handle.task is not None
+                and not handle.task.done()
+                and not handle.parked
+            )
+            if running or a["status"] in life.WORKING:
                 out.append(a["name"])
         return out
 
@@ -1294,6 +1613,9 @@ class CrewRuntime:
         if target is None:
             known = ", ".join(a["name"] for a in self.store.list_agents(ctx.space_id))
             return f"no agent named '{target_name}' here (known: {known})"
+        refused = self._refuse_dead(ctx, target)
+        if refused:
+            return refused
         if target["id"] == row["id"]:
             return "DENIED: you cannot ask yourself"
         if self.switch.would_deadlock(row["id"], target["id"]):
@@ -1311,14 +1633,18 @@ class CrewRuntime:
             # matched to this question rather than merely to its sender.
             self.switch.rekey_ask(row["id"], target["id"], str(msg["id"]))
         try:
+            prev = row.get("status")
+            self._set_status(row["id"], life.STATUS_WAITING)
             kind, answer = await asyncio.wait_for(future, timeout=timeout)
         except (TimeoutError, asyncio.TimeoutError):
             self.switch.close_ask(row["id"], target["id"])
+            self._set_status(row["id"], prev or life.STATUS_ACTIVE)
             fresh = self.store.get_agent(target["id"]) or target
             return (
                 f"{target_name} did not answer within {timeout}s"
                 f" (they are {fresh.get('status')}). Proceed without them, or ask again."
             )
+        self._set_status(row["id"], prev or life.STATUS_ACTIVE)
         if kind == a2a.NO_ANSWER:
             return f"{target_name} {answer}"
         # REPORT is an answering kind on the switchboard (keyed by asker+target,
@@ -1410,11 +1736,15 @@ class CrewRuntime:
         """
         if target["name"] == "Manager":
             return  # the manager is driven by the run loop, never restarted here
+        if not life.can_accept(target):
+            return
         handle = self._handle(target)
         if handle.task is not None and not handle.task.done():
             return
         fresh = self.store.get_agent(target["id"]) or target
-        if fresh["status"] in {"thinking", "acting"}:
+        if not life.can_accept(fresh):
+            return
+        if fresh["status"] in life.WORKING:
             return
         task = asyncio.create_task(self._teammate_run(ctx, fresh, ""))
         handle.task = task
@@ -1560,7 +1890,8 @@ class CrewRuntime:
             self._open_questions.setdefault(me, {}).update(owed)
         tail = _openable(out[-limit:])
         if not tail:
-            tail = [{"role": "user", "content": brief or "Report in."}]
+            stored_goal = str(row.get("goal_text") or "").strip()
+            tail = [{"role": "user", "content": brief or stored_goal or "Report in."}]
         return tail
 
 

--- a/CortexOS/crew/server.py
+++ b/CortexOS/crew/server.py
@@ -157,6 +157,28 @@ class SkillIn(BaseModel):
     body: str
 
 
+class AgentSpawnIn(BaseModel):
+    name: str
+    brief: str = ""
+    role: str = ""
+    capability: str = ""
+    mode: str = "active"
+    goal: str = ""
+
+
+class AgentModeIn(BaseModel):
+    mode: str
+    goal: str = ""
+
+
+class AgentKillIn(BaseModel):
+    reason: str = "operator killed"
+
+
+class AgentAcceptIn(BaseModel):
+    brief: str = ""
+
+
 class ImportIn(BaseModel):
     title: str = "Imported chat"
     text: str = ""
@@ -281,6 +303,75 @@ def build_router(crew: CrewApp) -> APIRouter:
     @router.get("/spaces/{space_id}/agents")
     async def agents(space_id: str) -> list[dict[str, Any]]:
         return crew.store.list_agents(space_id)
+
+    @router.post("/spaces/{space_id}/agents")
+    async def spawn_agent(space_id: str, body: AgentSpawnIn) -> dict[str, Any]:
+        if crew.store.get_space(space_id) is None:
+            raise HTTPException(404, "unknown space")
+        result = await crew.runtime.operator_spawn(
+            space_id,
+            {
+                "name": body.name,
+                "brief": body.brief,
+                "role": body.role,
+                "capability": body.capability,
+                "mode": body.mode,
+                "goal": body.goal,
+            },
+        )
+        if result.get("error"):
+            raise HTTPException(400, str(result["error"]))
+        return result
+
+    @router.post("/spaces/{space_id}/agents/{agent_id}/stop")
+    async def stop_agent(space_id: str, agent_id: str) -> dict[str, Any]:
+        row = crew.store.get_agent(agent_id)
+        if row is None or row.get("space_id") != space_id:
+            raise HTTPException(404, "unknown agent")
+        stopped = crew.runtime.stop_agent(agent_id)
+        if isinstance(stopped, dict) and stopped.get("error"):
+            raise HTTPException(400, str(stopped["error"]))
+        return {"ok": True, "agent": stopped}
+
+    @router.post("/spaces/{space_id}/agents/{agent_id}/kill")
+    async def kill_agent(space_id: str, agent_id: str, body: AgentKillIn | None = None) -> dict[str, Any]:
+        row = crew.store.get_agent(agent_id)
+        if row is None or row.get("space_id") != space_id:
+            raise HTTPException(404, "unknown agent")
+        killed = crew.runtime.kill_agent(
+            agent_id, reason=(body.reason if body is not None else "operator killed")
+        )
+        if isinstance(killed, dict) and killed.get("error"):
+            raise HTTPException(400, str(killed["error"]))
+        return {"ok": True, "agent": killed}
+
+    @router.post("/spaces/{space_id}/agents/{agent_id}/mode")
+    async def set_agent_mode(space_id: str, agent_id: str, body: AgentModeIn) -> dict[str, Any]:
+        row = crew.store.get_agent(agent_id)
+        if row is None or row.get("space_id") != space_id:
+            raise HTTPException(404, "unknown agent")
+        updated = crew.runtime.set_agent_mode(agent_id, body.mode, goal_text=body.goal)
+        if updated is None:
+            raise HTTPException(404, "unknown agent")
+        return {"ok": True, "agent": updated}
+
+    @router.post("/spaces/{space_id}/agents/{agent_id}/accept")
+    async def accept_task(space_id: str, agent_id: str, body: AgentAcceptIn | None = None) -> dict[str, Any]:
+        row = crew.store.get_agent(agent_id)
+        if row is None or row.get("space_id") != space_id:
+            raise HTTPException(404, "unknown agent")
+        accepted = crew.runtime.accept_task(
+            agent_id, brief=(body.brief if body is not None else "")
+        )
+        if isinstance(accepted, dict) and accepted.get("error"):
+            raise HTTPException(400, str(accepted["error"]))
+        return {"ok": True, "agent": accepted}
+
+    @router.post("/spaces/{space_id}/clear")
+    async def clear_chat(space_id: str) -> dict[str, Any]:
+        if crew.store.get_space(space_id) is None:
+            raise HTTPException(404, "unknown space")
+        return crew.runtime.clear_chat(space_id)
 
     @router.get("/spaces/{space_id}/events")
     async def events(space_id: str, after: int = -1) -> StreamingResponse:

--- a/CortexOS/crew/store.py
+++ b/CortexOS/crew/store.py
@@ -41,6 +41,10 @@ CREATE TABLE IF NOT EXISTS agents (
     verify_criteria TEXT NOT NULL DEFAULT '',
     model TEXT NOT NULL DEFAULT '',
     skills TEXT NOT NULL DEFAULT '',
+    mode TEXT NOT NULL DEFAULT 'active',
+    goal_text TEXT NOT NULL DEFAULT '',
+    stop_reason TEXT NOT NULL DEFAULT '',
+    alive INTEGER NOT NULL DEFAULT 1,
     created_at TEXT NOT NULL,
     UNIQUE (space_id, name)
 );
@@ -130,6 +134,10 @@ class CrewStore:
             ("verify_criteria", "TEXT NOT NULL DEFAULT ''"),
             ("model", "TEXT NOT NULL DEFAULT ''"),
             ("skills", "TEXT NOT NULL DEFAULT ''"),
+            ("mode", "TEXT NOT NULL DEFAULT 'active'"),
+            ("goal_text", "TEXT NOT NULL DEFAULT ''"),
+            ("stop_reason", "TEXT NOT NULL DEFAULT ''"),
+            ("alive", "INTEGER NOT NULL DEFAULT 1"),
         )
         for name, ddl in extras:
             if name not in cols:
@@ -202,6 +210,8 @@ class CrewStore:
         verify_criteria: Any = "",
         model: str = "",
         skills: Any = "",
+        mode: str = "",
+        goal_text: str = "",
     ) -> dict[str, Any]:
         allow_s = _dumps(allow_tools)
         deny_s = _dumps(deny_tools)
@@ -211,6 +221,10 @@ class CrewStore:
         if "grok" in model_s.lower() and "fast" in model_s.lower():
             model_s = "openai/grok-4.6"
         verify_i = 1 if verify else 0
+        from CortexOS.crew.life import canonical_mode
+
+        mode_s = canonical_mode(mode) if (mode or "").strip() else ""
+        goal_s = (goal_text or "").strip()
         existing = self.get_agent_by_name(space_id, name)
         if existing is not None:
             patch: dict[str, Any] = {}
@@ -230,6 +244,10 @@ class CrewStore:
                 patch["model"] = model_s
             if skills_s and skills_s != (existing.get("skills") or ""):
                 patch["skills"] = skills_s
+            if mode_s and mode_s != (existing.get("mode") or "active"):
+                patch["mode"] = mode_s
+            if goal_s and goal_s != (existing.get("goal_text") or ""):
+                patch["goal_text"] = goal_s
             if patch:
                 sets = ", ".join(f"{k} = ?" for k in patch)
                 with self._lock:
@@ -245,7 +263,8 @@ class CrewStore:
             self._db.execute(
                 "INSERT INTO agents (id, space_id, name, icon, color, role_prompt, spawned_by,"
                 " allow_tools, deny_tools, capability, verify, verify_criteria, model, skills,"
-                " created_at) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+                " mode, goal_text, created_at) VALUES"
+                " (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
                 (
                     agent_id,
                     space_id,
@@ -261,6 +280,8 @@ class CrewStore:
                     crit_s,
                     model_s,
                     skills_s,
+                    mode_s or "active",
+                    goal_s,
                     _now(),
                 ),
             )
@@ -303,11 +324,90 @@ class CrewStore:
             ).fetchall()
         return [dict(r) for r in rows]
 
-    def set_agent_status(self, agent_id: str, status: str) -> dict[str, Any] | None:
+    def mark_agent_failed(self, agent_id: str, reason: str) -> dict[str, Any] | None:
+        if self.get_agent(agent_id) is None:
+            return None
+        why = (reason or "").strip() or "failed"
         with self._lock:
-            self._db.execute("UPDATE agents SET status = ? WHERE id = ?", (status, agent_id))
+            self._db.execute(
+                "UPDATE agents SET status = 'failed', stop_reason = ? WHERE id = ?",
+                (why, agent_id),
+            )
             self._db.commit()
         return self.get_agent(agent_id)
+
+    def set_agent_status(self, agent_id: str, status: str) -> dict[str, Any] | None:
+        from CortexOS.crew.life import canonical_status, park_status
+
+        row = self.get_agent(agent_id)
+        if row is None:
+            return None
+        wanted = canonical_status(status)
+        if wanted == "idle":
+            wanted = park_status(row)
+        with self._lock:
+            self._db.execute("UPDATE agents SET status = ? WHERE id = ?", (wanted, agent_id))
+            self._db.commit()
+        return self.get_agent(agent_id)
+
+    def set_agent_mode(
+        self, agent_id: str, mode: str, goal_text: str | None = None
+    ) -> dict[str, Any] | None:
+        from CortexOS.crew.life import canonical_mode, park_status
+
+        row = self.get_agent(agent_id)
+        if row is None:
+            return None
+        mode_s = canonical_mode(mode)
+        patch: dict[str, Any] = {"mode": mode_s}
+        if goal_text is not None:
+            patch["goal_text"] = (goal_text or "").strip()
+        status = str(row.get("status") or "idle")
+        if status in {"idle", "goal", "done"}:
+            merged = dict(row)
+            merged["mode"] = mode_s
+            patch["status"] = park_status(merged)
+        sets = ", ".join(f"{k} = ?" for k in patch)
+        with self._lock:
+            self._db.execute(
+                f"UPDATE agents SET {sets} WHERE id = ?", (*patch.values(), agent_id)
+            )
+            self._db.commit()
+        return self.get_agent(agent_id)
+
+    def kill_agent(self, agent_id: str, reason: str) -> dict[str, Any] | None:
+        if self.get_agent(agent_id) is None:
+            return None
+        why = (reason or "").strip() or "operator killed"
+        with self._lock:
+            self._db.execute(
+                "UPDATE agents SET alive = 0, status = 'stopped', stop_reason = ? WHERE id = ?",
+                (why, agent_id),
+            )
+            self._db.commit()
+        return self.get_agent(agent_id)
+
+    def clear_messages(self, space_id: str) -> None:
+        """Drop the transcript. Agent rows (mode/goal) stay; that is crew memory."""
+        with self._lock:
+            self._db.execute("DELETE FROM messages WHERE space_id = ?", (space_id,))
+            self._db.commit()
+
+    def reset_life_after_clear(self, space_id: str) -> list[dict[str, Any]]:
+        """After chat clear: goal mode stays goal, everyone else parks idle.
+
+        Stopped/failed rows keep their reason. Manager stays in the roster.
+        """
+        from CortexOS.crew.life import is_alive, park_status
+
+        out: list[dict[str, Any]] = []
+        for row in self.list_agents(space_id):
+            if not is_alive(row):
+                out.append(row)
+                continue
+            parked = self.set_agent_status(row["id"], park_status(row))
+            out.append(parked or row)
+        return out
 
     # -- messages ----------------------------------------------------------
 

--- a/CortexOS/crew/ui/crew.css
+++ b/CortexOS/crew/ui/crew.css
@@ -849,7 +849,23 @@ button { cursor: pointer; }
   margin-right: 0.35rem;
   vertical-align: middle;
 }
-.row-actions { display: flex; gap: 0.25rem; margin-top: 0.2rem; }
+.row-actions { display: flex; gap: 0.25rem; margin-top: 0.2rem; flex-wrap: wrap; }
+.life-spawn {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 0.28rem;
+  margin: 0.35rem 0 0.55rem;
+}
+.life-spawn input, .life-spawn select {
+  width: 100%;
+  background: var(--well);
+  color: var(--ink);
+  border: 1px solid var(--line);
+  font: 0.72rem var(--mono);
+  padding: 0.28rem 0.4rem;
+}
+.life-spawn button { grid-column: 1 / -1; }
+.agent-card { border-bottom: 1px solid var(--line); padding-bottom: 0.25rem; margin-bottom: 0.2rem; }
 .ladder {
   margin-top: 0.85rem;
   border-top: 1px solid var(--line);

--- a/CortexOS/crew/ui/index.html
+++ b/CortexOS/crew/ui/index.html
@@ -40,6 +40,7 @@
           <button class="ghost" id="uiBigger" type="button" title="Bigger text">A+</button>
           <button class="ghost" id="toggleActivity" title="Show only agent-to-agent traffic">Activity</button>
           <button class="ghost danger" id="cancelRun" hidden title="Stops this run. Does not kill Manager.">Cancel</button>
+          <button class="ghost" id="clearChat" type="button" title="Clears chat. Goal/active mode stays in crew store.">Clear chat</button>
         </div>
       </div>
       <div class="focus-bar" id="focusBar" hidden></div>
@@ -96,6 +97,16 @@
         </div>
         <div class="block">
           <h2>Crew</h2>
+          <p class="hint">Status: active / idle / waiting / goal. Stop parks. Kill refuses with a reason.</p>
+          <div class="life-spawn">
+            <input id="spawnName" placeholder="name" />
+            <input id="spawnBrief" placeholder="brief" />
+            <select id="spawnMode">
+              <option value="active">active</option>
+              <option value="goal">goal</option>
+            </select>
+            <button class="ghost" id="spawnTeammate" type="button">Spawn teammate</button>
+          </div>
           <div id="agents" class="empty empty--orb">No agents yet.</div>
         </div>
         <div class="block">
@@ -537,7 +548,7 @@
       }).join("");
       const dots = nodes.map((a) => {
         const p = at[a.id];
-        const busy = a.status === "thinking" || a.status === "acting";
+        const busy = lifeBusy(a);
         return `<circle cx="${p.x.toFixed(1)}" cy="${p.y.toFixed(1)}" r="${busy ? 8 : 6}"`
           + ` fill="${esc(a.color || "#8b91a3")}" stroke="${busy ? "#5ec4c9" : "none"}" stroke-width="1.5">`
           + `<title>${esc(a.name)} (${esc(a.status)})</title></circle>`
@@ -621,20 +632,45 @@
         bar.innerHTML = chips.join(" ");
       } else { bar.hidden = true; bar.innerHTML = ""; }
     }
+    function lifeBusy(a) {
+      return a.status === "active" || a.status === "waiting" || a.status === "thinking" || a.status === "acting";
+    }
     function renderAgents() {
       if (!state.agents.length) { $("agents").innerHTML = `<div class="empty empty--orb">No agents yet.</div>`; return; }
       $("agents").innerHTML = state.agents.map((a) => {
         const cap = a.capability ? " - " + a.capability : "";
         const model = a.model ? " - " + a.model : "";
         const deny = a.deny_tools ? " - deny " + a.deny_tools : "";
-        const busy = a.status === "thinking" || a.status === "acting";
-        return `<button class="agent${state.focusAgent === a.id ? " agent--on" : ""}" data-id="${esc(a.id)}" type="button" title="Show only this agent's traffic">`
+        const busy = lifeBusy(a);
+        const mode = a.mode || "active";
+        const goal = a.goal_text ? esc(String(a.goal_text).slice(0, 80)) : "";
+        const reason = a.stop_reason ? `<div class="hint">DENIED: ${esc(a.stop_reason)}</div>` : "";
+        const manager = a.name === "Manager";
+        const actions = manager
+          ? `<div class="row-actions"><span class="hint">Cancel stops the run. Does not kill Manager.</span></div>`
+          : `<div class="row-actions">`
+            + `<button class="ghost" data-act="stop" data-id="${esc(a.id)}" type="button">Stop</button>`
+            + `<button class="ghost deny" data-act="kill" data-id="${esc(a.id)}" type="button">Kill</button>`
+            + `<button class="ghost" data-act="mode" data-id="${esc(a.id)}" data-mode="${mode === "goal" ? "active" : "goal"}" type="button">${mode === "goal" ? "to active" : "to goal"}</button>`
+            + `<button class="ghost" data-act="accept" data-id="${esc(a.id)}" type="button">Accept task</button>`
+            + `</div>`;
+        return `<div class="agent-card">`
+          + `<button class="agent${state.focusAgent === a.id ? " agent--on" : ""}" data-id="${esc(a.id)}" type="button" title="Show only this agent's traffic">`
           + `<div class="orb ${busy ? "thinking" : ""}" style="background:${esc(a.color || "#7ea0d4")}">${esc((a.icon || a.name || "?").slice(0, 2))}</div>`
-          + `<div>${esc(a.name)}<small><span class="id">${esc(a.id || "")}</span> ${esc(a.status)}${esc(cap)}${esc(model)}${esc(deny)}</small></div></button>`;
+          + `<div>${esc(a.name)}<small><span class="id">${esc(a.id || "")}</span>`
+          + ` <span class="claim">${esc(a.status || "idle")}</span>`
+          + ` <span class="scope">${esc(mode)}</span>`
+          + `${esc(cap)}${esc(model)}${esc(deny)}</small>`
+          + (goal ? `<small>goal: ${goal}</small>` : "")
+          + reason
+          + `</div></button>${actions}</div>`;
       }).join("");
       $("agents").querySelectorAll(".agent").forEach((el) => el.onclick = () => {
         state.focusAgent = state.focusAgent === el.dataset.id ? null : el.dataset.id;
         renderAgents(); renderFocus(); renderLog();
+      });
+      $("agents").querySelectorAll("button[data-act]").forEach((el) => {
+        el.onclick = (ev) => { ev.stopPropagation(); lifeAct(el.dataset.act, el.dataset.id, el.dataset.mode); };
       });
     }
     function renderSkills(rows) {
@@ -804,7 +840,11 @@
         state.messages.filter((m) => m.role === "user").slice(-4).forEach((m) =>
           facts.push({ k: "you", v: String(m.content || "").slice(0, 80), id: m.id }));
       } else if (scope === "agent") {
-        state.agents.slice(0, 6).forEach((a) => facts.push({ k: a.name, v: a.status + (a.capability ? " " + a.capability : ""), id: a.id }));
+        state.agents.slice(0, 8).forEach((a) => facts.push({
+          k: a.name,
+          v: (a.mode || "active") + " / " + (a.status || "idle") + (a.goal_text ? " goal=" + a.goal_text : "") + (a.stop_reason ? " DENIED: " + a.stop_reason : ""),
+          id: a.id
+        }));
       } else if (scope === "run") {
         facts.push({ k: "run", v: $("runStatus").textContent || "idle", id: state.runId || "" });
         facts.push({ k: "seq", v: String(state.seq || 0), id: "seq" });
@@ -1235,6 +1275,51 @@
       if (!state.runId) return;
       try { await api("/crew/runs/" + state.runId + "/cancel", { method: "POST" }); }
       catch (err) { toast(err.message, "bad"); }
+    };
+    async function refreshAgents() {
+      if (!state.spaceId) return;
+      state.agents = await api("/crew/spaces/" + state.spaceId + "/agents");
+      renderAgents();
+      renderMemory();
+    }
+    async function lifeAct(act, id, mode) {
+      if (!state.spaceId || !id) return;
+      const base = "/crew/spaces/" + state.spaceId + "/agents/" + id;
+      try {
+        if (act === "stop") await api(base + "/stop", { method: "POST", body: "{}" });
+        else if (act === "kill") await api(base + "/kill", { method: "POST", body: JSON.stringify({ reason: "operator killed" }) });
+        else if (act === "mode") await api(base + "/mode", { method: "POST", body: JSON.stringify({ mode: mode || "goal", goal: "" }) });
+        else if (act === "accept") await api(base + "/accept", { method: "POST", body: JSON.stringify({ brief: "" }) });
+        await refreshAgents();
+      } catch (err) { toast(err.message, "bad"); }
+    }
+    $("spawnTeammate").onclick = async () => {
+      if (!state.spaceId) return;
+      const name = $("spawnName").value.trim();
+      if (!name) { toast("Name the teammate.", "bad"); return; }
+      try {
+        await api("/crew/spaces/" + state.spaceId + "/agents", {
+          method: "POST",
+          body: JSON.stringify({
+            name: name,
+            brief: $("spawnBrief").value.trim(),
+            mode: $("spawnMode").value || "active",
+            goal: $("spawnMode").value === "goal" ? $("spawnBrief").value.trim() : ""
+          })
+        });
+        $("spawnName").value = "";
+        $("spawnBrief").value = "";
+        await refreshAgents();
+        toast("Spawned " + name + ".");
+      } catch (err) { toast(err.message, "bad"); }
+    };
+    $("clearChat").onclick = async () => {
+      if (!state.spaceId) return;
+      try {
+        await api("/crew/spaces/" + state.spaceId + "/clear", { method: "POST", body: "{}" });
+        await selectSpace(state.spaceId);
+        toast("Chat cleared. Goal/active mode stayed in store.");
+      } catch (err) { toast(err.message, "bad"); }
     };
     $("toggleRail").onclick = () => {
       const rail = $("rail");

--- a/tests/test_crew/test_life.py
+++ b/tests/test_crew/test_life.py
@@ -1,0 +1,155 @@
+"""Spawn/kill/stop, smart-idle, and goal/active persistence.
+
+Asserted on stored statuses, transcript refusals, and HUD routes the operator
+reads (CLAUDE.md section 8). No second daemon loop: parked teammates wait on
+the existing A2A mailbox inside the same run task.
+"""
+
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+from CortexOS.crew import a2a, life
+from CortexOS.crew.llm import LLMResult
+from tests.test_crew.conftest import wait_run_done
+from tests.test_crew.test_a2a import NamedLLM, _agent_msgs, _tc, _tool_results
+
+pytestmark = pytest.mark.asyncio
+
+
+@pytest.fixture()
+def rig2(rig):
+    llm = NamedLLM()
+    rig.runtime._llm = llm
+    rig.llm = llm
+    return rig
+
+
+async def test_operator_spawn_kill_stop_statuses(rig2) -> None:
+    space = rig2.store.create_space("Life")
+    spawned = await rig2.runtime.operator_spawn(
+        space["id"], {"name": "Scout", "brief": "watch", "mode": "active"}
+    )
+    assert spawned.get("ok") is True
+    scout = spawned["agent"]
+    assert scout["status"] in {life.STATUS_IDLE, life.STATUS_ACTIVE}
+    assert scout["mode"] == life.MODE_ACTIVE
+
+    stopped = rig2.runtime.stop_agent(scout["id"])
+    assert stopped is not None and not stopped.get("error")
+    parked = rig2.store.get_agent(scout["id"])
+    assert parked is not None and parked["status"] == life.STATUS_IDLE
+    assert life.can_accept(parked)
+
+    killed = rig2.runtime.kill_agent(scout["id"], reason="operator killed")
+    assert killed is not None
+    assert killed["status"] == life.STATUS_STOPPED
+    assert int(killed["alive"]) == 0
+    assert "operator killed" in killed["stop_reason"]
+    manager_kill = rig2.runtime.kill_agent(rig2.runtime.ensure_manager(space["id"])["id"])
+    assert manager_kill is not None and "DENIED" in str(manager_kill.get("error"))
+
+
+async def test_killed_agent_ask_is_a_visible_refusal(rig2) -> None:
+    space = rig2.store.create_space("Ghost")
+    rig2.llm.script(
+        "Manager",
+        LLMResult(tool_calls=[_tc("spawn_agent", name="Ghost", brief="go look")]),
+        LLMResult(tool_calls=[_tc("kill_agent", name="Ghost", reason="silent-dead")]),
+        LLMResult(tool_calls=[_tc("ask_agent", name="Ghost", question="well?")]),
+        LLMResult(text="Ghost is dead; I am not inventing its answer."),
+    )
+    rig2.llm.script("Ghost", 0.2, LLMResult(text="should-not-land"))
+
+    await rig2.runtime.on_user_message(space["id"], "kill ghost")
+    await wait_run_done(rig2.runtime, space["id"])
+
+    ghost = rig2.store.get_agent_by_name(space["id"], "Ghost")
+    assert ghost is not None
+    assert ghost["status"] == life.STATUS_STOPPED
+    sysmsgs = [m for m in rig2.store.list_messages(space["id"]) if m["role"] == "system"]
+    assert any("DENIED" in m["content"] and "silent-dead" in m["content"] for m in sysmsgs)
+    results = _tool_results(rig2, "Manager")
+    assert any("DENIED" in t and "silent-dead" in t for t in results)
+    final = [m for m in rig2.store.list_messages(space["id"]) if m["role"] == "assistant"][-1]
+    assert "dead" in final["content"].lower() or "not inventing" in final["content"].lower()
+
+
+async def test_smart_idle_accepts_a_second_task_without_a_daemon(rig2) -> None:
+    space = rig2.store.create_space("Idle")
+    rig2.llm.script(
+        "Manager",
+        LLMResult(tool_calls=[_tc("spawn_agent", name="Scout", brief="FIRST-THING")]),
+        LLMResult(tool_calls=[_tc("wait_for_replies", timeout_seconds=5)]),
+        LLMResult(tool_calls=[_tc("send_to_agent", name="Scout", message="SECOND-THING")]),
+        LLMResult(tool_calls=[_tc("wait_for_replies", timeout_seconds=5)]),
+        LLMResult(text="Scout handled both from idle."),
+    )
+    rig2.llm.script("Scout", LLMResult(text="FIRST-DONE"), LLMResult(text="SECOND-DONE"))
+
+    await rig2.runtime.on_user_message(space["id"], "two jobs")
+    await wait_run_done(rig2.runtime, space["id"])
+
+    contents = [m["content"] for m in _agent_msgs(rig2, space["id"])]
+    assert any("FIRST-DONE" in c for c in contents)
+    assert any("SECOND-DONE" in c for c in contents)
+    scout = rig2.store.get_agent_by_name(space["id"], "Scout")
+    assert scout is not None
+    assert scout["status"] in {life.STATUS_IDLE, life.STATUS_GOAL}
+    handle = rig2.runtime._handles.get(scout["id"])
+    for _ in range(50):
+        if handle is None or handle.task is None or handle.task.done():
+            break
+        await asyncio.sleep(0.01)
+    handle = rig2.runtime._handles.get(scout["id"])
+    assert handle is None or handle.task is None or handle.task.done()
+
+
+async def test_goal_mode_survives_chat_clear(rig2) -> None:
+    space = rig2.store.create_space("Goal")
+    spawned = await rig2.runtime.operator_spawn(
+        space["id"],
+        {"name": "Keeper", "brief": "hold the line", "mode": "goal", "goal": "hold the line"},
+    )
+    keeper = spawned["agent"]
+    rig2.store.add_message(space["id"], "user", "forget this")
+    cleared = rig2.runtime.clear_chat(space["id"])
+    assert cleared["ok"] is True
+    users = [m for m in rig2.store.list_messages(space["id"]) if m["role"] == "user"]
+    assert users == []
+    again = rig2.store.get_agent(keeper["id"])
+    assert again is not None
+    assert again["mode"] == life.MODE_GOAL
+    assert again["goal_text"] == "hold the line"
+    assert again["status"] == life.STATUS_GOAL
+
+    worker = await rig2.runtime.operator_spawn(
+        space["id"], {"name": "Temp", "brief": "one shot", "mode": "active"}
+    )
+    temp = worker["agent"]
+    rig2.runtime.clear_chat(space["id"])
+    temp2 = rig2.store.get_agent(temp["id"])
+    assert temp2 is not None
+    assert temp2["mode"] == life.MODE_ACTIVE
+    assert temp2["status"] == life.STATUS_IDLE
+
+
+async def test_mailbox_unget_keeps_smart_idle_accept_order() -> None:
+    box = a2a.Mailbox()
+    first = a2a.Envelope(
+        id="m1", kind=a2a.TELL, from_id="a", from_name="A",
+        to_id="b", to_name="B", text="one", seq=1,
+    )
+    second = a2a.Envelope(
+        id="m2", kind=a2a.TELL, from_id="a", from_name="A",
+        to_id="b", to_name="B", text="two", seq=2,
+    )
+    box.put(first)
+    box.put(second)
+    taken = await box.get(timeout=0.1)
+    assert taken is not None and taken.text == "one"
+    box.unget(taken)
+    drained = box.drain()
+    assert [e.text for e in drained] == ["one", "two"]

--- a/tests/test_crew/test_server.py
+++ b/tests/test_crew/test_server.py
@@ -115,6 +115,9 @@ def test_ui_index_is_served(client) -> None:
     assert "Tickets" in page.text
     assert "Auto-detect" in page.text
     assert "Spawn the " not in page.text
+    assert "Spawn teammate" in page.text
+    assert "Clear chat" in page.text
+    assert "active / idle / waiting / goal" in page.text
     assert "Ask the Manager. Type / for commands, @ for a teammate." in page.text
     assert 'id="suggest"' in page.text
     assert "/crew/commands" in page.text
@@ -322,3 +325,53 @@ def test_commands_autocomplete_and_mention_targets(client) -> None:
     users = [m for m in lined if m["role"] == "user"]
     assert users[-1]["meta"]["a2a"]["to"] == "PRD"
     assert users[-1]["meta"]["mentions"][0]["kind"] == "role"
+
+
+def test_operator_life_routes_spawn_kill_clear(client) -> None:
+    space = client.http.post("/crew/spaces", json={"title": "Life"}).json()
+    spawned = client.http.post(
+        f"/crew/spaces/{space['id']}/agents",
+        json={"name": "Scout", "brief": "hold the line", "mode": "goal", "goal": "hold the line"},
+    ).json()
+    assert spawned["ok"] is True
+    scout = spawned["agent"]
+    assert scout["mode"] == "goal"
+    assert scout["status"] == "goal"
+    assert scout["goal_text"] == "hold the line"
+    listed = client.http.get(f"/crew/spaces/{space['id']}/agents").json()
+    assert any(a["name"] == "Scout" and a["status"] == "goal" for a in listed)
+
+    client.http.post(
+        f"/crew/spaces/{space['id']}/messages",
+        json={"text": "throw away"},
+    )
+    # The scripted model is empty; wait until the space is idle so clear
+    # does not race a finishing run.
+    deadline = time.time() + 5
+    while client.crew.runtime._space_run.get(space["id"]):
+        if time.time() > deadline:
+            break
+        time.sleep(0.02)
+    cleared = client.http.post(f"/crew/spaces/{space['id']}/clear").json()
+    assert cleared["ok"] is True
+    msgs = client.http.get(f"/crew/spaces/{space['id']}/messages").json()
+    assert not any(m["role"] == "user" for m in msgs)
+    after = client.http.get(f"/crew/spaces/{space['id']}/agents").json()
+    keeper = next(a for a in after if a["name"] == "Scout")
+    assert keeper["mode"] == "goal"
+    assert keeper["goal_text"] == "hold the line"
+    assert keeper["status"] == "goal"
+
+    killed = client.http.post(
+        f"/crew/spaces/{space['id']}/agents/{scout['id']}/kill",
+        json={"reason": "operator killed"},
+    ).json()
+    assert killed["ok"] is True
+    assert killed["agent"]["status"] == "stopped"
+    assert "operator killed" in killed["agent"]["stop_reason"]
+    refuse = client.http.post(
+        f"/crew/spaces/{space['id']}/agents/{scout['id']}/accept",
+        json={"brief": "nope"},
+    )
+    assert refuse.status_code == 400
+    assert "DENIED" in refuse.json()["detail"]

--- a/tests/test_crew/test_store.py
+++ b/tests/test_crew/test_store.py
@@ -81,3 +81,36 @@ def test_confirm_lifecycle(tmp_path: Path) -> None:
     took = store.decide_confirm(wall["id"], approved=False, takeover=True)
     assert took is not None and took["status"] == "takeover"
     assert store.pending_confirms(space["id"]) == []
+
+
+def test_mode_and_goal_survive_chat_clear(tmp_path: Path) -> None:
+    store = CrewStore(tmp_path / "crew.db")
+    space = store.create_space("Life")
+    scout = store.upsert_agent(
+        space["id"], "Scout", mode="goal", goal_text="keep the brief"
+    )
+    store.add_message(space["id"], "user", "hello")
+    store.add_message(space["id"], "assistant", "hi")
+    store.set_agent_status(scout["id"], "active")
+    store.clear_messages(space["id"])
+    store.reset_life_after_clear(space["id"])
+    assert store.list_messages(space["id"]) == []
+    again = store.get_agent(scout["id"])
+    assert again is not None
+    assert again["mode"] == "goal"
+    assert again["goal_text"] == "keep the brief"
+    assert again["status"] == "goal"
+
+
+def test_kill_sets_stopped_reason_and_active_parks_idle(tmp_path: Path) -> None:
+    store = CrewStore(tmp_path / "crew.db")
+    space = store.create_space("Life")
+    worker = store.upsert_agent(space["id"], "Worker", mode="active")
+    store.set_agent_status(worker["id"], "active")
+    parked = store.set_agent_status(worker["id"], "idle")
+    assert parked is not None and parked["status"] == "idle"
+    dead = store.kill_agent(worker["id"], "operator killed")
+    assert dead is not None
+    assert dead["status"] == "stopped"
+    assert int(dead["alive"]) == 0
+    assert dead["stop_reason"] == "operator killed"


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Fixes #129
Parent: #116 (EPIC-CREW-01). Chrome already landed via #119 (`080e47eb`). This PR is CREW-LIFE only; it does not dual-write other Crew slices.

Rebased onto `origin/main` after #140 RUNTIME (`3ec6471`), #141 ROUTER (`9795186`), and #139 CMD (`faaafb90`). Conflict resolution kept LIFE plus the already-merged runtime/router/cmd surfaces. New head: `36f3f7dbe9a740e95b375d6c58c4cf229fe220e0`. Do not force-merge.

## What

Operator-visible teammate lifecycle on the existing Crew runtime (not a second orchestrator):

1. **Spawn / stop / kill** from HUD and Manager tools, with live status `active | idle | waiting | goal` (plus terminal `failed` / `stopped` with a reason).
2. **Smart-idle / wait / accept-task** parks the same `_teammate_run` task on the A2A mailbox. No hidden daemon loop. Run shutdown cancels parked waiters and persists idle/goal.
3. **Goal/active mode** is stored on the agent row in `CrewStore` (`agents.mode`, `agents.goal_text`). Chat clear drops the transcript and keeps those columns.
4. **Silent-dead refuse (R-0011):** killed/failed teammates return a visible `DENIED:` in the transcript and tool result.

## How modes are stored

SQLite `agents` table in `data/crew/crew.db` (via `CortexOS/crew/store.py`):

- `mode` TEXT: `active` (session default) or `goal`
- `goal_text` TEXT: assignment that survives `POST /crew/spaces/{id}/clear`
- `status` TEXT: `active|idle|waiting|goal` while live; `failed|stopped` when dead
- `alive` INTEGER + `stop_reason` TEXT: kill sets `alive=0`, `status=stopped`

HUD Memory (agent scope) reads those columns. Not localStorage, not a MemGPT store.

## Out of scope (honored)

- No CSS paste from guaca/rakazo (tiny original `.life-spawn` / `.agent-card` only)
- Did not touch :8020, Cortex#4/#41/#42/#43/#44
- Do not force-merge

`python3 -m pytest tests/test_crew -q` after rebase.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-403ef5b4-1bbd-4374-86d7-d729bb1ac3f8?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-403ef5b4-1bbd-4374-86d7-d729bb1ac3f8&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

