### PR TITLE
Honor chemicals listing and supplier scorecard paraphrases on L1

### DIFF
--- a/CortexOS/dms/answer_engine.py
+++ b/CortexOS/dms/answer_engine.py
@@ -218,6 +218,13 @@ def _location(question: str) -> str | None:
     return res.value if res.ok else None
 
 
+def _category(question: str) -> str | None:
+    from packs.dms.semantic import values as vd
+
+    res = vd.resolve(question, "category")
+    return res.value if res.ok else None
+
+
 _EXCLUSION_STOP = re.compile(
     r"\b(?:what|show|list|give|find|get|top|bottom|best|worst|highest|lowest|"
     r"ranked?|numbers?|ranks?|selling|sold|"
@@ -840,6 +847,18 @@ def route_to_metric(question: str) -> MetricPlan | None:
         and not re.search(r"\b(category|per|by)\b", q)
     ):
         return _metric_plan("sku_count", {}, "distinct SKU count")
+    if (
+        re.search(r"\bchemicals?\b", q)
+        and not _wants_aggregate(q)
+        and "value" not in q
+        and not re.search(r"\b(per|by|each)\b", q)
+    ):
+        cat = _category(q) or "CHEMICALS"
+        return _metric_plan(
+            "items_by_category",
+            {"category": cat},
+            f"inventory listing for category {cat}",
+        )
     # "how many delayed" / Malay "berapa ... delayed" must not return the listing.
     if (
         ("delayed" in q)
@@ -922,6 +941,16 @@ def route_to_metric(question: str) -> MetricPlan | None:
         return _metric_plan("suppliers_by_risk",
                           {"threshold": _threshold(q_raw), "op": _threshold_op(q_raw)},
                           "suppliers filtered by risk-score threshold")
+    if (
+        re.search(r"\b(rank|ranking|scorecard|benchmark|compare)\b", q)
+        and re.search(r"\bsuppliers?\b", q)
+        and re.search(r"\b(risk|lead|score|combined|together)\b", q)
+    ):
+        return _metric_plan(
+            "supplier_ranking",
+            {"limit": _explicit_limit(q_raw) or 10, "direction": _direction(q_raw)},
+            "suppliers ranked by combined risk and lead time",
+        )
 
     # average lead time by country
     if re.search(r"\baverage\b|\bmean\b|\bavg\b", q) and "lead time" in q:

--- a/packs/dms/semantic/vocabulary.py
+++ b/packs/dms/semantic/vocabulary.py
@@ -58,6 +58,7 @@ _RULES: tuple[tuple[str, str], ...] = (
     # ── suppliers ──────────────────────────────────────────────────────────
     (r"\bvendors?\b", "suppliers"),
     (r"\bprocurement\s+spend\b", "total spend"),
+    (r"\b(?:still\s+)?owe us\b", "pending"),
 
     # ── inventory ──────────────────────────────────────────────────────────
     (r"\b(?:running low|needs? replenishment|need(?:s|ing)? reordering|"

--- a/tests/dms/test_certified_synonyms.py
+++ b/tests/dms/test_certified_synonyms.py
@@ -92,6 +92,10 @@ def test_sku_count_metric_synonyms_hit_l1(question: str):
         ("procurement spend broken down by country", "spend_by_country"),
         ("which vendors are due for an audit", "audit_overdue"),
         ("camera feed for warehouse A", "cctv_by_location"),
+        ("show me everything in the chemicals category", "items_by_category"),
+        ("what chemical products do we hold", "items_by_category"),
+        ("rank our vendors on risk and lead time together", "supplier_ranking"),
+        ("risky suppliers who still owe us shipments", "high_risk_pending"),
     ],
 )
 def test_declared_yaml_synonyms_hit_stated_metric(question: str, metric_id: str):
@@ -204,6 +208,42 @@ def test_cctv_warehouse_a_returns_camera_id():
     assert rows[0].get("cctv_camera_id")
     assert "WH-A" in text
     assert str(rows[0]["cctv_camera_id"]) in text
+
+
+def test_chemicals_paraphrase_lists_chemical_skus():
+    from CortexOS.dms.answer_engine import answer, route_to_metric
+
+    q = "show me everything in the chemicals category"
+    plan = route_to_metric(q)
+    assert plan is not None
+    assert plan.metric_id == "items_by_category"
+    assert str(plan.slots.get("category")).upper() == "CHEMICALS"
+    r = answer(q)
+    assert r["badge"] != "abstain", r.get("answer")
+    rows = r.get("rows") or []
+    assert rows, r.get("answer")
+    text = r.get("answer") or ""
+    assert text.strip()
+    assert "sku" in rows[0]
+    assert str(rows[0]["sku"]) in text
+
+
+def test_supplier_scorecard_paraphrase_ranks_suppliers():
+    from CortexOS.dms.answer_engine import answer, route_to_metric
+
+    q = "rank our vendors on risk and lead time together"
+    plan = route_to_metric(q)
+    assert plan is not None
+    assert plan.metric_id == "supplier_ranking"
+    r = answer(q)
+    assert r["badge"] != "abstain", r.get("answer")
+    rows = r.get("rows") or []
+    assert rows, r.get("answer")
+    text = r.get("answer") or ""
+    assert text.strip()
+    assert "supplier_id" in rows[0]
+    assert "ranking_score" in rows[0]
+    assert str(rows[0]["supplier_id"]) in text
 
 
 def test_certified_sales_synonym_hits_l0():


### PR DESCRIPTION
## Summary
- Route chemicals listings to `items_by_category` (category from the existing values helper, else `CHEMICALS`).
- Route vendor risk/lead-time scorecards to `supplier_ranking` without stealing `which vendors score worse than 0.7`.
- Map `owe us` to `pending` so risky-suppliers-who-still-owe-us hits `high_risk_pending`.

## Test plan
- [x] `pytest tests/dms/test_certified_synonyms.py tests/dms/test_vocabulary_normalization.py tests/dms/test_destructive_intent.py tests/dms/test_paraphrase_benchmark.py::test_paraphrase_zero_confidently_wrong` -- 139 passed, paraphrase wrong=0
- [ ] CI lint-type-test / base-install / protected-paths / rls-proof / secrets-scan
- Does not enable `DMS_L2_ENABLED`. Does not close #104.
