### PR TITLE
Re-read DMS_WAREHOUSE_DB in warehouse_path at call time

### DIFF
--- a/CortexOS/execution/warehouse.py
+++ b/CortexOS/execution/warehouse.py
@@ -20,7 +20,18 @@ _RO_CONNECTIONS: dict[str, Any] = {}
 
 
 def warehouse_path(db_path: Path | str | None = None) -> Path:
-    return Path(db_path or DEFAULT_DB)
+    """Resolve the serving warehouse. Re-reads ``DMS_WAREHOUSE_DB`` each call.
+
+    ``DEFAULT_DB`` stays an import-time snapshot for callers that monkeypatch
+    the constant. Loaders go through this function so a later env change
+    (tests, a second process) is not stuck on the import-time path.
+    """
+    if db_path is not None:
+        return Path(db_path)
+    env = os.environ.get("DMS_WAREHOUSE_DB")
+    if env:
+        return Path(env)
+    return Path(DEFAULT_DB)
 
 
 def read_only_queries_enabled() -> bool:

--- a/tests/test_execution/test_warehouse_path.py
+++ b/tests/test_execution/test_warehouse_path.py
@@ -1,0 +1,14 @@
+"""warehouse_path re-reads DMS_WAREHOUSE_DB at call time."""
+
+from __future__ import annotations
+
+from CortexOS.execution import warehouse as w
+
+
+def test_warehouse_path_honors_env_after_import(tmp_path, monkeypatch):
+    frozen = w.DEFAULT_DB
+    isolated = tmp_path / "call_time.duckdb"
+    monkeypatch.setenv("DMS_WAREHOUSE_DB", str(isolated))
+    assert w.DEFAULT_DB == frozen
+    assert w.warehouse_path() == isolated
+    assert w.warehouse_path() != frozen


### PR DESCRIPTION
## Summary
- `warehouse_path()` re-reads `DMS_WAREHOUSE_DB` on each call instead of the import-time `DEFAULT_DB` snapshot.
- One unit test sets the env after import and asserts the call-time path, not `DEFAULT_DB`.
- Narrow on purpose. Does not bundle DMS Studio. Supersedes the warehouse-path intent of mixed 31-file PR #43; leave #43 open until this merges.

## Test plan
- [x] `D:\Cortex\.venv\Scripts\python.exe -m pytest tests/test_execution/test_warehouse_path.py -q` (1 passed)
- [ ] required CI green