### PR TITLE
Crew: /spawn /kill /stop /idle /wait /goal in the slash catalog

### DIFF
--- a/CortexOS/crew/commands.py
+++ b/CortexOS/crew/commands.py
@@ -57,6 +57,57 @@ _DESK: tuple[dict[str, Any], ...] = (
     },
 )
 
+_LIFE: tuple[dict[str, Any], ...] = (
+    {
+        "slash": "spawn",
+        "aliases": ("hire",),
+        "kind": "life",
+        "action": "spawn",
+        "title": "Spawn teammate",
+        "hint": "/spawn name | brief | goal",
+    },
+    {
+        "slash": "kill",
+        "aliases": (),
+        "kind": "life",
+        "action": "kill",
+        "title": "Kill teammate",
+        "hint": "/kill name | reason",
+    },
+    {
+        "slash": "stop",
+        "aliases": (),
+        "kind": "life",
+        "action": "stop",
+        "title": "Stop teammate",
+        "hint": "/stop name  (parks idle/goal; can accept again)",
+    },
+    {
+        "slash": "idle",
+        "aliases": (),
+        "kind": "life",
+        "action": "idle",
+        "title": "Park idle",
+        "hint": "/idle name",
+    },
+    {
+        "slash": "wait",
+        "aliases": (),
+        "kind": "life",
+        "action": "wait",
+        "title": "Park waiting",
+        "hint": "/wait name",
+    },
+    {
+        "slash": "goal",
+        "aliases": (),
+        "kind": "life",
+        "action": "goal",
+        "title": "Set goal mode",
+        "hint": "/goal name | goal text",
+    },
+)
+
 _MEMORY: tuple[dict[str, Any], ...] = (
     {
         "slash": "memory",
@@ -137,6 +188,22 @@ def catalog(skills_dir: Path | None = None) -> list[dict[str, Any]]:
             _public_cmd(
                 slash=slash,
                 kind="desk",
+                action=str(row["action"]),
+                title=str(row["title"]),
+                hint=str(row["hint"]),
+                aliases=aliases,
+            )
+        )
+
+    for row in _LIFE:
+        slash = str(row["slash"])
+        if not take(slash):
+            continue
+        aliases = tuple(a for a in row["aliases"] if take(a))
+        out.append(
+            _public_cmd(
+                slash=slash,
+                kind="life",
                 action=str(row["action"]),
                 title=str(row["title"]),
                 hint=str(row["hint"]),

--- a/CortexOS/crew/runtime.py
+++ b/CortexOS/crew/runtime.py
@@ -210,6 +210,8 @@ class CrewRuntime:
             self._run_slash_desk(space_id, manager, parsed.command, parsed.rest)
         elif parsed.command and parsed.command.get("kind") == "memory":
             self._run_slash_memory(space_id, manager, parsed.command, parsed.rest)
+        elif parsed.command and parsed.command.get("kind") == "life":
+            await self._run_slash_life(space_id, manager, parsed.command, parsed.rest)
         elif parsed.command and parsed.command.get("kind") in {"skill", "routine"}:
             self._load_slash_pack(space_id, parsed.command, parsed.rest)
 
@@ -224,7 +226,12 @@ class CrewRuntime:
             and parsed.command.get("kind") == "memory"
             and not parsed.mentions
         )
-        if desk_only or memory_only:
+        life_only = bool(
+            parsed.command
+            and parsed.command.get("kind") == "life"
+            and not parsed.mentions
+        )
+        if desk_only or memory_only or life_only:
             return {"ok": True, "command": parsed.command.get("slash"), "run_id": None}
 
         turn_provider = (provider or "").strip() or None
@@ -425,6 +432,105 @@ class CrewRuntime:
             to_agent_id=manager["id"],
             meta={
                 "tool": f"memory_{action}",
+                "args": args,
+                "slash": True,
+                "a2a": {"kind": a2a.USER, "from": "operator", "to": manager["name"]},
+            },
+        )
+        self.bus.emit(space_id, "message", {"message": msg})
+
+    async def _run_slash_life(
+        self,
+        space_id: str,
+        manager: dict[str, Any],
+        command: dict[str, Any],
+        rest: str,
+    ) -> None:
+        """Operator /spawn /kill /stop /idle /wait /goal. Same methods as the HUD."""
+        action = str(command.get("action") or "")
+        parts = [p.strip() for p in rest.split("|")]
+        name = parts[0] if parts else ""
+        extra = parts[1] if len(parts) > 1 else ""
+        more = "|".join(parts[2:]).strip() if len(parts) > 2 else ""
+        args: dict[str, Any] = {"name": name}
+        text = ""
+        if action == "spawn":
+            if not name:
+                text = "DENIED: /spawn name | brief | goal"
+            else:
+                payload = {"name": name, "brief": extra}
+                if more:
+                    payload["mode"] = life.MODE_GOAL
+                    payload["goal"] = more
+                elif extra and not more:
+                    payload["brief"] = extra
+                result = await self.operator_spawn(space_id, payload)
+                args = payload
+                if result.get("error"):
+                    text = str(result["error"])
+                else:
+                    agent = result["agent"]
+                    text = (
+                        f"Spawned {agent['name']} status={agent.get('status')} "
+                        f"mode={agent.get('mode')}"
+                    )
+        elif action in {"kill", "stop", "idle", "wait", "goal"}:
+            if not name:
+                text = f"DENIED: /{action} name"
+            else:
+                row = self.store.get_agent_by_name(space_id, name)
+                if row is None:
+                    text = f"DENIED: no teammate named {name}"
+                elif action == "kill":
+                    why = extra or "operator killed"
+                    args = {"name": name, "reason": why}
+                    result = self.kill_agent(row["id"], reason=why)
+                    if isinstance(result, dict) and result.get("error"):
+                        text = str(result["error"])
+                    else:
+                        text = life.dead_reason(result or row)
+                elif action in {"stop", "idle"}:
+                    result = self.stop_agent(row["id"])
+                    if isinstance(result, dict) and result.get("error"):
+                        text = str(result["error"])
+                    else:
+                        parked = result or row
+                        text = f"{parked.get('name')} status={parked.get('status')}"
+                elif action == "wait":
+                    if row["name"] == "Manager":
+                        text = "DENIED: Manager wait is the run; do not park the Manager"
+                    elif not life.can_accept(row):
+                        text = f"DENIED: {life.dead_reason(row)}"
+                    else:
+                        self._set_status(row["id"], life.STATUS_WAITING)
+                        parked = self.store.get_agent(row["id"]) or row
+                        text = f"{parked.get('name')} status={parked.get('status')}"
+                else:
+                    goal_text = extra or more
+                    if not goal_text:
+                        text = "DENIED: /goal name | goal text"
+                    else:
+                        args = {"name": name, "goal": goal_text}
+                        updated = self.set_agent_mode(
+                            row["id"], life.MODE_GOAL, goal_text=goal_text
+                        )
+                        if updated is None:
+                            text = f"DENIED: no teammate named {name}"
+                        else:
+                            text = (
+                                f"{updated.get('name')} mode={updated.get('mode')} "
+                                f"goal={updated.get('goal_text')}"
+                            )
+        else:
+            text = f"Unknown life action {action}"
+        msg = self.store.add_message(
+            space_id,
+            "tool",
+            text[:4000],
+            agent_id=manager["id"],
+            to_agent_id=manager["id"],
+            meta={
+                "tool": action,
                 "args": args,
                 "slash": True,
                 "a2a": {"kind": a2a.USER, "from": "operator", "to": manager["name"]},

--- a/CortexOS/crew/ui/index.html
+++ b/CortexOS/crew/ui/index.html
@@ -97,7 +97,7 @@
         </div>
         <div class="block">
           <h2>Crew</h2>
-          <p class="hint">Status: active / idle / waiting / goal. Stop parks. Kill refuses with a reason.</p>
+          <p class="hint">Status: active / idle / waiting / goal. /spawn /kill /stop /idle /wait /goal. Stop parks. Kill refuses with a reason.</p>
           <div class="life-spawn">
             <input id="spawnName" placeholder="name" />
             <input id="spawnBrief" placeholder="brief" />

--- a/tests/test_crew/test_commands.py
+++ b/tests/test_crew/test_commands.py
@@ -21,7 +21,22 @@ from tests.test_crew.conftest import wait_run_done
 def test_catalog_lists_desk_routines_and_skills(settings) -> None:
     rows = catalog(settings.data_dir / "skills")
     slashes = {r["slash"] for r in rows}
-    assert {"desk", "board", "estate", "ship_gate", "remember", "memory", "recall", "forget"} <= slashes
+    assert {
+        "desk",
+        "board",
+        "estate",
+        "ship_gate",
+        "spawn",
+        "kill",
+        "stop",
+        "idle",
+        "wait",
+        "goal",
+        "remember",
+        "memory",
+        "recall",
+        "forget",
+    } <= slashes
     assert "pr-check" in slashes
     assert "build" in slashes
     desk = match_command("desk_status", settings.data_dir / "skills")
@@ -37,6 +52,10 @@ def test_parse_slash_and_mentions() -> None:
     hit = parse("/ship_gate Cortex")
     assert hit.command is not None and hit.command["action"] == "ship_gate"
     assert hit.rest == "Cortex"
+    spawn = parse("/spawn Scout | watch")
+    assert spawn.command is not None and spawn.command["action"] == "spawn"
+    assert spawn.command["kind"] == "life"
+    assert spawn.rest == "Scout | watch"
     names = parse_mentions("@PRD check the brief with @Gate")
     assert names == ("PRD", "Gate")
     resolved = resolve_mentions(names)
@@ -94,6 +113,43 @@ async def test_slash_remember_writes_facts_md_without_a_run(rig) -> None:
     assert "8020" in facts.read_text(encoding="utf-8")
     rig.runtime.clear_chat(space["id"])
     assert "8020" in facts.read_text(encoding="utf-8")
+
+
+@pytest.mark.asyncio
+async def test_slash_spawn_kill_idle_wait_goal_without_a_run(rig) -> None:
+    from CortexOS.crew import life
+
+    space = rig.store.create_space("HQ")
+    posted = await rig.runtime.on_user_message(
+        space["id"], "/spawn Scout | watch the belt | hold the line"
+    )
+    assert posted.get("run_id") is None
+    assert posted.get("command") == "spawn"
+    scout = rig.store.get_agent_by_name(space["id"], "Scout")
+    assert scout is not None
+    assert scout["mode"] == life.MODE_GOAL
+    assert scout["goal_text"] == "hold the line"
+    parked = await rig.runtime.on_user_message(space["id"], "/idle Scout")
+    assert parked.get("run_id") is None
+    idle = rig.store.get_agent(scout["id"])
+    assert idle is not None and idle["status"] in {life.STATUS_IDLE, life.STATUS_GOAL}
+    waiting = await rig.runtime.on_user_message(space["id"], "/wait Scout")
+    assert waiting.get("run_id") is None
+    wait_row = rig.store.get_agent(scout["id"])
+    assert wait_row is not None and wait_row["status"] == life.STATUS_WAITING
+    goaled = await rig.runtime.on_user_message(space["id"], "/goal Scout | keep watching")
+    assert goaled.get("run_id") is None
+    again = rig.store.get_agent(scout["id"])
+    assert again is not None and again["mode"] == life.MODE_GOAL
+    assert again["goal_text"] == "keep watching"
+    killed = await rig.runtime.on_user_message(space["id"], "/kill Scout | test done")
+    assert killed.get("run_id") is None
+    dead = rig.store.get_agent(scout["id"])
+    assert dead is not None and dead["status"] == life.STATUS_STOPPED
+    await rig.runtime.on_user_message(space["id"], "/kill Nobody")
+    tool = [m for m in rig.store.list_messages(space["id"]) if m["role"] == "tool"][-1]
+    assert "DENIED" in tool["content"] and "Nobody" in tool["content"]
+    assert not rig.runtime._space_run.get(space["id"])
 
 
 @pytest.mark.asyncio

--- a/tests/test_crew/test_server.py
+++ b/tests/test_crew/test_server.py
@@ -312,7 +312,7 @@ def test_operator_can_choose_runtime_backend(client) -> None:
 def test_commands_autocomplete_and_mention_targets(client) -> None:
     body = client.http.get("/crew/commands").json()
     slashes = {c["slash"] for c in body["commands"]}
-    assert {"desk", "board", "estate", "ship_gate"} <= slashes
+    assert {"desk", "board", "estate", "ship_gate", "spawn", "kill"} <= slashes
     assert any(c["kind"] == "skill" and c["slash"] == "build" for c in body["commands"])
     assert any(c["kind"] == "routine" for c in body["commands"])
     names = {m["name"] for m in body["mentions"]}


### PR DESCRIPTION
## Summary
- Operator `/spawn` `/kill` `/stop` `/idle` `/wait` `/goal` call the same life methods as the HUD.
- Missing name or unknown teammate is a named DENIED (R-0011). No grok-bot paste. Ticket Runner still seats writers.

## Test plan
- [x] `python -m pytest tests/test_crew -q` (183 passed on the parent tree)
- [ ] Live `:8020` `/crew/commands` includes spawn/kill/wait/goal
