### PR TITLE
C7-05: L2 SQL without Gemini metadata, keep FROM, honor sku_count synonyms

### DIFF
--- a/CortexOS/dms/answer_engine.py
+++ b/CortexOS/dms/answer_engine.py
@@ -730,7 +730,10 @@ def route_to_metric(question: str) -> MetricPlan | None:
     # metrics.yaml sku_count synonyms, not only "how many skus"
     if (
         re.search(r"\bskus?\b", q)
-        and re.search(r"\b(how many|number of|count of|count)\b", q)
+        and (
+            re.search(r"\b(how many|number of|count of|count)\b", q)
+            or re.search(r"\bberapa\b.{0,24}\b(banyak|sku)", q)
+        )
         and not re.search(r"\b(category|per|by)\b", q)
     ):
         return _metric_plan("sku_count", {}, "distinct SKU count")

--- a/CortexOS/dms/answer_engine.py
+++ b/CortexOS/dms/answer_engine.py
@@ -727,7 +727,12 @@ def route_to_metric(question: str) -> MetricPlan | None:
     # scalars first — "how many X" must not fall through to a listing
     if re.search(r"\b(how many|number of|count of|count)\b", q) and "cold storage" in q:
         return _metric_plan("cold_storage_count", {}, "count of cold-storage locations")
-    if re.search(r"\bhow many\b", q) and re.search(r"\bskus?\b", q) and not re.search(r"\b(category|per|by)\b", q):
+    # metrics.yaml sku_count synonyms, not only "how many skus"
+    if (
+        re.search(r"\bskus?\b", q)
+        and re.search(r"\b(how many|number of|count of|count)\b", q)
+        and not re.search(r"\b(category|per|by)\b", q)
+    ):
         return _metric_plan("sku_count", {}, "distinct SKU count")
     # "how many delayed" / Malay "berapa ... delayed" must not return the listing.
     if (

--- a/CortexOS/dms/sql_guardrail.py
+++ b/CortexOS/dms/sql_guardrail.py
@@ -84,6 +84,10 @@ def validate_sql(sql: str, semantic: dict[str, Any]) -> GuardrailResult:
         violations.append("DDL_ATTEMPT")
         return GuardrailResult(False, violations, None)
 
+    if not any(True for _ in stmt.find_all(exp.Table)):
+        violations.append("MISSING_FROM")
+        return GuardrailResult(False, violations, None)
+
     for node in stmt.walk():
         if isinstance(node, FORBIDDEN):
             violations.append("DDL_ATTEMPT")

--- a/CortexOS/dms/sql_guardrail.py
+++ b/CortexOS/dms/sql_guardrail.py
@@ -84,7 +84,12 @@ def validate_sql(sql: str, semantic: dict[str, Any]) -> GuardrailResult:
         violations.append("DDL_ATTEMPT")
         return GuardrailResult(False, violations, None)
 
-    if not any(True for _ in stmt.find_all(exp.Table)):
+    # Column without a relation is the fenced-SELECT-list bug (`SELECT i.sku`).
+    # Session follow-ups emit `SELECT CAST(n AS DOUBLE) AS sum_…` with no FROM;
+    # that is a literal, not an unbound alias.
+    has_table = any(True for _ in stmt.find_all(exp.Table))
+    has_column = any(True for _ in stmt.find_all(exp.Column))
+    if has_column and not has_table:
         violations.append("MISSING_FROM")
         return GuardrailResult(False, violations, None)
 

--- a/bench/corpus/answering_baseline.json
+++ b/bench/corpus/answering_baseline.json
@@ -23,6 +23,7 @@
     "ms_cold_storage",
     "ms_delayed_count",
     "ms_exclude_beta",
+    "ms_sku_count",
     "ms_top5_revenue",
     "ns_expired_count",
     "ns_expired_list",

--- a/bench/heldout.py
+++ b/bench/heldout.py
@@ -524,6 +524,14 @@ def collect_dev_questions(root: Path | None = None) -> list[str]:
                     if isinstance(row, dict):
                         _add_dev_question(row.get("question"), seen, out)
 
+    personas = yaml.safe_load((base / "bench/live_personas.yaml").read_text(encoding="utf-8")) or {}
+    for persona in (personas.get("personas") or {}).values():
+        if not isinstance(persona, dict):
+            continue
+        for probe in persona.get("probes") or []:
+            if isinstance(probe, dict):
+                _add_dev_question(probe.get("raw_question"), seen, out)
+
     return out
 
 

--- a/bench/heldout.py
+++ b/bench/heldout.py
@@ -648,10 +648,13 @@ def replay_shadow(
     *,
     shadow_path: Path | str | None = None,
     limit: int | None = None,
+    offset: int = 0,
     ask: Callable[..., dict[str, Any]] | None = None,
 ) -> dict[str, Any]:
     """Call answer() with SHADOW on and L2 serve off. Restores env."""
     qs = list(questions if questions is not None else collect_dev_questions())
+    start = max(0, int(offset))
+    qs = qs[start:]
     if limit is not None:
         qs = qs[: max(0, int(limit))]
     target = _shadow_target(shadow_path)
@@ -818,10 +821,13 @@ def main() -> None:
     )
     parser.add_argument("--shadow-path", default=None, help="JSONL path for shadow replay/report")
     parser.add_argument("--limit", type=int, default=None, help="cap --shadow-replay questions")
+    parser.add_argument("--offset", type=int, default=0, help="skip first N questions on --shadow-replay")
     parser.add_argument("--json", default=None, help="write report JSON")
     args = parser.parse_args()
     if args.shadow_replay:
-        report = replay_shadow(shadow_path=args.shadow_path, limit=args.limit)
+        report = replay_shadow(
+            shadow_path=args.shadow_path, limit=args.limit, offset=args.offset
+        )
         print(json.dumps({
             "n_lines": report["n_lines"],
             "n_unique": report["n_unique"],

--- a/bench/heldout.py
+++ b/bench/heldout.py
@@ -432,11 +432,14 @@ def summarize(results: list[HeldoutResult]) -> dict[str, Any]:
 
 
 def _shadow_target(path: Path | str | None = None) -> Path:
-    if path is None:
-        from CortexOS.paths import data_path
+    if path is not None:
+        return Path(path)
+    env = (os.environ.get("DMS_L2_SHADOW_PATH") or "").strip()
+    if env:
+        return Path(env)
+    from CortexOS.paths import data_path
 
-        return data_path("engine", "l2_shadow.jsonl")
-    return Path(path)
+    return data_path("engine", "l2_shadow.jsonl")
 
 
 def shadow_line_count(path: Path | str | None = None) -> int:

--- a/docs/subagents_findings/2026-09-04_c7-05-gsh-and-leave-gate.md
+++ b/docs/subagents_findings/2026-09-04_c7-05-gsh-and-leave-gate.md
@@ -25,3 +25,9 @@ python -m bench.heldout --shadow-replay --limit 3 --shadow-path .tmp/l2_shadow_p
 ```
 
 Does not prove: G-sh >= 500 live lines, L2-on-miss serve, or p95 vs SHADOW-off.
+
+## After PR 126 squash (2026-09-04)
+
+`#126` merged the live scorer + leave-gate. It did **not** take metadata-off, `MISSING_FROM` / fenced-FROM extract, sku_count synonyms, or Malay `berapa`. Those live on `cursor/c7-05-l2-sql-main` vs current `main`.
+
+G-sh snapshot (local `.tmp/l2_shadow_gsh.jsonl`, gitignored): **237 unique / 96 `l2_sql`**. Histogram still includes pre-FROM-fix `NO_CANDIDATE` and leftover alias EXPLAIN rows. Continue `--offset 237`. Do not close Cortex `#104`.

--- a/docs/subagents_findings/2026-09-04_c7-05-gsh-and-leave-gate.md
+++ b/docs/subagents_findings/2026-09-04_c7-05-gsh-and-leave-gate.md
@@ -15,6 +15,7 @@ HIT. reuse: `docs/subagents_findings/2026-09-04_c7-05-engine-scorer.md`, `docs/s
 3. `and whose` / `and also have|appear` abstain BIRD stacks. `ignore SKU-X and also show the top 5` is ANS-01 and must stay L1.
 4. G-sh needs real `maybe_record_l2_shadow` lines plus L1-only-correct vs L2-only-correct. Dummy JSONL and all-refusal padding do not unlock C7-05 serve.
 5. `cutover` stays false. Do not set `DMS_L2_ENABLED` as the process default.
+6. Do not put OpenAI `metadata` on `/v1/chat/completions`. OpenVault `extra=allow` forwards it to Gemini, which 400s; Cortex then records `NO_CANDIDATE`.
 
 ## Verify
 

--- a/docs/subagents_findings/2026-09-04_c7-05-gsh-and-leave-gate.md
+++ b/docs/subagents_findings/2026-09-04_c7-05-gsh-and-leave-gate.md
@@ -30,4 +30,4 @@ Does not prove: G-sh >= 500 live lines, L2-on-miss serve, or p95 vs SHADOW-off.
 
 `#126` merged the live scorer + leave-gate. It did **not** take metadata-off, `MISSING_FROM` / fenced-FROM extract, sku_count synonyms, or Malay `berapa`. Those live on `cursor/c7-05-l2-sql-main` vs current `main`.
 
-G-sh snapshot (local `.tmp/l2_shadow_gsh.jsonl`, gitignored): **237 unique / 96 `l2_sql`**. Histogram still includes pre-FROM-fix `NO_CANDIDATE` and leftover alias EXPLAIN rows. Continue `--offset 237`. Do not close Cortex `#104`.
+G-sh snapshot (local `.tmp/l2_shadow_gsh.jsonl`, gitignored): **512 lines / 500 unique / 197 `l2_sql`**. Gate `shadow_lines >= 500` is the line count. `l1_only_correct` / `l2_only_correct` stay 0 until `summarize_shadow(..., items=heldout)`. Do not close Cortex `#104`. `MISSING_FROM` must not refuse session literal `SELECT CAST(n AS DOUBLE) AS sum_…`.

--- a/packs/dms/generative/sql_generator.py
+++ b/packs/dms/generative/sql_generator.py
@@ -95,9 +95,10 @@ def _freeroute_complete(prompt: str, *, identity: str = "dms:l2-sql") -> str | N
         ],
         "temperature": 0.0,
         "max_tokens": 600,
-        "metadata": {"identity": identity, "tier": "sql_generation"},
     }
-    # Prefer OpenVault proxy; fall back to direct path variants.
+    # Do not send OpenAI ``metadata``: OpenVault extra=allow forwards it to
+    # Google AI Studio, which 400s (non_retryable) and Cortex sees NO_CANDIDATE.
+    _ = identity
     data = post_json("/v1/chat/completions", body, timeout=45.0, base=openvault_base_url())
     if not data:
         return None

--- a/packs/dms/generative/sql_generator.py
+++ b/packs/dms/generative/sql_generator.py
@@ -17,6 +17,7 @@ from packs.dms.generative.schema_retrieval import retrieve, schema_prompt_block
 
 _SQL_FENCE = re.compile(r"```(?:sql)?\s*(.*?)```", re.I | re.S)
 _SELECT = re.compile(r"(SELECT\b.+)", re.I | re.S)
+_FROM = re.compile(r"\bfrom\b", re.I)
 
 
 def is_configured() -> bool:
@@ -57,21 +58,37 @@ def _leave_machine_allowed() -> tuple[bool, str]:
         return False, f"gate error: {exc}"[:240]
 
 
-def _extract_sql(text: str) -> str | None:
-    if not text:
-        return None
-    m = _SQL_FENCE.search(text)
-    body = (m.group(1) if m else text).strip()
+def _one_select(body: str) -> str | None:
     m2 = _SELECT.search(body)
     if not m2:
         return None
     sql = m2.group(1).strip().rstrip(";")
-    # Single statement only
     if ";" in sql:
         sql = sql.split(";", 1)[0].strip()
     if not sql.upper().startswith("SELECT"):
         return None
     return sql
+
+
+def _extract_sql(text: str) -> str | None:
+    """Take one SELECT. Prefer a statement that still has FROM.
+
+    Models often fence only the SELECT list and leave ``FROM t i`` outside
+    the fence. That parsed as ``SELECT i.sku LIMIT 1000`` and EXPLAIN died
+    on alias ``i``. No FROM → None (caller retries / abstains).
+    """
+    if not text:
+        return None
+    blobs: list[str] = []
+    for m in _SQL_FENCE.finditer(text):
+        blobs.append(m.group(1).strip())
+    blobs.append(_SQL_FENCE.sub(" ", text).strip())
+    blobs.append(text.strip())
+    for body in blobs:
+        sql = _one_select(body)
+        if sql and _FROM.search(sql):
+            return sql
+    return None
 
 
 def _freeroute_complete(prompt: str, *, identity: str = "dms:l2-sql") -> str | None:

--- a/tests/dms/test_c7_full_generation.py
+++ b/tests/dms/test_c7_full_generation.py
@@ -118,6 +118,19 @@ def test_guardrail_rejects_select_without_from():
     assert "MISSING_FROM" in out.violations
 
 
+def test_guardrail_allows_literal_select_without_from():
+    """ANS-02 session follow-up SQL is a CAST literal, not a warehouse FROM."""
+    from CortexOS.dms.sql_guardrail import validate_sql
+
+    semantic = {"tables": {"inventory": {"columns": ["sku"]}}}
+    out = validate_sql(
+        "SELECT CAST(12.5 AS DOUBLE) AS sum_sales_value_myr",
+        semantic,
+    )
+    assert out.passed is True, out.violations
+    assert out.safe_sql
+
+
 def test_freeroute_body_omits_metadata_google_rejects(monkeypatch):
     """OV extra=allow forwards metadata to Gemini, which 400s the L2 call."""
     seen: list[dict] = []

--- a/tests/dms/test_c7_full_generation.py
+++ b/tests/dms/test_c7_full_generation.py
@@ -93,6 +93,38 @@ def test_leave_machine_asks_ov_leave_not_llm(monkeypatch):
     assert seen[0]["destination"] == "freeroute"
 
 
+def test_freeroute_body_omits_metadata_google_rejects(monkeypatch):
+    """OV extra=allow forwards metadata to Gemini, which 400s the L2 call."""
+    seen: list[dict] = []
+
+    def fake_post(path, body, **kwargs):
+        del path, kwargs
+        seen.append(dict(body))
+        return {
+            "choices": [{
+                "message": {
+                    "content": "SELECT COUNT(DISTINCT sku) AS sku_count FROM inventory",
+                }
+            }]
+        }
+
+    monkeypatch.setattr(sql_generator, "is_configured", lambda: True)
+    monkeypatch.setattr(sql_generator, "_leave_machine_allowed", lambda: (True, "ok:leave"))
+    monkeypatch.setattr(
+        "CortexOS.integrations.openvault_client.post_json",
+        fake_post,
+    )
+    out = sql_generator.generate_candidates(
+        "how many skus",
+        {"tables": {"inventory": {"columns": ["sku"]}}},
+    )
+    assert seen, "FreeRoute POST was not attempted"
+    assert "metadata" not in seen[0]
+    assert out
+    assert "inventory" in out[0].lower()
+    assert "sku" in out[0].lower()
+
+
 def test_l2_path_abstains_without_freeroute(monkeypatch):
     from CortexOS.dms.answer_engine import answer
 

--- a/tests/dms/test_c7_full_generation.py
+++ b/tests/dms/test_c7_full_generation.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import re
 from pathlib import Path
 
 import pytest
@@ -91,6 +92,30 @@ def test_leave_machine_asks_ov_leave_not_llm(monkeypatch):
     assert len(seen) == 1
     assert seen[0]["action"] == "leave"
     assert seen[0]["destination"] == "freeroute"
+
+
+def test_extract_sql_keeps_from_outside_the_fence():
+    text = (
+        "```sql\nSELECT i.sku, i.sku_name\n```\n"
+        "FROM inventory i WHERE i.quantity_kg > 0"
+    )
+    sql = sql_generator._extract_sql(text)
+    assert sql is not None
+    assert re.search(r"\bfrom\b", sql, re.I)
+    assert "inventory" in sql.lower()
+
+
+def test_extract_sql_rejects_select_list_with_no_from():
+    assert sql_generator._extract_sql("SELECT i.sku, i.sku_name") is None
+
+
+def test_guardrail_rejects_select_without_from():
+    from CortexOS.dms.sql_guardrail import validate_sql
+
+    semantic = {"tables": {"inventory": {"columns": ["sku", "sku_name"]}}}
+    out = validate_sql("SELECT i.sku, i.sku_name", semantic)
+    assert out.passed is False
+    assert "MISSING_FROM" in out.violations
 
 
 def test_freeroute_body_omits_metadata_google_rejects(monkeypatch):

--- a/tests/dms/test_c7_heldout.py
+++ b/tests/dms/test_c7_heldout.py
@@ -318,6 +318,15 @@ def test_collect_dev_questions_are_operator_phrases():
     lowered = {q.lower() for q in qs}
     assert "sku_count" not in lowered
     assert any("how many" in q.lower() for q in qs)
+    assert any("berapa banyak sku" in q.lower() for q in qs)
+
+
+def test_malay_berapa_banyak_sku_routes_to_sku_count():
+    from CortexOS.dms.answer_engine import route_to_metric
+
+    plan = route_to_metric("boss, berapa banyak SKU kita ada sekarang?")
+    assert plan is not None
+    assert plan.metric_id == "sku_count"
 
 
 def test_replay_shadow_restores_l2_env(tmp_path: Path, monkeypatch):

--- a/tests/dms/test_c7_heldout.py
+++ b/tests/dms/test_c7_heldout.py
@@ -310,6 +310,18 @@ def test_summarize_shadow_reports_l1_only_vs_l2_only(tmp_path: Path):
     assert out["l2_only_correct"] == 1
 
 
+def test_shadow_target_honors_env_path(tmp_path: Path, monkeypatch):
+    from bench.heldout import _shadow_target, summarize_shadow
+
+    dest = tmp_path / "gsh.jsonl"
+    dest.write_text('{"question": "how many skus in inventory now", "l2_sql": "SELECT 1"}\n', encoding="utf-8")
+    monkeypatch.setenv("DMS_L2_SHADOW_PATH", str(dest))
+    assert _shadow_target() == dest
+    out = summarize_shadow()
+    assert out["n_lines"] == 1
+    assert out["n_l2_sql"] == 1
+
+
 def test_collect_dev_questions_are_operator_phrases():
     from bench.heldout import collect_dev_questions
 

--- a/tests/dms/test_c7_heldout.py
+++ b/tests/dms/test_c7_heldout.py
@@ -326,6 +326,8 @@ def test_replay_shadow_restores_l2_env(tmp_path: Path, monkeypatch):
     from bench.heldout import replay_shadow
 
     monkeypatch.setenv("DMS_L2_ENABLED", "0")
+    monkeypatch.delenv("DMS_L2_SHADOW", raising=False)
+    monkeypatch.delenv("DMS_L2_SHADOW_PATH", raising=False)
     path = tmp_path / "shadow.jsonl"
     seen: list[str] = []
 
@@ -351,3 +353,8 @@ def test_replay_shadow_restores_l2_env(tmp_path: Path, monkeypatch):
     assert os.environ.get("DMS_L2_SHADOW") is None
     assert out["n_lines"] == 1
     assert out["replayed"] == 1
+
+    skipped = replay_shadow(
+        ["first", "second"], shadow_path=path, ask=ask, offset=1, limit=1
+    )
+    assert skipped["replayed"] == 1

--- a/tests/dms/test_certified_synonyms.py
+++ b/tests/dms/test_certified_synonyms.py
@@ -45,6 +45,33 @@ def test_certified_synonym_hits_l0():
     assert int(rows[0]["sku_count"]) > 0
 
 
+@pytest.mark.parametrize(
+    "question",
+    [
+        "number of skus",
+        "sku count",
+        "count skus",
+    ],
+)
+def test_sku_count_metric_synonyms_hit_l1(question: str):
+    """metrics.yaml sku_count synonyms must answer, not only 'how many skus'."""
+    from CortexOS.dms.answer_engine import answer, route_to_metric
+
+    plan = route_to_metric(question)
+    assert plan is not None, question
+    assert plan.metric_id == "sku_count"
+    r = answer(question)
+    assert r["layer"] == "governed_metric"
+    rows = r.get("rows") or []
+    assert rows, f"{question!r} returned no rows: {r.get('answer')!r}"
+    text = r.get("answer") or ""
+    assert text.strip()
+    assert any(ch.isdigit() for ch in text)
+    n = int(rows[0]["sku_count"])
+    assert n > 0
+    assert str(n) in text
+
+
 def test_certified_sales_synonym_hits_l0():
     cq = match_certified("Top 5 SKUs by revenue")
     assert cq is not None


### PR DESCRIPTION
## Summary

PR #126 squashed the C7-05 scorer + leave-machine gate onto `main`, but dropped the L2 SQL generation fixes that were still on the local worktree.

- Stop sending OpenAI `metadata` on `/v1/chat/completions` (OpenVault forwards it; Gemini 400s; Cortex records `NO_CANDIDATE`).
- Keep `FROM` on fenced L2 SQL; guardrail `MISSING_FROM` so EXPLAIN is not `SELECT i.sku` with alias `i` unbound.
- Honor `sku_count` synonyms (`number of skus` / `sku count` / Malay `berapa banyak SKU`), not only `\bhow many\b`.
- Shadow replay `--offset`; collect live persona probes into the unique-question pool.

`cutover` stays false. Do not set `DMS_L2_ENABLED` as the process default. Do not close Cortex #104 until G-abs / G-err / G-env / G-man / G-sh pass on a real held-out report.

## Test plan

- [x] `pytest tests/dms/test_c7_full_generation.py` extract/FROM/metadata/leave (targeted) + sku_count + Malay route — 10 passed
- [ ] CI lint-type-test / protected-paths / rls-proof
- [ ] Continue G-sh `--shadow-replay --offset 237` toward 500 unique lines
- [ ] Re-run `--engine` held-out (L2 off) for G-abs / G-err / G-env after merge
