### PR TITLE
Crew: /fetch open issues and /assign teammate locally (#160)

### DIFF
--- a/CortexOS/crew/assign.py
+++ b/CortexOS/crew/assign.py
@@ -1,0 +1,123 @@
+"""Crew-local ticket binds. Not CLAIMS seating. Not GitHub assignees.
+
+Control GET-displays these on the belt. Crew executes via /assign -> teammate
+goal. Ticket Runner still owns CLAIMS.json.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+from CortexOS.crew import github as github_mod
+
+_FILE = "assignments.json"
+_CAP = 80
+
+
+def _path(data_dir: Path) -> Path:
+    return data_dir / _FILE
+
+
+def load(data_dir: Path) -> list[dict[str, Any]]:
+    path = _path(data_dir)
+    if not path.is_file():
+        return []
+    try:
+        blob = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, ValueError):
+        return []
+    rows = blob if isinstance(blob, list) else blob.get("assignments") if isinstance(blob, dict) else []
+    out: list[dict[str, Any]] = []
+    for row in rows or []:
+        if isinstance(row, dict) and str(row.get("spec") or "").strip():
+            out.append(row)
+    return out[:_CAP]
+
+
+def save(data_dir: Path, rows: list[dict[str, Any]]) -> None:
+    data_dir.mkdir(parents=True, exist_ok=True)
+    _path(data_dir).write_text(
+        json.dumps(rows[:_CAP], ensure_ascii=True, indent=2),
+        encoding="utf-8",
+    )
+
+
+def public(data_dir: Path) -> list[dict[str, Any]]:
+    """Belt JSON. Control must not POST this."""
+    out: list[dict[str, Any]] = []
+    for row in load(data_dir):
+        spec = str(row.get("spec") or "").strip()
+        out.append(
+            {
+                "spec": spec,
+                "agent": str(row.get("agent") or ""),
+                "space_id": str(row.get("space_id") or ""),
+                "title": str(row.get("title") or spec),
+                "ready": github_mod.seated_claim(spec) is None,
+            }
+        )
+    return out
+
+
+def bind(
+    data_dir: Path,
+    *,
+    space_id: str,
+    spec: str,
+    agent_id: str,
+    agent_name: str,
+    title: str = "",
+) -> dict[str, Any]:
+    parsed = github_mod.parse_issue_spec(spec)
+    if parsed is None:
+        return {
+            "ok": False,
+            "detail": "DENIED: /assign owner/repo#n | Name",
+        }
+    seated = github_mod.seated_claim(spec)
+    if seated is not None:
+        return {
+            "ok": False,
+            "detail": (
+                f"DENIED: {seated.get('ticket')} is SEATED "
+                f"({seated.get('owner_pr')}). Ticket Runner owns the seat. "
+                "Crew does not steal it."
+            ),
+        }
+    who = (agent_name or "").strip()
+    if not who or who.lower() == "manager":
+        return {
+            "ok": False,
+            "detail": "DENIED: assign a teammate, not Manager",
+        }
+    canon = github_mod.canonical_spec(spec)
+    rows = [r for r in load(data_dir) if str(r.get("spec") or "") != canon]
+    row = {
+        "spec": canon,
+        "space_id": space_id,
+        "agent_id": agent_id,
+        "agent": who,
+        "title": (title or canon).strip()[:200],
+    }
+    rows.append(row)
+    save(data_dir, rows)
+    return {
+        "ok": True,
+        "spec": canon,
+        "agent": who,
+        "agent_id": agent_id,
+        "title": row["title"],
+        "law": (
+            "Local bind only. Did not write CLAIMS.json. Did not set a GitHub assignee."
+        ),
+    }
+
+
+def release(data_dir: Path, spec: str) -> None:
+    canon = github_mod.canonical_spec(spec)
+    if not canon:
+        return
+    keep = [r for r in load(data_dir) if str(r.get("spec") or "") != canon]
+    save(data_dir, keep)

--- a/CortexOS/crew/commands.py
+++ b/CortexOS/crew/commands.py
@@ -63,6 +63,22 @@ _DESK: tuple[dict[str, Any], ...] = (
         "title": "Close issue (HITL)",
         "hint": "/done owner/repo#n | comment. Refuses SEATED claims. Never merges.",
     },
+    {
+        "slash": "fetch",
+        "aliases": ("issues",),
+        "kind": "desk",
+        "action": "fetch_issues",
+        "title": "Fetch open issues",
+        "hint": "Open GitHub issues for CLAIMS repos. Marks SEATED. Control does not assign.",
+    },
+    {
+        "slash": "assign",
+        "aliases": ("give",),
+        "kind": "desk",
+        "action": "assign_issue",
+        "title": "Assign teammate (local)",
+        "hint": "/assign owner/repo#n | Name. Local goal bind. Refuses SEATED. No GitHub assignee.",
+    },
 )
 
 _LIFE: tuple[dict[str, Any], ...] = (

--- a/CortexOS/crew/github.py
+++ b/CortexOS/crew/github.py
@@ -18,6 +18,14 @@ def _run(argv: list[str], timeout: float = 20.0) -> subprocess.CompletedProcess[
     return subprocess.run(argv, capture_output=True, text=True, timeout=timeout)
 
 
+def _gh_wait_s() -> float:
+    raw = os.environ.get("CREW_GH_WAIT_S", "1.5")
+    try:
+        return max(0.4, min(8.0, float(raw)))
+    except ValueError:
+        return 1.5
+
+
 def available(*, runner: RunFn | None = None) -> bool:
     if os.environ.get("CREW_LIVE_PROBES", "1") == "0":
         return False
@@ -208,6 +216,135 @@ def seated_claim(raw: str) -> dict[str, Any] | None:
         if ticket == key or owner_pr == key:
             return row
     return None
+
+
+def issue_spec(repo: str, number: Any, url: str = "") -> str:
+    if repo and number is not None:
+        try:
+            return f"{repo}#{int(number)}"
+        except (TypeError, ValueError):
+            pass
+    parsed = parse_issue_spec((url or "").strip())
+    if parsed is None:
+        return ""
+    owner, name, n = parsed
+    return f"{owner}/{name}#{n}"
+
+
+def issue_title(spec: str, *, runner: RunFn | None = None) -> str:
+    """Read-only title. Empty string when gh cannot answer."""
+    parsed = parse_issue_spec(spec)
+    if parsed is None:
+        return ""
+    if os.environ.get("CREW_LIVE_PROBES", "1") == "0":
+        return canonical_spec(spec)
+    owner, repo, number = parsed
+    run = runner or _run
+    argv = [
+        "gh",
+        "issue",
+        "view",
+        str(number),
+        "--repo",
+        f"{owner}/{repo}",
+        "--json",
+        "title",
+    ]
+    try:
+        result = run(argv, timeout=_gh_wait_s())
+    except (FileNotFoundError, OSError, subprocess.TimeoutExpired):
+        return canonical_spec(spec)
+    if result.returncode != 0:
+        return canonical_spec(spec)
+    try:
+        blob = json.loads(result.stdout or "{}")
+    except ValueError:
+        return canonical_spec(spec)
+    title = str(blob.get("title") or "").strip() if isinstance(blob, dict) else ""
+    return title or canonical_spec(spec)
+
+
+def list_open_issues(limit: int = 20, *, runner: RunFn | None = None) -> dict[str, Any]:
+    """Open GitHub *issues* for CLAIMS repos. Marks SEATED. Never assigns on GitHub."""
+    law = (
+        "Crew /assign binds a teammate locally. Ticket Runner seats CLAIMS. "
+        "Control does not assign. Crew does not set GitHub assignees."
+    )
+    if os.environ.get("CREW_LIVE_PROBES", "1") == "0":
+        return {
+            "ok": False,
+            "detail": "CREW_LIVE_PROBES=0",
+            "issues": [],
+            "repos": [],
+            "law": law,
+        }
+    run = runner or _run
+    repos = _repos()
+    issues: list[dict[str, Any]] = []
+    errors: list[str] = []
+    wait = _gh_wait_s()
+    targets = repos or [""]
+    for repo in targets:
+        argv = [
+            "gh",
+            "issue",
+            "list",
+            "--state",
+            "open",
+            "--limit",
+            str(limit),
+            "--json",
+            "number,title,url,updatedAt",
+        ]
+        if repo:
+            argv.extend(["--repo", repo])
+        try:
+            result = run(argv, timeout=wait)
+        except FileNotFoundError:
+            return {
+                "ok": False,
+                "detail": "gh not installed",
+                "issues": [],
+                "repos": repos,
+                "law": law,
+            }
+        except (OSError, subprocess.TimeoutExpired) as exc:
+            errors.append(f"{repo or 'cwd'}:{type(exc).__name__}")
+            continue
+        if result.returncode != 0:
+            errors.append((result.stderr or result.stdout or "gh failed")[:200])
+            continue
+        try:
+            rows = json.loads(result.stdout or "[]")
+        except ValueError:
+            errors.append(f"{repo or 'cwd'}: invalid json")
+            continue
+        for row in rows if isinstance(rows, list) else []:
+            if not isinstance(row, dict):
+                continue
+            spec = issue_spec(str(repo or ""), row.get("number"), str(row.get("url") or ""))
+            if not spec:
+                continue
+            seated = seated_claim(spec)
+            issues.append(
+                {
+                    "spec": spec,
+                    "repo": repo or spec.rsplit("#", 1)[0],
+                    "number": row.get("number"),
+                    "title": row.get("title") or "",
+                    "url": row.get("url") or "",
+                    "updated": row.get("updatedAt") or "",
+                    "seated": seated is not None,
+                    "ready": seated is None,
+                }
+            )
+    return {
+        "ok": not errors or bool(issues),
+        "detail": "; ".join(errors)[:400] if errors else "",
+        "issues": issues[:80],
+        "repos": repos,
+        "law": law,
+    }
 
 
 def close_issue(

--- a/CortexOS/crew/runtime.py
+++ b/CortexOS/crew/runtime.py
@@ -207,7 +207,7 @@ class CrewRuntime:
         self.bus.emit(space_id, "message", {"message": msg})
 
         if parsed.command and parsed.command.get("kind") == "desk":
-            self._run_slash_desk(space_id, manager, parsed.command, parsed.rest)
+            await self._run_slash_desk(space_id, manager, parsed.command, parsed.rest)
         elif parsed.command and parsed.command.get("kind") == "memory":
             self._run_slash_memory(space_id, manager, parsed.command, parsed.rest)
         elif parsed.command and parsed.command.get("kind") == "life":
@@ -236,7 +236,17 @@ class CrewRuntime:
             and parsed.command.get("action") == "close_issue"
             and not parsed.mentions
         )
-        if desk_only or memory_only or life_only or close_only:
+        fetch_only = bool(
+            parsed.command
+            and parsed.command.get("action") == "fetch_issues"
+            and not parsed.mentions
+        )
+        assign_only = bool(
+            parsed.command
+            and parsed.command.get("action") == "assign_issue"
+            and not parsed.mentions
+        )
+        if desk_only or memory_only or life_only or close_only or fetch_only or assign_only:
             return {"ok": True, "command": parsed.command.get("slash"), "run_id": None}
 
         turn_provider = (provider or "").strip() or None
@@ -327,7 +337,7 @@ class CrewRuntime:
         if ctx is not None and target is not None and target["id"] != manager["id"]:
             self._wake_if_idle(ctx, target)
 
-    def _run_slash_desk(
+    async def _run_slash_desk(
         self,
         space_id: str,
         manager: dict[str, Any],
@@ -403,6 +413,24 @@ class CrewRuntime:
                     f"HITL pending {confirm['id']}: Approve to close {canon}. "
                     "Crew does not merge PRs."
                 )
+        elif action == "fetch_issues":
+            from CortexOS.crew import github as github_mod
+
+            fetched = github_mod.list_open_issues()
+            lines = [
+                f"{len(fetched.get('issues') or [])} open issues. {fetched.get('law')}"
+            ]
+            if fetched.get("detail"):
+                lines.append(str(fetched["detail"]))
+            for item in (fetched.get("issues") or [])[:30]:
+                mark = "SEATED" if item.get("seated") else "ready"
+                lines.append(
+                    f"- {item.get('spec')} {mark} {item.get('title')}"
+                )
+            text = "\n".join(lines)
+            args = {"repos": fetched.get("repos") or []}
+        elif action == "assign_issue":
+            text, args = await self._assign_issue_slash(space_id, rest)
         else:
             text = f"Unknown desk action {action}"
         msg = self.store.add_message(
@@ -419,6 +447,78 @@ class CrewRuntime:
             },
         )
         self.bus.emit(space_id, "message", {"message": msg})
+
+    async def _assign_issue_slash(
+        self, space_id: str, rest: str
+    ) -> tuple[str, dict[str, Any]]:
+        from CortexOS.crew import assign as assign_mod
+        from CortexOS.crew import github as github_mod
+
+        bits = [p.strip() for p in rest.split("|")]
+        spec = bits[0] if bits else ""
+        agent_name = bits[1] if len(bits) > 1 else ""
+        args: dict[str, Any] = {"spec": spec, "name": agent_name}
+        parsed = github_mod.parse_issue_spec(spec)
+        if parsed is None or not agent_name:
+            return "DENIED: /assign owner/repo#n | Name", args
+        seated = github_mod.seated_claim(spec)
+        if seated is not None:
+            return (
+                f"DENIED: {seated.get('ticket')} is SEATED "
+                f"({seated.get('owner_pr')}). Ticket Runner owns the seat. "
+                "Crew does not steal it.",
+                args,
+            )
+        if agent_name.lower() == "manager":
+            return "DENIED: assign a teammate, not Manager", args
+        canon = github_mod.canonical_spec(spec)
+        title = github_mod.issue_title(canon)
+        goal = (
+            f"{canon}: {title}. Execute this issue. Close with /done after verify. "
+            "Do not steal SEATED seats. Do not merge PRs."
+        )
+        row = self.store.get_agent_by_name(space_id, agent_name)
+        if row is None:
+            spawned = await self.operator_spawn(
+                space_id,
+                {
+                    "name": agent_name,
+                    "mode": life.MODE_GOAL,
+                    "goal": goal,
+                    "brief": canon,
+                },
+            )
+            if spawned.get("error"):
+                return str(spawned["error"]), args
+            row = spawned.get("agent")
+        elif row.get("name") == "Manager":
+            return "DENIED: assign a teammate, not Manager", args
+        elif not life.can_accept(row):
+            return f"DENIED: {life.dead_reason(row)}", args
+        else:
+            updated = self.set_agent_mode(row["id"], life.MODE_GOAL, goal_text=goal)
+            row = updated or row
+        if not isinstance(row, dict) or not row.get("id"):
+            return "DENIED: spawn failed", args
+        bound = assign_mod.bind(
+            self.settings.data_dir,
+            space_id=space_id,
+            spec=canon,
+            agent_id=str(row["id"]),
+            agent_name=str(row.get("name") or agent_name),
+            title=title or canon,
+        )
+        args = {
+            "spec": canon,
+            "name": row.get("name"),
+            "agent_id": row.get("id"),
+        }
+        if not bound.get("ok"):
+            return str(bound.get("detail") or "DENIED: assign failed"), args
+        return (
+            f"Assigned {canon} to {row.get('name')} mode=goal. {bound.get('law')}",
+            args,
+        )
 
     def _run_slash_memory(
         self,
@@ -666,6 +766,9 @@ class CrewRuntime:
         text = result.get("detail") or ("closed " + spec if result.get("ok") else "close failed")
         if result.get("ok"):
             text = f"Closed {result.get('spec')}. {result.get('law')}"
+            from CortexOS.crew.assign import release as release_bind
+
+            release_bind(self.settings.data_dir, spec)
         else:
             text = f"DENIED: {text}"
         msg = self.store.add_message(

--- a/CortexOS/crew/server.py
+++ b/CortexOS/crew/server.py
@@ -107,11 +107,14 @@ class CrewApp:
         return a2a.hud(self.store.list_messages(space_id), pending)
 
     def belt(self) -> dict[str, Any]:
+        from CortexOS.crew.assign import public as assignment_public
+
         return conveyor(
             self.store,
             self.wakes,
             self.queue,
             mailbox_nonempty=self.mailbox_nonempty(),
+            assignments=assignment_public(self.settings.data_dir),
         )
 
     async def startup(self) -> None:

--- a/CortexOS/crew/wakes.py
+++ b/CortexOS/crew/wakes.py
@@ -85,6 +85,7 @@ def conveyor(
     queue: JobQueue,
     *,
     mailbox_nonempty: bool = False,
+    assignments: list[dict[str, Any]] | None = None,
 ) -> dict[str, Any]:
     """Display JSON for ``GET /v1/belt`` and ``GET /crew/belt``.
 
@@ -119,5 +120,10 @@ def conveyor(
         "confirms": [{"id": c["id"]} for c in confirms],
         "spaces": [{"id": s["id"]} for s in spaces],
         "agents": [{"id": a["id"], "name": a["name"]} for a in agents],
+        "assignments": list(assignments or []),
+        "assign_owner": (
+            "Crew /assign (local bind). CLAIMS seating is Ticket Runner. "
+            "Control does not assign."
+        ),
         "converse": True,
     }

--- a/docs/subagents_findings/2026-09-04_crew-assign-fetch.md
+++ b/docs/subagents_findings/2026-09-04_crew-assign-fetch.md
@@ -1,0 +1,11 @@
+# Crew /fetch and /assign (local bind)
+
+- **Date:** 2026-09-04
+- **Keywords:** crew, assign, fetch, belt, seated, f-0030, epic-116, issue-160
+- **Main idea:** Crew fetches open GitHub issues and binds an unseated ticket to a teammate goal. Control still display-only. CLAIMS seating stays Ticket Runner. No GitHub assignee write.
+- **Verify:** `cd D:\Cortex-wt\crew-facts` then `D:\Cortex\.venv\Scripts\python.exe -m pytest tests/test_crew/test_commands.py tests/test_crew/test_wakes.py tests/test_crew/test_connectors_import.py tests/test_crew/test_server.py -q`
+- **Does not prove:** live `:8020` has `/assign` until founder restart; CLAIMS-seated tickets were closed (they must not be).
+
+## Golden rule
+
+Control GET `/v1/belt` may show `assignments`. POST assign on Control stays not-200. `/assign` refuses SEATED. `/done` HITL still closes only unseated issues and drops the local bind.

--- a/docs/subagents_findings/INDEX.md
+++ b/docs/subagents_findings/INDEX.md
@@ -2,6 +2,7 @@
 
 | Date | Topic | Keywords | Main idea | Path |
 |------|-------|----------|-----------|------|
+| 2026-09-04 | crew-assign-fetch | crew, assign, fetch, belt, seated, f-0030, issue-160 | Crew /fetch lists open GH issues; /assign binds unseated to a teammate goal. Control display-only. No CLAIMS/GitHub assignee write. | `2026-09-04_crew-assign-fetch.md` |
 | 2026-09-04 | crew-facts-md-hud | crew, facts.md, memory, epic-116, hud, clear-chat | EPIC-CREW-01 leftover was facts.md not on main. Landed durable markdown memory on cursor/crew-facts-md-116. | `2026-09-04_crew-facts-md-hud.md` |
 | 2026-09-04 | c7-l1-yaml-synonyms | metrics.yaml, synonyms, sellers, cost_by_destination, G-lat, leftover-filler | Longest declared synonym is L1 fallback after the regex cascade. Nested phrases with leftover content are skipped. Freight/shipping cost by destination is cost, not count. | `2026-09-04_c7-l1-yaml-synonyms.md` |
 | 2026-09-04 | c7-05-gsh-and-leave-gate | C7-05, G-sh, DMS_L2_SHADOW, leave, GateCheckBody, ANS-01 | OV gate action is `leave` not `llm`. Shadow report compares L1-only vs L2-only. `and also show` stays L1. | `2026-09-04_c7-05-gsh-and-leave-gate.md` |

--- a/tests/test_crew/test_commands.py
+++ b/tests/test_crew/test_commands.py
@@ -33,6 +33,8 @@ def test_catalog_lists_desk_routines_and_skills(settings) -> None:
         "wait",
         "goal",
         "done",
+        "fetch",
+        "assign",
         "remember",
         "memory",
         "recall",
@@ -205,6 +207,92 @@ async def test_slash_done_refuses_seated_and_hitl_closes_unseated(
     assert denied.get("run_id") is None
     bad = [m for m in rig.store.list_messages(space["id"]) if m["role"] == "tool"][-1]
     assert "DENIED" in bad["content"]
+    assert not rig.runtime._space_run.get(space["id"])
+
+
+@pytest.mark.asyncio
+async def test_slash_fetch_and_assign_refuse_seated_and_bind_ready(
+    rig, tmp_path, monkeypatch
+) -> None:
+    from CortexOS.crew import github as github_mod
+
+    claims = tmp_path / "CLAIMS.json"
+    claims.write_text(
+        '{"tickets":[{"ticket":"Netie-AI/Cortex#128","owner_pr":"Netie-AI/Cortex#128","role":"SEATED"}]}',
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("CREW_CLAIMS", str(claims))
+    monkeypatch.setattr(
+        github_mod,
+        "list_open_issues",
+        lambda **_k: {
+            "ok": True,
+            "detail": "",
+            "repos": ["Netie-AI/Cortex"],
+            "law": "Crew /assign binds a teammate locally.",
+            "issues": [
+                {
+                    "spec": "Netie-AI/Cortex#128",
+                    "title": "seated",
+                    "seated": True,
+                    "ready": False,
+                },
+                {
+                    "spec": "Netie-AI/Cortex#160",
+                    "title": "assign slice",
+                    "seated": False,
+                    "ready": True,
+                },
+            ],
+        },
+    )
+    monkeypatch.setattr(github_mod, "issue_title", lambda spec, **_k: spec)
+    space = rig.store.create_space("HQ")
+    fetched = await rig.runtime.on_user_message(space["id"], "/fetch")
+    assert fetched.get("run_id") is None
+    tool = [m for m in rig.store.list_messages(space["id"]) if m["role"] == "tool"][-1]
+    assert "Netie-AI/Cortex#160" in tool["content"]
+    assert "SEATED" in tool["content"]
+    seated = await rig.runtime.on_user_message(
+        space["id"], "/assign Netie-AI/Cortex#128 | Scout"
+    )
+    assert seated.get("run_id") is None
+    deny = [m for m in rig.store.list_messages(space["id"]) if m["role"] == "tool"][-1]
+    assert "SEATED" in deny["content"]
+    assert rig.store.get_agent_by_name(space["id"], "Scout") is None
+    posted = await rig.runtime.on_user_message(
+        space["id"], "/assign Netie-AI/Cortex#160 | Scout"
+    )
+    assert posted.get("run_id") is None
+    scout = rig.store.get_agent_by_name(space["id"], "Scout")
+    assert scout is not None
+    assert "Netie-AI/Cortex#160" in (scout.get("goal_text") or "")
+    ok = [m for m in rig.store.list_messages(space["id"]) if m["role"] == "tool"][-1]
+    assert "Assigned" in ok["content"] and "Scout" in ok["content"]
+    from CortexOS.crew.assign import public as assignment_public
+
+    rows = assignment_public(rig.settings.data_dir)
+    assert rows[0]["spec"] == "Netie-AI/Cortex#160"
+    assert rows[0]["agent"] == "Scout"
+    pending_done = await rig.runtime.on_user_message(
+        space["id"], "/done Netie-AI/Cortex#160 | verified on desk"
+    )
+    assert pending_done.get("run_id") is None
+    confirms = rig.store.pending_confirms(space["id"])
+    assert confirms[0]["tool"] == "close_issue"
+
+    def fake_close(spec, *, comment="", runner=None):  # noqa: ANN001, ARG001
+        return {
+            "ok": True,
+            "spec": spec,
+            "detail": "Closed",
+            "law": "Closed the issue. Did not merge a PR. Ticket Runner seats writers.",
+        }
+
+    monkeypatch.setattr(github_mod, "close_issue", fake_close)
+    row = rig.runtime.decide_confirm(confirms[0]["id"], True)
+    assert row is not None and row["status"] == "approved"
+    assert assignment_public(rig.settings.data_dir) == []
     assert not rig.runtime._space_run.get(space["id"])
 
 

--- a/tests/test_crew/test_connectors_import.py
+++ b/tests/test_crew/test_connectors_import.py
@@ -184,6 +184,40 @@ def test_github_close_issue_refuses_seated_claim(tmp_path, monkeypatch) -> None:
     assert called["n"] == 0
 
 
+def test_github_list_open_issues_marks_seated(tmp_path, monkeypatch) -> None:
+    from types import SimpleNamespace
+
+    from CortexOS.crew import github as github_mod
+
+    claims = tmp_path / "CLAIMS.json"
+    claims.write_text(
+        '{"tickets":[{"ticket":"Netie-AI/Cortex#128","owner_pr":"Netie-AI/Cortex#128","role":"SEATED"}]}',
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("CREW_CLAIMS", str(claims))
+    monkeypatch.setenv("CREW_LIVE_PROBES", "1")
+    monkeypatch.setenv("CREW_GH_REPOS", "Netie-AI/Cortex")
+    monkeypatch.setenv("CREW_GH_WAIT_S", "1.5")
+
+    def runner(argv, timeout=1.5):  # noqa: ANN001, ARG001
+        assert timeout <= 8.0
+        assert argv[:3] == ["gh", "issue", "list"]
+        payload = (
+            '[{"number":128,"title":"seated","url":'
+            '"https://github.com/Netie-AI/Cortex/issues/128"},'
+            '{"number":160,"title":"assign","url":'
+            '"https://github.com/Netie-AI/Cortex/issues/160"}]'
+        )
+        return SimpleNamespace(returncode=0, stdout=payload, stderr="")
+
+    body = github_mod.list_open_issues(runner=runner)
+    assert body["ok"] is True
+    by_spec = {row["spec"]: row for row in body["issues"]}
+    assert by_spec["Netie-AI/Cortex#128"]["seated"] is True
+    assert by_spec["Netie-AI/Cortex#160"]["ready"] is True
+    assert "does not assign" in body["law"].lower() or "Control does not assign" in body["law"]
+
+
 def test_inbox_without_creds_tells_operator_to_drop(monkeypatch) -> None:
     from CortexOS.crew import inbox as inbox_mod
 

--- a/tests/test_crew/test_server.py
+++ b/tests/test_crew/test_server.py
@@ -254,6 +254,8 @@ def test_belt_and_wakes_are_get_only_and_skip_cortex_ping(client) -> None:
     assert belt["wakes"] == []
     assert belt["queue"] == {"pending": 0, "leased": 0, "done": 0, "dead": 0}
     assert "tickets" in belt and "items" in belt["tickets"]
+    assert belt["assignments"] == []
+    assert "Control does not assign" in belt["assign_owner"]
     assert client.http.post("/crew/wakes", json={"kind": "timer"}).status_code == 405
     assert client.http.post("/v1/belt", json={"wake": "x"}).status_code == 405
     assert client.http.post("/crew/belt", json={"ticket": "x"}).status_code == 405

--- a/tests/test_crew/test_wakes.py
+++ b/tests/test_crew/test_wakes.py
@@ -75,4 +75,6 @@ def test_conveyor_skips_cortex_ping_and_does_not_decide_shape(tmp_path, monkeypa
     assert body["queue"] == {"pending": 0, "leased": 0, "done": 0, "dead": 0}
     assert body["spaces"][0]["id"] == space["id"]
     assert body["agents"][0]["name"] == "Scout"
+    assert body["assignments"] == []
+    assert "Control does not assign" in body["assign_owner"]
     assert "dag_runner" not in body


### PR DESCRIPTION
## Summary
- Crew `/fetch` (alias `/issues`) lists open GitHub issues for CLAIMS/CREW_GH_REPOS and marks SEATED vs ready.
- `/assign owner/repo#n | Name` binds an unseated issue to a teammate `mode=goal` (spawns the name if missing). Refuses CLAIMS SEATED. Does not write CLAIMS.json. Does not set GitHub assignees. Does not merge.
- `GET /v1/belt` adds `assignments` + `assign_owner` so Control can display. Control still does not POST-assign (F-0030).
- `/done` HITL close of an unseated issue drops the local bind.

Closes #160

## Test plan
- [x] `pytest tests/test_crew` (188 passed locally)
- [ ] Live `/crew/commands` includes `fetch` and `assign` after converse restart (do not kill healthy `:8020` from an agent)
- [ ] `/assign Netie-AI/Cortex#128 | Scout` DENIED SEATED
- [ ] Control `GET /v1/belt` 200 `display_only`; POST `/v1/run` still 405
