### PR TITLE
L1: spend-by-country, overdue audit, CCTV; contract ask sku_count

### DIFF
--- a/CortexOS/dms/answer_engine.py
+++ b/CortexOS/dms/answer_engine.py
@@ -862,6 +862,13 @@ def route_to_metric(question: str) -> MetricPlan | None:
         and re.search(r"\b(destination|warehouse|location)\b", q)
     ):
         return _metric_plan("cost_by_destination", {}, "shipment cost grouped by destination")
+    if (
+        re.search(r"\bspend\b", q)
+        and re.search(r"\b(country|countries)\b", q)
+        and re.search(r"\b(per|by|each)\b", q)
+        and not re.search(r"\b(destination|warehouse)\b", q)
+    ):
+        return _metric_plan("spend_by_country", {}, "inventory spend grouped by supplier country")
 
     # revenue — calendar month before rolling-day window; bare total before ranked "top sales"
     if re.search(r"\b(revenue|sales|sold)\b", q) and _calendar_month(q) == "last":
@@ -900,6 +907,15 @@ def route_to_metric(question: str) -> MetricPlan | None:
             "high_risk_pending",
             {"threshold": _threshold(q_raw)},
             "high-risk suppliers with pending/in-transit shipments",
+        )
+    if "audit" in q and re.search(r"\b(overdue|due|lapsed)\b", q):
+        return _metric_plan("audit_overdue", {}, "suppliers with an overdue audit")
+    loc = _location(q_raw)
+    if loc and re.search(r"\b(cctv|camera)\b", q):
+        return _metric_plan(
+            "cctv_by_location",
+            {"location": loc},
+            f"CCTV camera for {loc}",
         )
     # supplier risk threshold
     if re.search(r"\brisk\b", q) and re.search(r"\b(above|over|below|under|greater|less|more than|exceed|>|<)\b", q):

--- a/docs/subagents_findings/2026-09-04_c7-l1-yaml-synonyms.md
+++ b/docs/subagents_findings/2026-09-04_c7-l1-yaml-synonyms.md
@@ -2,7 +2,7 @@
 
 - Date: 2026-09-04
 - Keywords: metrics.yaml, synonyms, route_to_metric, sellers, cost_by_destination, C7-05, G-lat
-- Main idea: After the regex cascade, L1 takes the longest `metrics.yaml` synonym (space, >=16 chars, leftover filler only, no required slot). Nested `high risk suppliers` is not the pending-shipment ask. Grouped SKU count beats the warehouse-wide scalar. Freight/shipping cost by destination is `cost_by_destination`, not a shipment count. `selling`/`sellers` count as sales-rank.
+- Main idea: After the regex cascade, L1 takes the longest `metrics.yaml` synonym (space, >=16 chars, leftover filler only, no required slot). Nested `high risk suppliers` is not the pending-shipment ask. Grouped SKU count beats the warehouse-wide scalar. Freight/shipping cost by destination is `cost_by_destination`. Spend-by-country, overdue audit, and CCTV-for-warehouse-A are L1. `selling`/`sellers` count as sales-rank.
 
 ## PREFLIGHT
 

--- a/tests/dms/test_c7_02_manifest_before_explain.py
+++ b/tests/dms/test_c7_02_manifest_before_explain.py
@@ -275,3 +275,26 @@ def test_same_grant_l1_revenue_still_answers(dms_http, monkeypatch: pytest.Monke
     crows = cbody.get("rows") or []
     assert crows
     assert cbody.get("answer")
+
+
+def test_contract_ask_sku_count_on_inventory_grant(dms_http):
+    """POST /v1/contract/ask: L1 sku_count under a bound inventory grant."""
+    dms_http.bind_session(SESSION, {"inventory": "TRUE"})
+    contract = dms_http.post(
+        "/v1/contract/ask",
+        json={"question": "how many skus", "session_id": SESSION},
+    )
+    assert contract.status_code == 200, contract.text
+    cbody = contract.json()
+    assert _badge(cbody).lower() not in {"abstain", "refused", "blocked"}
+    crows = cbody.get("rows") or []
+    assert crows, cbody.get("answer")
+    assert "sku_count" in crows[0]
+    n = int(crows[0]["sku_count"])
+    assert n > 0
+    text = cbody.get("answer") or ""
+    assert text.strip()
+    assert str(n) in text.replace(",", "")
+    assert cbody.get("sql_used")
+    assert "inventory" in str(cbody.get("sql_used")).lower()
+    assert cbody.get("audit_id") or (cbody.get("provenance") or {}).get("audit_id")

--- a/tests/dms/test_certified_synonyms.py
+++ b/tests/dms/test_certified_synonyms.py
@@ -88,6 +88,10 @@ def test_sku_count_metric_synonyms_hit_l1(question: str):
         ("shipment cost by destination", "cost_by_destination"),
         ("freight spend per destination", "cost_by_destination"),
         ("what does shipping cost us by drop-off point", "cost_by_destination"),
+        ("how much do we spend in each supplier country", "spend_by_country"),
+        ("procurement spend broken down by country", "spend_by_country"),
+        ("which vendors are due for an audit", "audit_overdue"),
+        ("camera feed for warehouse A", "cctv_by_location"),
     ],
 )
 def test_declared_yaml_synonyms_hit_stated_metric(question: str, metric_id: str):
@@ -161,6 +165,45 @@ def test_freight_spend_per_destination_is_cost_not_count():
     assert "shipment_count" not in rows[0]
     assert str(rows[0]["location_code"]) in text
     assert str(int(float(rows[0]["total_cost_myr"]))) in text.replace(",", "")
+
+
+def test_spend_by_country_paraphrase_is_grouped_spend():
+    from CortexOS.dms.answer_engine import answer, route_to_metric
+
+    q = "how much do we spend in each supplier country"
+    plan = route_to_metric(q)
+    assert plan is not None
+    assert plan.metric_id == "spend_by_country"
+    r = answer(q)
+    assert r["badge"] != "abstain", r.get("answer")
+    rows = r.get("rows") or []
+    assert rows, r.get("answer")
+    text = r.get("answer") or ""
+    assert text.strip()
+    assert "country" in rows[0]
+    assert "total_spend_myr" in rows[0]
+    assert str(rows[0]["country"]) in text
+    assert str(int(float(rows[0]["total_spend_myr"]))) in text.replace(",", "")
+
+
+def test_cctv_warehouse_a_returns_camera_id():
+    from CortexOS.dms.answer_engine import answer, route_to_metric
+
+    q = "camera feed for warehouse A"
+    plan = route_to_metric(q)
+    assert plan is not None
+    assert plan.metric_id == "cctv_by_location"
+    assert plan.slots.get("location") == "WH-A"
+    r = answer(q)
+    assert r["badge"] != "abstain", r.get("answer")
+    rows = r.get("rows") or []
+    assert rows, r.get("answer")
+    text = r.get("answer") or ""
+    assert text.strip()
+    assert rows[0].get("location_code") == "WH-A"
+    assert rows[0].get("cctv_camera_id")
+    assert "WH-A" in text
+    assert str(rows[0]["cctv_camera_id"]) in text
 
 
 def test_certified_sales_synonym_hits_l0():


### PR DESCRIPTION
## Summary
- L1 now answers spend-by-country, overdue-audit, and CCTV-for-warehouse-A paraphrases (not adjacent metrics).
- `POST /v1/contract/ask` for `how many skus` under an inventory grant returns sku_count on rendered text and rows.

## Test plan
- [x] local: test_certified_synonyms + test_contract_ask_sku_count_on_inventory_grant + paraphrase wrong=0
- [ ] GitHub lint-type-test