### PR TITLE
L1: honor metrics.yaml synonym phrases after the regex cascade

### DIFF
--- a/CortexOS/dms/answer_engine.py
+++ b/CortexOS/dms/answer_engine.py
@@ -708,11 +708,68 @@ def _param_is_required(spec: dict[str, Any]) -> bool:
     return bool(spec.get("required") or (spec.get("kind") == "value" and not spec.get("optional")))
 
 
+#: Leftover tokens allowed around a yaml synonym. Content leftover means the
+#: phrase is nested in a different question ("pending … high risk suppliers"
+#: is not the bare risk listing).
+_SYNONYM_FILLER = frozenset(
+    {
+        "a",
+        "an",
+        "the",
+        "me",
+        "my",
+        "our",
+        "your",
+        "please",
+        "show",
+        "tell",
+        "what",
+        "is",
+        "are",
+        "of",
+        "for",
+        "in",
+        "on",
+        "to",
+        "from",
+        "with",
+        "and",
+        "or",
+        "do",
+        "we",
+        "i",
+        "you",
+        "which",
+        "list",
+        "get",
+        "give",
+        "us",
+        "all",
+        "any",
+        "some",
+        "just",
+        "now",
+        "today",
+        "currently",
+        "current",
+        "about",
+        "at",
+    }
+)
+
+
+def _synonym_leftover_is_filler(q: str, phrase: str) -> bool:
+    rest = q.replace(phrase, " ", 1)
+    tokens = [t for t in re.split(r"\W+", rest) if t]
+    return all(t in _SYNONYM_FILLER for t in tokens)
+
+
 def _plan_from_declared_synonyms(q: str, q_raw: str) -> MetricPlan | None:
     """Longest metrics.yaml synonym that is a contiguous phrase in ``q``.
 
     The regex cascade still wins. Skip one-word / short fragments and metrics
-    that need a required slot the synonym does not carry.
+    that need a required slot the synonym does not carry. A nested phrase
+    with leftover content words is a different question, not a match.
     """
     from packs.dms.semantic.loader import load_all
 
@@ -725,6 +782,8 @@ def _plan_from_declared_synonyms(q: str, q_raw: str) -> MetricPlan | None:
             if " " not in phrase or len(phrase) < 16:
                 continue
             if phrase not in q:
+                continue
+            if not _synonym_leftover_is_filler(q, phrase):
                 continue
             n = len(phrase)
             if best is None or n > best[0]:
@@ -762,6 +821,14 @@ def route_to_metric(question: str) -> MetricPlan | None:
     # scalars first — "how many X" must not fall through to a listing
     if re.search(r"\b(how many|number of|count of|count)\b", q) and "cold storage" in q:
         return _metric_plan("cold_storage_count", {}, "count of cold-storage locations")
+    # grouped SKU count before the warehouse-wide scalar
+    if (
+        re.search(r"\b(how many|number of|count of|count)\b", q)
+        and re.search(r"\b(sku|skus|product|products|items?)\b", q)
+        and re.search(r"\b(per|by|each)\b", q)
+        and "category" in q
+    ):
+        return _metric_plan("sku_count_by_category", {}, "SKU count grouped by category")
     # metrics.yaml sku_count synonyms, not only "how many skus"
     if (
         re.search(r"\bskus?\b", q)
@@ -818,6 +885,17 @@ def route_to_metric(question: str) -> MetricPlan | None:
     ):
         return _metric_plan("revenue_total", {}, "total outbound revenue")
 
+    # pending/in-transit from high-risk suppliers — before a bare risk listing
+    if (
+        re.search(r"\b(high[- ]?risk|risky)\b", q)
+        and re.search(r"\b(pending|in transit|in_transit|deliver(?:y|ies)?)\b", q)
+        and re.search(r"\b(suppliers?|shipments?)\b", q)
+    ):
+        return _metric_plan(
+            "high_risk_pending",
+            {"threshold": _threshold(q_raw)},
+            "high-risk suppliers with pending/in-transit shipments",
+        )
     # supplier risk threshold
     if re.search(r"\brisk\b", q) and re.search(r"\b(above|over|below|under|greater|less|more than|exceed|>|<)\b", q):
         return _metric_plan("suppliers_by_risk",

--- a/CortexOS/dms/answer_engine.py
+++ b/CortexOS/dms/answer_engine.py
@@ -422,6 +422,7 @@ _SUBJECT_MEASURES = frozenset({
 _TABLE_SUBJECT_ALIASES: dict[str, tuple[str, ...]] = {
     "inventory": (
         "sku", "skus", "item", "items", "product", "products",
+        "seller", "sellers",
         "inventory", "stock", "category", "categories",
         "chemical", "chemicals",
     ),
@@ -548,7 +549,7 @@ def undefined_subject(question: str) -> str | None:
     return subject
 
 
-_SKU_SUBJECTS = frozenset({"sku", "skus", "item", "items", "product", "products"})
+_SKU_SUBJECTS = frozenset({"sku", "skus", "item", "items", "product", "products", "seller", "sellers"})
 
 
 def _subject_allows_sales_rank(q: str) -> bool:
@@ -563,7 +564,7 @@ def _wants_sales_rank(q: str, q_raw: str) -> bool:
     if not _subject_allows_sales_rank(q):
         return False
     if re.search(r"\b(top|best|highest|most)\b", q) and re.search(
-        r"\b(sell|sold|revenue|sales|sku|skus|revnue)\b", q
+        r"\b(sell(?:ing|ers)?|sold|revenue|sales|sku|skus|revnue)\b", q
     ):
         return True
     if re.search(r"\btop\s+\d+\b", q):
@@ -703,6 +704,40 @@ def _shape_refusal(question: str) -> str | None:
     )
 
 
+def _param_is_required(spec: dict[str, Any]) -> bool:
+    return bool(spec.get("required") or (spec.get("kind") == "value" and not spec.get("optional")))
+
+
+def _plan_from_declared_synonyms(q: str, q_raw: str) -> MetricPlan | None:
+    """Longest metrics.yaml synonym that is a contiguous phrase in ``q``.
+
+    The regex cascade still wins. Skip one-word / short fragments and metrics
+    that need a required slot the synonym does not carry.
+    """
+    from packs.dms.semantic.loader import load_all
+
+    best: tuple[int, str] | None = None
+    for metric in load_all().metrics.values():
+        if any(_param_is_required(spec) for spec in (metric.params or {}).values()):
+            continue
+        for syn in metric.synonyms or []:
+            phrase = " ".join(str(syn).lower().split())
+            if " " not in phrase or len(phrase) < 16:
+                continue
+            if phrase not in q:
+                continue
+            n = len(phrase)
+            if best is None or n > best[0]:
+                best = (n, metric.id)
+    if best is None:
+        return None
+    metric_id = best[1]
+    slots: dict[str, Any] = {}
+    if metric_id in ("sales_by_value", "sales_by_volume"):
+        slots = _sales_rank_slots(q_raw)
+    return _metric_plan(metric_id, slots, f"declared synonym → {metric_id}")
+
+
 # ── L1 metric router (ordered; specific rules before generic) ────────────────
 def route_to_metric(question: str) -> MetricPlan | None:
     """Pick a governed metric + its slots.
@@ -733,6 +768,7 @@ def route_to_metric(question: str) -> MetricPlan | None:
         and (
             re.search(r"\b(how many|number of|count of|count)\b", q)
             or re.search(r"\bberapa\b.{0,24}\b(banyak|sku)", q)
+            or re.search(r"\bdistinct skus?\b", q)
         )
         and not re.search(r"\b(category|per|by)\b", q)
     ):
@@ -750,7 +786,8 @@ def route_to_metric(question: str) -> MetricPlan | None:
     if "delayed" in q and re.search(r"\bcarrier", q):
         return _metric_plan("count_by_carrier", {"status": "DELAYED"}, "delayed shipments grouped by carrier")
     if re.search(r"\b(per|by|each)\b", q) and re.search(r"\b(warehouse|destination|location)\b", q) \
-            and ("delayed" in q or "incoming" in q or "shipment" in q):
+            and ("delayed" in q or "incoming" in q or "shipment" in q) \
+            and not re.search(r"\b(cost|spend|price)\b", q):
         status = "DELAYED" if "delayed" in q else "IN_TRANSIT"
         return _metric_plan("count_by_destination", {"status": status}, f"{status} shipments grouped by destination")
 
@@ -758,6 +795,15 @@ def route_to_metric(question: str) -> MetricPlan | None:
     if re.search(r"\b(revenue|sales|sold)\b", q) and _calendar_month(q) == "last":
         return _metric_plan("revenue_last_month", {}, "revenue in the previous calendar month")
     if re.search(r"\b(revenue|sales|sold)\b", q) and re.search(r"\b(last|past|within|previous)\b.*\bday", q):
+        return _metric_plan("revenue_windowed", {"days": _days(q_raw, 30)}, "revenue over a rolling window")
+    # metrics.yaml revenue_windowed synonyms ("recent revenue", "revenue last")
+    if (
+        re.search(r"\b(revenue|sales|sold)\b", q)
+        and re.search(r"\b(recent|last|past|within|previous)\b", q)
+        and _calendar_month(q) is None
+        and _RANKING.search(_DISCOURSE_LEADIN.sub("", q)) is None
+        and not re.search(r"\b(top|best|highest|most|sku|skus|rank|per|by|each)\b", q)
+    ):
         return _metric_plan("revenue_windowed", {"days": _days(q_raw, 30)}, "revenue over a rolling window")
     # G6 — bare total revenue (no month/window); must not fall through to abstain.
     # A ranking that happens to say "total revenue" as its sort key is not this.
@@ -849,7 +895,7 @@ def route_to_metric(question: str) -> MetricPlan | None:
     if re.search(r"\b(sales|revenue)\b", q) and _calendar_month(q) == "last":
         return _metric_plan("revenue_last_month", {}, "revenue in the previous calendar month")
 
-    return None
+    return _plan_from_declared_synonyms(q, q_raw)
 
 
 # ── truncation-honest total ──────────────────────────────────────────────────

--- a/docs/subagents_findings/2026-09-04_c7-l1-yaml-synonyms.md
+++ b/docs/subagents_findings/2026-09-04_c7-l1-yaml-synonyms.md
@@ -2,7 +2,7 @@
 
 - Date: 2026-09-04
 - Keywords: metrics.yaml, synonyms, route_to_metric, sellers, cost_by_destination, C7-05, G-lat
-- Main idea: After the regex cascade, L1 takes the longest `metrics.yaml` synonym (space, >=16 chars, no required slot). `selling`/`sellers` count as sales-rank. `sellers` is an inventory alias so `best sellers` does not abstain as an unknown subject. Shipment *cost* by destination is not a shipment *count*.
+- Main idea: After the regex cascade, L1 takes the longest `metrics.yaml` synonym (space, >=16 chars, leftover filler only, no required slot). Nested `high risk suppliers` is not the pending-shipment ask. Grouped SKU count beats the warehouse-wide scalar. `selling`/`sellers` count as sales-rank.
 
 ## PREFLIGHT
 
@@ -11,7 +11,7 @@ HIT. reuse: `docs/subagents_findings/2026-09-04_c7-design-and-shadow-mode.md`. s
 ## Golden rules
 
 1. Regex cascade still wins. Synonym fallback is last, not C7-06 retirement of `route_to_metric`.
-2. Do not treat one-word yaml fragments (`reorder`, `by carrier`) as a metric id.
+2. Do not treat one-word yaml fragments (`reorder`, `by carrier`) as a metric id. Nested leftover content words (`pending … high risk suppliers`) are a different question.
 3. G-lat (2026-09-04, 28 held-out): SHADOW-off p95 ~68ms. SHADOW-on extra is not a serve gate (~8s p95 on an 8-item L2 sample).
 4. Do not set `DMS_L2_ENABLED` as the process default. Cortex `#104` stays open until SHADOW-off p95 is accepted on a merged tree and L2-on-miss is an explicit serve flip.
 

--- a/docs/subagents_findings/2026-09-04_c7-l1-yaml-synonyms.md
+++ b/docs/subagents_findings/2026-09-04_c7-l1-yaml-synonyms.md
@@ -1,0 +1,24 @@
+# L1 honors metrics.yaml synonym phrases
+
+- Date: 2026-09-04
+- Keywords: metrics.yaml, synonyms, route_to_metric, sellers, cost_by_destination, C7-05, G-lat
+- Main idea: After the regex cascade, L1 takes the longest `metrics.yaml` synonym (space, >=16 chars, no required slot). `selling`/`sellers` count as sales-rank. `sellers` is an inventory alias so `best sellers` does not abstain as an unknown subject. Shipment *cost* by destination is not a shipment *count*.
+
+## PREFLIGHT
+
+HIT. reuse: `docs/subagents_findings/2026-09-04_c7-design-and-shadow-mode.md`. spawn: skip.
+
+## Golden rules
+
+1. Regex cascade still wins. Synonym fallback is last, not C7-06 retirement of `route_to_metric`.
+2. Do not treat one-word yaml fragments (`reorder`, `by carrier`) as a metric id.
+3. G-lat (2026-09-04, 28 held-out): SHADOW-off p95 ~68ms. SHADOW-on extra is not a serve gate (~8s p95 on an 8-item L2 sample).
+4. Do not set `DMS_L2_ENABLED` as the process default. Cortex `#104` stays open until SHADOW-off p95 is accepted on a merged tree and L2-on-miss is an explicit serve flip.
+
+## Verify
+
+```
+D:\Cortex\.venv\Scripts\python.exe -m pytest tests/dms/test_certified_synonyms.py tests/dms/test_ans02_aggregate_over_ranking.py -q
+```
+
+Does not prove: every yaml fragment (62 still include short/incomplete phrases), L2 serve, or live `POST /v1/chat/ask`.

--- a/docs/subagents_findings/INDEX.md
+++ b/docs/subagents_findings/INDEX.md
@@ -2,6 +2,7 @@
 
 | Date | Topic | Keywords | Main idea | Path |
 |------|-------|----------|-----------|------|
+| 2026-09-04 | c7-l1-yaml-synonyms | metrics.yaml, synonyms, sellers, cost_by_destination, G-lat | Longest declared synonym is L1 fallback after the regex cascade. `best sellers` is SKUs. Cost-by-destination is not a count. | `2026-09-04_c7-l1-yaml-synonyms.md` |
 | 2026-09-04 | c7-05-gsh-and-leave-gate | C7-05, G-sh, DMS_L2_SHADOW, leave, GateCheckBody, ANS-01 | OV gate action is `leave` not `llm`. Shadow report compares L1-only vs L2-only. `and also show` stays L1. | `2026-09-04_c7-05-gsh-and-leave-gate.md` |
 | 2026-09-04 | c7-05-engine-scorer | C7-05, held-out, score_engine, G-abs, G-err, G-env, DMS_L2_ENABLED | Live engine scorer on frozen items; L2 env is process-local; cutover stays false until G-man/G-sh too. | `2026-09-04_c7-05-engine-scorer.md` |
 | 2026-09-04 | c7-03-plausibility | C7-03, plausibility, empty-success, implausible_shape, retrieval miss, L2_VALIDATED | After L2 execute, `l2_plausibility.assess_plausibility` abstains (badge=abstain, empty rows) on empty-success, scalar-vs-listing, retrieval-miss, leftover literals, or score below 0.55. Does not rewrite SQL or call the enforcer. | `2026-09-04_c7-03-plausibility.md` |

--- a/tests/dms/test_certified_synonyms.py
+++ b/tests/dms/test_certified_synonyms.py
@@ -80,8 +80,11 @@ def test_sku_count_metric_synonyms_hit_l1(question: str):
         ("best sellers", "sales_by_value"),
         ("stock value by category", "stock_value_by_category"),
         ("sku count by category", "sku_count_by_category"),
+        ("how many SKUs per category", "sku_count_by_category"),
+        ("number of products in each category", "sku_count_by_category"),
         ("recent revenue", "revenue_windowed"),
         ("high risk suppliers", "suppliers_by_risk"),
+        ("pending deliveries from high risk vendors", "high_risk_pending"),
         ("shipment cost by destination", "cost_by_destination"),
     ],
 )
@@ -97,6 +100,45 @@ def test_declared_yaml_synonyms_hit_stated_metric(question: str, metric_id: str)
     assert r.get("rows"), r.get("answer")
     text = r.get("answer") or ""
     assert text.strip()
+
+
+def test_pending_high_risk_is_not_a_bare_risk_listing():
+    """Nested 'high risk suppliers' must not steal the pending-shipment metric."""
+    from CortexOS.dms.answer_engine import answer, route_to_metric
+
+    q = "pending deliveries from high risk vendors"
+    plan = route_to_metric(q)
+    assert plan is not None
+    assert plan.metric_id == "high_risk_pending"
+    r = answer(q)
+    assert r["badge"] != "abstain", r.get("answer")
+    rows = r.get("rows") or []
+    assert rows, r.get("answer")
+    text = r.get("answer") or ""
+    assert text.strip()
+    assert "supplier_name" in rows[0]
+    assert "shipment_id" in rows[0]
+    assert str(rows[0]["supplier_name"]) in text
+    assert str(rows[0]["shipment_id"]) in text
+
+
+def test_sku_count_per_category_is_grouped_not_scalar():
+    from CortexOS.dms.answer_engine import answer, route_to_metric
+
+    q = "how many SKUs per category"
+    plan = route_to_metric(q)
+    assert plan is not None
+    assert plan.metric_id == "sku_count_by_category"
+    r = answer(q)
+    assert r["badge"] != "abstain", r.get("answer")
+    rows = r.get("rows") or []
+    assert rows, r.get("answer")
+    text = r.get("answer") or ""
+    assert text.strip()
+    assert "category" in rows[0]
+    assert "sku_count" in rows[0]
+    assert str(rows[0]["category"]) in text
+    assert str(rows[0]["sku_count"]) in text.replace(",", "")
 
 
 def test_certified_sales_synonym_hits_l0():

--- a/tests/dms/test_certified_synonyms.py
+++ b/tests/dms/test_certified_synonyms.py
@@ -72,6 +72,33 @@ def test_sku_count_metric_synonyms_hit_l1(question: str):
     assert str(n) in text
 
 
+@pytest.mark.parametrize(
+    "question,metric_id",
+    [
+        ("distinct skus", "sku_count"),
+        ("top selling", "sales_by_value"),
+        ("best sellers", "sales_by_value"),
+        ("stock value by category", "stock_value_by_category"),
+        ("sku count by category", "sku_count_by_category"),
+        ("recent revenue", "revenue_windowed"),
+        ("high risk suppliers", "suppliers_by_risk"),
+        ("shipment cost by destination", "cost_by_destination"),
+    ],
+)
+def test_declared_yaml_synonyms_hit_stated_metric(question: str, metric_id: str):
+    """metrics.yaml phrases must select that metric, not an adjacent one."""
+    from CortexOS.dms.answer_engine import answer, route_to_metric
+
+    plan = route_to_metric(question)
+    assert plan is not None, question
+    assert plan.metric_id == metric_id, (question, plan.metric_id)
+    r = answer(question)
+    assert r["badge"] != "abstain", r.get("answer")
+    assert r.get("rows"), r.get("answer")
+    text = r.get("answer") or ""
+    assert text.strip()
+
+
 def test_certified_sales_synonym_hits_l0():
     cq = match_certified("Top 5 SKUs by revenue")
     assert cq is not None


### PR DESCRIPTION
## Summary

PR #143 landed L2 SQL generation fixes. This follow-up makes L1 actually use `metrics.yaml` phrases the regex cascade missed.

- Longest declared synonym (multi-word, >=16 chars, no required slot) is the fallback after existing rules. Not C7-06 retirement of `route_to_metric`.
- `selling` / `sellers` count as a sales rank. `sellers` aliases inventory so `best sellers` is not an unknown subject.
- Shipment *cost* by destination is not a shipment *count*.

`cutover` stays false. Do not set `DMS_L2_ENABLED` as the process default. Cortex #104 stays open.

## Test plan

- [x] `pytest tests/dms/test_certified_synonyms.py tests/dms/test_ans02_aggregate_over_ranking.py` — 42 passed
- [x] DMS `tests/test_ask_mapping.py` — 14 passed (customer envelope mapping, no live `:8090`)
- [ ] CI lint-type-test / rls-proof / secrets-scan
