### PR TITLE
Crew: HITL /done closes issues, refuses SEATED seats

### DIFF
--- a/CortexOS/crew/commands.py
+++ b/CortexOS/crew/commands.py
@@ -55,6 +55,14 @@ _DESK: tuple[dict[str, Any], ...] = (
         "title": "Ship-gate",
         "hint": "Deterministic production gate. Arg: repo slug or all.",
     },
+    {
+        "slash": "done",
+        "aliases": ("close_issue",),
+        "kind": "desk",
+        "action": "close_issue",
+        "title": "Close issue (HITL)",
+        "hint": "/done owner/repo#n | comment. Refuses SEATED claims. Never merges.",
+    },
 )
 
 _LIFE: tuple[dict[str, Any], ...] = (

--- a/CortexOS/crew/github.py
+++ b/CortexOS/crew/github.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import json
 import os
+import re
 import subprocess
 from collections.abc import Callable
 from typing import Any
@@ -166,4 +167,93 @@ def list_prs(limit: int = 20, *, runner: RunFn | None = None) -> dict[str, Any]:
         "prs": prs[:80],
         "repos": repos,
         "law": "Report in chat. Do not auto-merge. Ticket Runner seats existing writers.",
+    }
+
+
+_ISSUE_SPEC = re.compile(
+    r"(?:https://github\.com/)?([A-Za-z0-9_.-]+)/([A-Za-z0-9_.-]+)(?:#|/issues/)(\d+)\Z"
+)
+
+
+def parse_issue_spec(raw: str) -> tuple[str, str, int] | None:
+    text = (raw or "").strip()
+    matched = _ISSUE_SPEC.match(text)
+    if matched is None:
+        return None
+    return matched.group(1), matched.group(2), int(matched.group(3))
+
+
+def canonical_spec(raw: str) -> str:
+    parsed = parse_issue_spec(raw)
+    if parsed is None:
+        return (raw or "").strip()
+    owner, repo, number = parsed
+    return f"{owner}/{repo}#{number}"
+
+
+def seated_claim(raw: str) -> dict[str, Any] | None:
+    """Ticket Runner seat. Crew must not close this without a different writer."""
+    parsed = parse_issue_spec(raw)
+    if parsed is None:
+        return None
+    owner, repo, number = parsed
+    key = f"{owner}/{repo}#{number}"
+    for row in board_snapshot().get("tickets") or []:
+        if not isinstance(row, dict):
+            continue
+        if str(row.get("role") or "") != "SEATED":
+            continue
+        ticket = str(row.get("ticket") or "")
+        owner_pr = str(row.get("owner_pr") or "")
+        if ticket == key or owner_pr == key:
+            return row
+    return None
+
+
+def close_issue(
+    spec: str,
+    *,
+    comment: str = "",
+    runner: RunFn | None = None,
+) -> dict[str, Any]:
+    """Close one GitHub *issue*. Never merges a PR."""
+    parsed = parse_issue_spec(spec)
+    if parsed is None:
+        return {
+            "ok": False,
+            "detail": "DENIED: need owner/repo#n (issues only; Crew does not merge PRs)",
+        }
+    seated = seated_claim(spec)
+    if seated is not None:
+        return {
+            "ok": False,
+            "detail": (
+                f"DENIED: {seated.get('ticket')} is SEATED "
+                f"({seated.get('owner_pr')}). Ticket Runner owns the seat."
+            ),
+        }
+    if os.environ.get("CREW_LIVE_PROBES", "1") == "0":
+        return {"ok": False, "detail": "CREW_LIVE_PROBES=0"}
+    owner, repo, number = parsed
+    argv = ["gh", "issue", "close", str(number), "--repo", f"{owner}/{repo}"]
+    note = (comment or "").strip()[:500]
+    if note:
+        argv.extend(["--comment", note])
+    run = runner or _run
+    try:
+        result = run(argv, timeout=20)
+    except FileNotFoundError:
+        return {"ok": False, "detail": "gh not installed"}
+    except (OSError, subprocess.TimeoutExpired) as exc:
+        return {"ok": False, "detail": type(exc).__name__}
+    if result.returncode != 0:
+        return {
+            "ok": False,
+            "detail": (result.stderr or result.stdout or "gh issue close failed")[:400],
+        }
+    return {
+        "ok": True,
+        "spec": f"{owner}/{repo}#{number}",
+        "detail": (result.stdout or "").strip()[:400],
+        "law": "Closed the issue. Did not merge a PR. Ticket Runner seats writers.",
     }

--- a/CortexOS/crew/runtime.py
+++ b/CortexOS/crew/runtime.py
@@ -231,7 +231,12 @@ class CrewRuntime:
             and parsed.command.get("kind") == "life"
             and not parsed.mentions
         )
-        if desk_only or memory_only or life_only:
+        close_only = bool(
+            parsed.command
+            and parsed.command.get("action") == "close_issue"
+            and not parsed.mentions
+        )
+        if desk_only or memory_only or life_only or close_only:
             return {"ok": True, "command": parsed.command.get("slash"), "run_id": None}
 
         turn_provider = (provider or "").strip() or None
@@ -366,6 +371,38 @@ class CrewRuntime:
             repo = rest.strip() or "all"
             args = {"repo": repo}
             text = render_slug(repo)
+        elif action == "close_issue":
+            from CortexOS.crew import github as github_mod
+
+            bits = [p.strip() for p in rest.split("|")]
+            spec = bits[0] if bits else ""
+            comment = "|".join(bits[1:]).strip() if len(bits) > 1 else ""
+            args = {"spec": spec, "comment": comment}
+            parsed = github_mod.parse_issue_spec(spec)
+            seated = github_mod.seated_claim(spec) if parsed else None
+            if parsed is None:
+                text = "DENIED: /done owner/repo#n | comment"
+            elif seated is not None:
+                text = (
+                    f"DENIED: {seated.get('ticket')} is SEATED "
+                    f"({seated.get('owner_pr')}). Ticket Runner owns the seat. "
+                    "Crew does not steal it."
+                )
+            else:
+                canon = github_mod.canonical_spec(spec)
+                confirm = self.store.create_confirm(
+                    space_id,
+                    run_id=None,
+                    agent_id=manager["id"],
+                    tool="close_issue",
+                    args={"spec": canon, "comment": comment},
+                )
+                args = {"spec": canon, "comment": comment, "confirm_id": confirm["id"]}
+                self.bus.emit(space_id, "confirm", {"confirm": confirm})
+                text = (
+                    f"HITL pending {confirm['id']}: Approve to close {canon}. "
+                    "Crew does not merge PRs."
+                )
         else:
             text = f"Unknown desk action {action}"
         msg = self.store.add_message(
@@ -608,7 +645,38 @@ class CrewRuntime:
             event.set()
         if row is not None:
             self.bus.emit(row["space_id"], "confirm", {"confirm": row})
+            if (
+                approved
+                and not takeover
+                and str(row.get("tool") or "") == "close_issue"
+                and str(row.get("status") or "") == "approved"
+            ):
+                self._finish_close_issue(row)
         return row
+
+    def _finish_close_issue(self, confirm: dict[str, Any]) -> None:
+        from CortexOS.crew import github as github_mod
+
+        args = confirm.get("args") if isinstance(confirm.get("args"), dict) else {}
+        spec = str(args.get("spec") or "")
+        comment = str(args.get("comment") or "")
+        result = github_mod.close_issue(spec, comment=comment)
+        space_id = str(confirm.get("space_id") or "")
+        manager = self.ensure_manager(space_id)
+        text = result.get("detail") or ("closed " + spec if result.get("ok") else "close failed")
+        if result.get("ok"):
+            text = f"Closed {result.get('spec')}. {result.get('law')}"
+        else:
+            text = f"DENIED: {text}"
+        msg = self.store.add_message(
+            space_id,
+            "tool",
+            str(text)[:4000],
+            agent_id=manager["id"],
+            to_agent_id=manager["id"],
+            meta={"tool": "close_issue", "args": args, "slash": True},
+        )
+        self.bus.emit(space_id, "message", {"message": msg})
 
     def cancel_run(self, run_id: str) -> bool:
         ctx = self._runs.get(run_id)

--- a/CortexOS/crew/ui/index.html
+++ b/CortexOS/crew/ui/index.html
@@ -298,6 +298,7 @@
       return false;
     }
     function scopeNote(tool, args) {
+      if (tool === "close_issue") return "scope: GitHub issue. Crew does not merge PRs. SEATED claims already refused.";
       const a = args || {};
       const path = String(a.path || a.file || a.filename || "");
       if (path && !leavesMachine(tool, args)) return "scope: local file";
@@ -305,6 +306,10 @@
       return "scope: crew-local";
     }
     function humanTitle(c) {
+      if ((c.tool || "") === "close_issue") {
+        const spec = (c.args && c.args.spec) || "";
+        return spec ? ("Close " + spec) : "Close GitHub issue";
+      }
       const cls = toolClass(c.tool);
       const name = toolTail(c.tool);
       if (cls === "click") return "Click on screen";
@@ -315,6 +320,7 @@
       return "Allow " + name;
     }
     function verbs(c) {
+      if ((c.tool || "") === "close_issue") return { ok: "Close issue", deny: "Keep open", edit: "Edit" };
       const cls = toolClass(c.tool);
       if (cls === "click") return { ok: "Click", deny: "Deny", edit: "Edit" };
       if (cls === "type") return { ok: "Type", deny: "Deny", edit: "Edit" };

--- a/tests/test_crew/test_commands.py
+++ b/tests/test_crew/test_commands.py
@@ -32,6 +32,7 @@ def test_catalog_lists_desk_routines_and_skills(settings) -> None:
         "idle",
         "wait",
         "goal",
+        "done",
         "remember",
         "memory",
         "recall",
@@ -149,6 +150,61 @@ async def test_slash_spawn_kill_idle_wait_goal_without_a_run(rig) -> None:
     await rig.runtime.on_user_message(space["id"], "/kill Nobody")
     tool = [m for m in rig.store.list_messages(space["id"]) if m["role"] == "tool"][-1]
     assert "DENIED" in tool["content"] and "Nobody" in tool["content"]
+    assert not rig.runtime._space_run.get(space["id"])
+
+
+@pytest.mark.asyncio
+async def test_slash_done_refuses_seated_and_hitl_closes_unseated(
+    rig, tmp_path, monkeypatch
+) -> None:
+    from CortexOS.crew import github as github_mod
+
+    claims = tmp_path / "CLAIMS.json"
+    claims.write_text(
+        '{"tickets":[{"ticket":"Netie-AI/Cortex#128","owner_pr":"Netie-AI/Cortex#128","role":"SEATED"}]}',
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("CREW_CLAIMS", str(claims))
+    space = rig.store.create_space("HQ")
+    seated = await rig.runtime.on_user_message(space["id"], "/done Netie-AI/Cortex#128")
+    assert seated.get("run_id") is None
+    tool = [m for m in rig.store.list_messages(space["id"]) if m["role"] == "tool"][-1]
+    assert "SEATED" in tool["content"]
+    assert rig.store.pending_confirms(space["id"]) == []
+
+    claims.write_text('{"tickets":[]}', encoding="utf-8")
+    posted = await rig.runtime.on_user_message(
+        space["id"], "/done Netie-AI/Cortex#99 | verified on desk"
+    )
+    assert posted.get("run_id") is None
+    pending = rig.store.pending_confirms(space["id"])
+    assert len(pending) == 1
+    assert pending[0]["tool"] == "close_issue"
+    assert pending[0]["args"]["spec"] == "Netie-AI/Cortex#99"
+
+    closed: dict[str, str] = {}
+
+    def fake_close(spec, *, comment="", runner=None):  # noqa: ANN001, ARG001
+        closed["spec"] = spec
+        closed["comment"] = comment
+        return {
+            "ok": True,
+            "spec": spec,
+            "detail": "Closed",
+            "law": "Closed the issue. Did not merge a PR. Ticket Runner seats writers.",
+        }
+
+    monkeypatch.setattr(github_mod, "close_issue", fake_close)
+    row = rig.runtime.decide_confirm(pending[0]["id"], True)
+    assert row is not None and row["status"] == "approved"
+    assert closed["spec"] == "Netie-AI/Cortex#99"
+    assert "verified" in closed["comment"]
+    last = [m for m in rig.store.list_messages(space["id"]) if m["role"] == "tool"][-1]
+    assert "Closed" in last["content"]
+    denied = await rig.runtime.on_user_message(space["id"], "/done not-a-ticket")
+    assert denied.get("run_id") is None
+    bad = [m for m in rig.store.list_messages(space["id"]) if m["role"] == "tool"][-1]
+    assert "DENIED" in bad["content"]
     assert not rig.runtime._space_run.get(space["id"])
 
 

--- a/tests/test_crew/test_connectors_import.py
+++ b/tests/test_crew/test_connectors_import.py
@@ -128,6 +128,62 @@ def test_github_list_org_repos_uses_injected_runner(monkeypatch) -> None:
     assert "auto-merge" in out["law"].lower()
 
 
+def test_github_close_issue_is_issue_close_not_merge(monkeypatch) -> None:
+    from CortexOS.crew import github as github_mod
+
+    monkeypatch.setenv("CREW_LIVE_PROBES", "1")
+
+    class Result:
+        def __init__(self) -> None:
+            self.returncode = 0
+            self.stdout = "Closed #99"
+            self.stderr = ""
+
+    seen: list[list[str]] = []
+
+    def runner(argv, timeout=20):  # noqa: ANN001, ARG001
+        seen.append(list(argv))
+        return Result()
+
+    empty = {
+        "ok": True,
+        "tickets": [],
+    }
+    monkeypatch.setattr(github_mod, "board_snapshot", lambda: empty)
+    out = github_mod.close_issue(
+        "https://github.com/Netie-AI/Cortex/issues/99",
+        comment="verified",
+        runner=runner,
+    )
+    assert out["ok"] is True
+    assert out["spec"] == "Netie-AI/Cortex#99"
+    assert "merge" not in out["law"].lower() or "Did not merge" in out["law"]
+    assert seen[0][:4] == ["gh", "issue", "close", "99"]
+    assert "--repo" in seen[0] and "Netie-AI/Cortex" in seen[0]
+    assert "merge" not in seen[0]
+
+
+def test_github_close_issue_refuses_seated_claim(tmp_path, monkeypatch) -> None:
+    from CortexOS.crew import github as github_mod
+
+    claims = tmp_path / "CLAIMS.json"
+    claims.write_text(
+        '{"tickets":[{"ticket":"Netie-AI/Cortex#128","owner_pr":"Netie-AI/Cortex#128","role":"SEATED"}]}',
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("CREW_CLAIMS", str(claims))
+    called = {"n": 0}
+
+    def runner(argv, timeout=20):  # noqa: ANN001, ARG001
+        called["n"] += 1
+        raise AssertionError("gh must not run for a SEATED ticket")
+
+    out = github_mod.close_issue("Netie-AI/Cortex#128", runner=runner)
+    assert out["ok"] is False
+    assert "SEATED" in out["detail"]
+    assert called["n"] == 0
+
+
 def test_inbox_without_creds_tells_operator_to_drop(monkeypatch) -> None:
     from CortexOS.crew import inbox as inbox_mod
 

--- a/tests/test_crew/test_server.py
+++ b/tests/test_crew/test_server.py
@@ -101,6 +101,9 @@ def test_ui_index_is_served(client) -> None:
     assert "Crew owns leases" in page.text
     assert "Control display-only" in page.text
     assert "Recall payloads are untrusted" in page.text
+    assert "Close GitHub issue" in page.text
+    assert "Keep open" in page.text
+    assert "Crew does not merge PRs" in page.text
     assert "facts.md" in page.text
     assert 'id="memSave"' in page.text
     assert 'id="memExport"' in page.text

--- a/tests/test_crew/test_server.py
+++ b/tests/test_crew/test_server.py
@@ -312,7 +312,7 @@ def test_operator_can_choose_runtime_backend(client) -> None:
 def test_commands_autocomplete_and_mention_targets(client) -> None:
     body = client.http.get("/crew/commands").json()
     slashes = {c["slash"] for c in body["commands"]}
-    assert {"desk", "board", "estate", "ship_gate", "spawn", "kill"} <= slashes
+    assert {"desk", "board", "estate", "ship_gate", "spawn", "kill", "done"} <= slashes
     assert any(c["kind"] == "skill" and c["slash"] == "build" for c in body["commands"])
     assert any(c["kind"] == "routine" for c in body["commands"])
     names = {m["name"] for m in body["mentions"]}


### PR DESCRIPTION
## Summary
- `/done owner/repo#n` opens HITL. Approve runs `gh issue close` only.
- SEATED CLAIMS tickets are refused so Crew does not steal a Ticket Runner seat. Never merges PRs.

## Test plan
- [x] `python -m pytest tests/test_crew -q` (186 passed)
- [ ] Live `/done Netie-AI/Cortex#128` names SEATED and does not call gh
