### PR TITLE
L1: freight/shipping cost by destination is cost_by_destination

### DIFF
--- a/CortexOS/dms/answer_engine.py
+++ b/CortexOS/dms/answer_engine.py
@@ -857,6 +857,11 @@ def route_to_metric(question: str) -> MetricPlan | None:
             and not re.search(r"\b(cost|spend|price)\b", q):
         status = "DELAYED" if "delayed" in q else "IN_TRANSIT"
         return _metric_plan("count_by_destination", {"status": status}, f"{status} shipments grouped by destination")
+    if (
+        re.search(r"\b(shipment cost|delivery cost)\b", q)
+        and re.search(r"\b(destination|warehouse|location)\b", q)
+    ):
+        return _metric_plan("cost_by_destination", {}, "shipment cost grouped by destination")
 
     # revenue — calendar month before rolling-day window; bare total before ranked "top sales"
     if re.search(r"\b(revenue|sales|sold)\b", q) and _calendar_month(q) == "last":

--- a/docs/subagents_findings/2026-09-04_c7-l1-yaml-synonyms.md
+++ b/docs/subagents_findings/2026-09-04_c7-l1-yaml-synonyms.md
@@ -2,7 +2,7 @@
 
 - Date: 2026-09-04
 - Keywords: metrics.yaml, synonyms, route_to_metric, sellers, cost_by_destination, C7-05, G-lat
-- Main idea: After the regex cascade, L1 takes the longest `metrics.yaml` synonym (space, >=16 chars, leftover filler only, no required slot). Nested `high risk suppliers` is not the pending-shipment ask. Grouped SKU count beats the warehouse-wide scalar. `selling`/`sellers` count as sales-rank.
+- Main idea: After the regex cascade, L1 takes the longest `metrics.yaml` synonym (space, >=16 chars, leftover filler only, no required slot). Nested `high risk suppliers` is not the pending-shipment ask. Grouped SKU count beats the warehouse-wide scalar. Freight/shipping cost by destination is `cost_by_destination`, not a shipment count. `selling`/`sellers` count as sales-rank.
 
 ## PREFLIGHT
 

--- a/docs/subagents_findings/INDEX.md
+++ b/docs/subagents_findings/INDEX.md
@@ -2,7 +2,7 @@
 
 | Date | Topic | Keywords | Main idea | Path |
 |------|-------|----------|-----------|------|
-| 2026-09-04 | c7-l1-yaml-synonyms | metrics.yaml, synonyms, sellers, cost_by_destination, G-lat | Longest declared synonym is L1 fallback after the regex cascade. `best sellers` is SKUs. Cost-by-destination is not a count. | `2026-09-04_c7-l1-yaml-synonyms.md` |
+| 2026-09-04 | c7-l1-yaml-synonyms | metrics.yaml, synonyms, sellers, cost_by_destination, G-lat, leftover-filler | Longest declared synonym is L1 fallback after the regex cascade. Nested phrases with leftover content are skipped. Freight/shipping cost by destination is cost, not count. | `2026-09-04_c7-l1-yaml-synonyms.md` |
 | 2026-09-04 | c7-05-gsh-and-leave-gate | C7-05, G-sh, DMS_L2_SHADOW, leave, GateCheckBody, ANS-01 | OV gate action is `leave` not `llm`. Shadow report compares L1-only vs L2-only. `and also show` stays L1. | `2026-09-04_c7-05-gsh-and-leave-gate.md` |
 | 2026-09-04 | c7-05-engine-scorer | C7-05, held-out, score_engine, G-abs, G-err, G-env, DMS_L2_ENABLED | Live engine scorer on frozen items; L2 env is process-local; cutover stays false until G-man/G-sh too. | `2026-09-04_c7-05-engine-scorer.md` |
 | 2026-09-04 | c7-03-plausibility | C7-03, plausibility, empty-success, implausible_shape, retrieval miss, L2_VALIDATED | After L2 execute, `l2_plausibility.assess_plausibility` abstains (badge=abstain, empty rows) on empty-success, scalar-vs-listing, retrieval-miss, leftover literals, or score below 0.55. Does not rewrite SQL or call the enforcer. | `2026-09-04_c7-03-plausibility.md` |

--- a/packs/dms/semantic/vocabulary.py
+++ b/packs/dms/semantic/vocabulary.py
@@ -47,6 +47,8 @@ _RULES: tuple[tuple[str, str], ...] = (
     (r"\bdelay\b(?!ed)", "delayed"),
     (r"\bfreight\s+compan(?:y|ies)\b", "carrier"),
     (r"\blogistics\s+providers?\b", "carrier"),
+    (r"\bfreight spend\b", "shipment cost"),
+    (r"\bshipping cost\b", "shipment cost"),
     (r"\b(?:on the road|currently moving|in motion)\b", "in transit shipments"),
     (r"\b(?:lands|arrives|arrive)\s+this\s+week\b", "arriving this week"),
     (r"\bdue\s+in\s+the\s+next\s+seven\s+days\b", "arriving in 7 days"),

--- a/tests/dms/test_certified_synonyms.py
+++ b/tests/dms/test_certified_synonyms.py
@@ -86,6 +86,8 @@ def test_sku_count_metric_synonyms_hit_l1(question: str):
         ("high risk suppliers", "suppliers_by_risk"),
         ("pending deliveries from high risk vendors", "high_risk_pending"),
         ("shipment cost by destination", "cost_by_destination"),
+        ("freight spend per destination", "cost_by_destination"),
+        ("what does shipping cost us by drop-off point", "cost_by_destination"),
     ],
 )
 def test_declared_yaml_synonyms_hit_stated_metric(question: str, metric_id: str):
@@ -139,6 +141,26 @@ def test_sku_count_per_category_is_grouped_not_scalar():
     assert "sku_count" in rows[0]
     assert str(rows[0]["category"]) in text
     assert str(rows[0]["sku_count"]) in text.replace(",", "")
+
+
+def test_freight_spend_per_destination_is_cost_not_count():
+    from CortexOS.dms.answer_engine import answer, route_to_metric
+
+    q = "freight spend per destination"
+    plan = route_to_metric(q)
+    assert plan is not None
+    assert plan.metric_id == "cost_by_destination"
+    r = answer(q)
+    assert r["badge"] != "abstain", r.get("answer")
+    rows = r.get("rows") or []
+    assert rows, r.get("answer")
+    text = r.get("answer") or ""
+    assert text.strip()
+    assert "location_code" in rows[0]
+    assert "total_cost_myr" in rows[0]
+    assert "shipment_count" not in rows[0]
+    assert str(rows[0]["location_code"]) in text
+    assert str(int(float(rows[0]["total_cost_myr"]))) in text.replace(",", "")
 
 
 def test_certified_sales_synonym_hits_l0():


### PR DESCRIPTION
## Summary
- Map `freight spend` / `shipping cost` into `shipment cost` and route per destination/warehouse/location to `cost_by_destination` (not shipment count).
- Assert freight-spend paraphrases return `location_code` + `total_cost_myr` on rendered text and rows.
- Nested yaml leftover-filler and grouped SKU / high-risk pending already landed in #145.

## Test plan
- [x] `pytest tests/dms/test_certified_synonyms.py tests/dms/test_vocabulary_normalization.py tests/dms/test_paraphrase_benchmark.py::test_paraphrase_zero_confidently_wrong` (local, 0 wrong)
- [ ] GitHub `lint-type-test`