### PR TITLE
Crew: HUD Claim/Release is local /assign, not CLAIMS seating (#162)

### DIFF
--- a/CortexOS/crew/server.py
+++ b/CortexOS/crew/server.py
@@ -217,6 +217,12 @@ class KeysIn(BaseModel):
     keys: dict[str, str | None]
 
 
+class TicketAssignIn(BaseModel):
+    spec: str
+    space_id: str
+    name: str = "Ticket"
+
+
 def build_router(crew: CrewApp) -> APIRouter:
     router = APIRouter(prefix="/crew")
 
@@ -637,9 +643,51 @@ def build_router(crew: CrewApp) -> APIRouter:
 
     @router.get("/tickets")
     async def list_tickets() -> dict[str, Any]:
+        from CortexOS.crew.assign import public as assignment_public
         from CortexOS.crew.board import snapshot
 
-        return snapshot()
+        body = snapshot()
+        body["assignments"] = assignment_public(crew.settings.data_dir)
+        return body
+
+    @router.post("/tickets/claim")
+    async def claim_ticket(body: TicketAssignIn) -> dict[str, Any]:
+        """Local /assign bind. Does not write CLAIMS.json. Does not seat Ticket Runner."""
+        if crew.store.get_space(body.space_id) is None:
+            raise HTTPException(404, "unknown space")
+        rest = f"{body.spec.strip()} | {body.name.strip() or 'Ticket'}"
+        text, args = await crew.runtime._assign_issue_slash(body.space_id, rest)
+        if text.startswith("DENIED"):
+            code = 409 if "SEATED" in text else 400
+            raise HTTPException(code, text)
+        return {
+            "ok": True,
+            "detail": text,
+            "args": args,
+            "law": "Local bind. Did not write CLAIMS.json. Did not set a GitHub assignee.",
+        }
+
+    @router.post("/tickets/release")
+    async def release_ticket(body: TicketAssignIn) -> dict[str, Any]:
+        """Drop a Crew-local bind. Never edits CLAIMS.json."""
+        from CortexOS.crew import github as github_mod
+        from CortexOS.crew.assign import release as release_bind
+
+        seated = github_mod.seated_claim(body.spec)
+        if seated is not None:
+            raise HTTPException(
+                409,
+                (
+                    f"DENIED: {seated.get('ticket')} is SEATED "
+                    f"({seated.get('owner_pr')}). Ticket Runner owns the seat."
+                ),
+            )
+        release_bind(crew.settings.data_dir, body.spec)
+        return {
+            "ok": True,
+            "spec": github_mod.canonical_spec(body.spec),
+            "law": "Released local bind. Did not edit CLAIMS.json.",
+        }
 
     @router.get("/desk")
     async def desk() -> dict[str, Any]:

--- a/CortexOS/crew/ui/index.html
+++ b/CortexOS/crew/ui/index.html
@@ -92,7 +92,8 @@
         <div id="ticketPane" hidden>
           <div class="block">
             <h2>Work - Tickets</h2>
-            <div id="tickets" class="empty">loading...</div>
+            <p class="hint">Claim is Crew /assign (local). Ticket Runner seats CLAIMS. Control does not assign.</p>
+            <div id="tickets" class="empty">unread</div>
           </div>
         </div>
         <div class="block">
@@ -854,21 +855,38 @@
       ).join("");
     }
     function renderTickets(board) {
+      const assigns = (board && board.assignments) || [];
+      const held = {};
+      assigns.forEach((a) => { if (a && a.spec) held[a.spec] = a; });
+      const assignBlock = assigns.length
+        ? assigns.slice(0, 12).map((a) =>
+            `<div class="row">${esc(a.spec)} <span class="claim">${esc(a.agent || "")}</span>`
+            + `<small>${esc(a.title || "")}</small></div>`
+          ).join("")
+        : `<div class="empty">assignments none. Claim or /assign binds a teammate. Control does not assign.</div>`;
       if (!board || !board.tickets || !board.tickets.length) {
-        $("tickets").innerHTML = `<div class="empty empty--orb">${esc((board && board.law) || "No CLAIMS.json")}</div>`;
+        $("tickets").innerHTML = assignBlock
+          + `<div class="empty empty--orb">${esc((board && board.law) || "CLAIMS unread")}</div>`;
         return;
       }
-      $("tickets").innerHTML = `<div class="empty">${esc(board.seated + " seated / " + board.unseated + " unseated. " + (board.law || ""))}</div>` +
-        board.tickets.slice(0, 12).map((t) => {
+      $("tickets").innerHTML = assignBlock
+        + `<div class="empty">${esc(board.seated + " seated / " + board.unseated + " unseated. " + (board.law || ""))}</div>`
+        + board.tickets.slice(0, 12).map((t) => {
           const seated = t.role === "SEATED";
-          const label = seated ? "claimed" : "unclaimed";
           const key = String(t.ticket || "");
-          return `<div class="row">${esc(key)} <span class="claim ${seated ? "" : "unclaimed"}">${label}</span>`
+          const mine = held[key];
+          const label = seated ? "SEATED" : (mine ? ("assigned " + (mine.agent || "")) : "unseated");
+          const actions = seated
+            ? `<small>Ticket Runner owns the seat. Crew does not steal it.</small>`
+            : (`<div class="row-actions">`
+              + (mine
+                ? `<button class="ghost" type="button" data-release="${esc(key)}">Release</button>`
+                : `<button class="ghost" type="button" data-claim="${esc(key)}">Claim</button>`)
+              + `</div>`);
+          return `<div class="row">${esc(key)} <span class="claim ${seated ? "" : "unclaimed"}">${esc(label)}</span>`
             + `<small><span class="id">${esc(t.owner_pr || "")}</span> ${esc(t.role)} - write=${t.may_write}</small>`
-            + `<div class="row-actions">`
-            + `<button class="ghost" type="button" data-claim="${esc(key)}" ${seated ? "disabled" : ""}>Claim</button>`
-            + `<button class="ghost" type="button" data-release="${esc(key)}" ${seated ? "" : "disabled"}>Release</button>`
-            + `</div></div>`;
+            + actions
+            + `</div>`;
         }).join("");
       $("tickets").querySelectorAll("[data-claim]").forEach((el) => el.onclick = () => checkoutTicket(el.dataset.claim, "claim"));
       $("tickets").querySelectorAll("[data-release]").forEach((el) => el.onclick = () => checkoutTicket(el.dataset.release, "release"));
@@ -878,20 +896,31 @@
         toast("Claim in flight. No silent retry.", "warn");
         return;
       }
+      if (!state.spaceId) {
+        toast("Open a space first.", "warn");
+        return;
+      }
       state.claimBusy = ticket + ":" + act;
       try {
-        const resp = await fetch("/crew/tickets/" + encodeURIComponent(ticket) + "/" + act, { method: "POST" });
+        const name = (($("spawnName") && $("spawnName").value) || "Ticket").trim() || "Ticket";
+        const resp = await fetch("/crew/tickets/" + act, {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ spec: ticket, space_id: state.spaceId, name: name })
+        });
+        const data = await resp.json().catch(() => ({}));
         if (resp.status === 409) {
-          toast("Someone else holds this claim.", "bad");
+          toast(data.detail || "SEATED. Ticket Runner owns the seat.", "bad");
           return;
         }
         if (!resp.ok) {
-          const data = await resp.json().catch(() => ({}));
           toast((data.detail || ("claim " + resp.status)) + " - no silent retry.", "bad");
           return;
         }
         const board = await api("/crew/tickets").catch(() => null);
         if (board) renderTickets(board);
+        const belt = await api("/v1/belt").catch(() => api("/crew/belt").catch(() => null));
+        if (belt) renderBelt(belt);
       } catch (err) {
         toast(err.message + " - no silent retry.", "bad");
       } finally {
@@ -971,16 +1000,17 @@
       const seated = items.filter((t) => !t.ready).length;
       const held = q.leased || 0;
       const hitl = (b.confirms || []).length;
+      const assigned = (b.assignments || []).length;
       $("workWidget").innerHTML =
         `<div class="work-stats">`
         + `<span>ready <b>${ready}</b></span>`
         + `<span>seated <b>${seated}</b></span>`
+        + `<span>assigned <b>${assigned}</b></span>`
         + `<span>held <b>${held}</b></span>`
         + `<span>HITL pending <b>${hitl}</b></span>`
         + `</div>`;
       const stalls = [];
-      const strandedReady = items.filter((t) => t.ready && !t.repo && !t.title);
-      if (ready && seated === 0) stalls.push("ready work, no assignee");
+      if (ready && seated === 0 && assigned === 0) stalls.push("ready work, no assignee");
       items.forEach((t) => {
         if (t.ready && !(t.number || t.title)) stalls.push("stranded ticket");
       });

--- a/docs/subagents_findings/2026-09-04_crew-ticket-claim.md
+++ b/docs/subagents_findings/2026-09-04_crew-ticket-claim.md
@@ -1,0 +1,7 @@
+# Crew HUD Claim is local /assign
+
+- **Date:** 2026-09-04
+- **Keywords:** crew, claim, release, hud, assign, seated, issue-162
+- **Main idea:** Tickets Claim/Release POSTed routes that 404. Now claim/release are local binds. SEATED is 409. CLAIMS.json untouched. Control still display-only.
+- **Verify:** `D:\Cortex\.venv\Scripts\python.exe -m pytest tests/test_crew/test_server.py::test_ticket_claim_is_local_assign_and_refuses_seated tests/test_crew -q`
+- **Does not prove:** live `:8020` HUD until founder restart; Control HTML paints assignments (other lane has WIP on NetieControl).

--- a/docs/subagents_findings/INDEX.md
+++ b/docs/subagents_findings/INDEX.md
@@ -2,6 +2,7 @@
 
 | Date | Topic | Keywords | Main idea | Path |
 |------|-------|----------|-----------|------|
+| 2026-09-04 | crew-ticket-claim | crew, claim, release, hud, assign, seated, issue-162 | HUD Claim/Release were 404 chrome. Now local /assign bind. SEATED 409. No CLAIMS write. | `2026-09-04_crew-ticket-claim.md` |
 | 2026-09-04 | crew-assign-fetch | crew, assign, fetch, belt, seated, f-0030, issue-160 | Crew /fetch lists open GH issues; /assign binds unseated to a teammate goal. Control display-only. No CLAIMS/GitHub assignee write. | `2026-09-04_crew-assign-fetch.md` |
 | 2026-09-04 | crew-facts-md-hud | crew, facts.md, memory, epic-116, hud, clear-chat | EPIC-CREW-01 leftover was facts.md not on main. Landed durable markdown memory on cursor/crew-facts-md-116. | `2026-09-04_crew-facts-md-hud.md` |
 | 2026-09-04 | c7-l1-yaml-synonyms | metrics.yaml, synonyms, sellers, cost_by_destination, G-lat, leftover-filler | Longest declared synonym is L1 fallback after the regex cascade. Nested phrases with leftover content are skipped. Freight/shipping cost by destination is cost, not count. | `2026-09-04_c7-l1-yaml-synonyms.md` |

--- a/tests/test_crew/test_server.py
+++ b/tests/test_crew/test_server.py
@@ -114,6 +114,7 @@ def test_ui_index_is_served(client) -> None:
     assert "Does not kill Manager" in page.text
     assert "Claim" in page.text
     assert "Release" in page.text
+    assert "Control does not assign" in page.text
     assert 'id="tabWork"' in page.text
     assert 'data-scope="space"' in page.text
     assert 'data-scope="user"' in page.text
@@ -280,6 +281,7 @@ def test_tickets_skills_and_voice(client, tmp_path, monkeypatch) -> None:
     assert board["ok"] is True
     assert board["unseated"] == 1
     assert board["tickets"][0]["ticket"] == "FF-03"
+    assert board["assignments"] == []
     assert "cloud agent" in board["law"]
     saved = client.http.post(
         "/crew/skills", json={"title": "monday-briefing", "body": "Goal:\nDo not spawn a cloud swarm.\n"}
@@ -290,6 +292,63 @@ def test_tickets_skills_and_voice(client, tmp_path, monkeypatch) -> None:
     voice = client.http.get("/crew/voice").json()
     assert voice["available"] is False
     assert "fake speech" in voice["reason"]
+
+
+def test_ticket_claim_is_local_assign_and_refuses_seated(
+    client, tmp_path, monkeypatch
+) -> None:
+    claims = tmp_path / "CLAIMS.json"
+    claims.write_text(
+        '{"tickets":[{"ticket":"Netie-AI/Cortex#128","owner_pr":"Netie-AI/Cortex#128","role":"SEATED"}]}',
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("CREW_CLAIMS", str(claims))
+    space = client.http.post("/crew/spaces", json={"title": "HQ"}).json()
+    seated = client.http.post(
+        "/crew/tickets/claim",
+        json={
+            "spec": "Netie-AI/Cortex#128",
+            "space_id": space["id"],
+            "name": "Scout",
+        },
+    )
+    assert seated.status_code == 409
+    assert "SEATED" in seated.json()["detail"]
+    blocked = client.http.post(
+        "/crew/tickets/release",
+        json={
+            "spec": "Netie-AI/Cortex#128",
+            "space_id": space["id"],
+            "name": "Scout",
+        },
+    )
+    assert blocked.status_code == 409
+    claims.write_text('{"tickets":[]}', encoding="utf-8")
+    ok = client.http.post(
+        "/crew/tickets/claim",
+        json={
+            "spec": "Netie-AI/Cortex#162",
+            "space_id": space["id"],
+            "name": "Scout",
+        },
+    ).json()
+    assert ok["ok"] is True
+    assert "CLAIMS" in ok["law"]
+    board = client.http.get("/crew/tickets").json()
+    assert board["assignments"][0]["spec"] == "Netie-AI/Cortex#162"
+    assert board["assignments"][0]["agent"] == "Scout"
+    belt = client.http.get("/v1/belt").json()
+    assert belt["assignments"][0]["agent"] == "Scout"
+    dropped = client.http.post(
+        "/crew/tickets/release",
+        json={
+            "spec": "Netie-AI/Cortex#162",
+            "space_id": space["id"],
+            "name": "Scout",
+        },
+    ).json()
+    assert dropped["ok"] is True
+    assert client.http.get("/crew/tickets").json()["assignments"] == []
 
 
 def test_operator_can_choose_runtime_backend(client) -> None:


### PR DESCRIPTION
## Summary
- Tickets pane Claim/Release posted routes that 404. That was chrome.
- `POST /crew/tickets/claim` binds like `/assign` (teammate goal). `POST /crew/tickets/release` drops the local bind.
- SEATED is HTTP 409. Does not write CLAIMS.json. Does not set GitHub assignees.
- GET `/crew/tickets` includes `assignments`. HUD paints them. Stall chip ignores ready-with-no-assignee when a local bind exists.

Closes #162

## Test plan
- [x] `pytest tests/test_crew` (189 passed locally)
- [ ] POST claim `Netie-AI/Cortex#128` -> 409 SEATED
- [ ] Control `GET /v1/belt` still display-only; POST `/v1/run` 405
