### PR TITLE
Crew: Tickets HUD lists fetched GitHub issues for Claim (#164)

### DIFF
--- a/CortexOS/crew/server.py
+++ b/CortexOS/crew/server.py
@@ -643,11 +643,34 @@ def build_router(crew: CrewApp) -> APIRouter:
 
     @router.get("/tickets")
     async def list_tickets() -> dict[str, Any]:
+        from CortexOS.crew import github as github_mod
         from CortexOS.crew.assign import public as assignment_public
         from CortexOS.crew.board import snapshot
 
         body = snapshot()
         body["assignments"] = assignment_public(crew.settings.data_dir)
+        claimed = {
+            str(row.get("ticket") or "")
+            for row in (body.get("tickets") or [])
+            if isinstance(row, dict)
+        }
+        claimed.update(
+            str(row.get("owner_pr") or "")
+            for row in (body.get("tickets") or [])
+            if isinstance(row, dict)
+        )
+        fetched = github_mod.list_open_issues()
+        issues = []
+        for row in fetched.get("issues") or []:
+            if not isinstance(row, dict):
+                continue
+            spec = str(row.get("spec") or "")
+            if spec and spec in claimed:
+                continue
+            issues.append(row)
+        body["issues"] = issues
+        body["issues_detail"] = fetched.get("detail") or ""
+        body["issues_ok"] = bool(fetched.get("ok"))
         return body
 
     @router.post("/tickets/claim")

--- a/CortexOS/crew/ui/index.html
+++ b/CortexOS/crew/ui/index.html
@@ -854,6 +854,20 @@
          <div class="${p.connected ? "on" : "empty"}">${p.connected ? "connected" : esc(p.detail || "mapped")}</div></div>`
       ).join("");
     }
+    function ticketRow(key, seated, mine, extra) {
+      const label = seated ? "SEATED" : (mine ? ("assigned " + (mine.agent || "")) : "ready");
+      const actions = seated
+        ? `<small>Ticket Runner owns the seat. Crew does not steal it.</small>`
+        : (`<div class="row-actions">`
+          + (mine
+            ? `<button class="ghost" type="button" data-release="${esc(key)}">Release</button>`
+            : `<button class="ghost" type="button" data-claim="${esc(key)}">Claim</button>`)
+          + `</div>`);
+      return `<div class="row">${esc(key)} <span class="claim ${seated ? "" : "unclaimed"}">${esc(label)}</span>`
+        + `<small>${esc(extra || "")}</small>`
+        + actions
+        + `</div>`;
+    }
     function renderTickets(board) {
       const assigns = (board && board.assignments) || [];
       const held = {};
@@ -864,30 +878,25 @@
             + `<small>${esc(a.title || "")}</small></div>`
           ).join("")
         : `<div class="empty">assignments none. Claim or /assign binds a teammate. Control does not assign.</div>`;
-      if (!board || !board.tickets || !board.tickets.length) {
-        $("tickets").innerHTML = assignBlock
-          + `<div class="empty empty--orb">${esc((board && board.law) || "CLAIMS unread")}</div>`;
-        return;
-      }
-      $("tickets").innerHTML = assignBlock
-        + `<div class="empty">${esc(board.seated + " seated / " + board.unseated + " unseated. " + (board.law || ""))}</div>`
-        + board.tickets.slice(0, 12).map((t) => {
-          const seated = t.role === "SEATED";
-          const key = String(t.ticket || "");
-          const mine = held[key];
-          const label = seated ? "SEATED" : (mine ? ("assigned " + (mine.agent || "")) : "unseated");
-          const actions = seated
-            ? `<small>Ticket Runner owns the seat. Crew does not steal it.</small>`
-            : (`<div class="row-actions">`
-              + (mine
-                ? `<button class="ghost" type="button" data-release="${esc(key)}">Release</button>`
-                : `<button class="ghost" type="button" data-claim="${esc(key)}">Claim</button>`)
-              + `</div>`);
-          return `<div class="row">${esc(key)} <span class="claim ${seated ? "" : "unclaimed"}">${esc(label)}</span>`
-            + `<small><span class="id">${esc(t.owner_pr || "")}</span> ${esc(t.role)} - write=${t.may_write}</small>`
-            + actions
-            + `</div>`;
-        }).join("");
+      const claims = (board && board.tickets) || [];
+      const issues = (board && board.issues) || [];
+      const claimsBlock = claims.length
+        ? `<div class="empty">${esc((board.seated || 0) + " seated / " + (board.unseated || 0) + " unseated. " + (board.law || ""))}</div>`
+          + claims.slice(0, 12).map((t) => {
+            const seated = t.role === "SEATED";
+            const key = String(t.ticket || "");
+            return ticketRow(key, seated, held[key], (t.owner_pr || "") + " " + (t.role || "") + " write=" + t.may_write);
+          }).join("")
+        : `<div class="empty empty--orb">${esc((board && board.law) || "CLAIMS unread")}</div>`;
+      const issueBlock = issues.length
+        ? `<div class="empty">open GitHub ${esc(issues.length)} (CLAIMS specs omitted). ${esc(board.issues_detail || "")}</div>`
+          + issues.slice(0, 20).map((t) => {
+            const seated = !!t.seated;
+            const key = String(t.spec || "");
+            return ticketRow(key, seated, held[key], t.title || "");
+          }).join("")
+        : `<div class="empty">open GitHub none. /fetch or live probes. Control does not assign.</div>`;
+      $("tickets").innerHTML = assignBlock + claimsBlock + issueBlock;
       $("tickets").querySelectorAll("[data-claim]").forEach((el) => el.onclick = () => checkoutTicket(el.dataset.claim, "claim"));
       $("tickets").querySelectorAll("[data-release]").forEach((el) => el.onclick = () => checkoutTicket(el.dataset.release, "release"));
     }

--- a/docs/subagents_findings/2026-09-04_crew-tickets-fetch.md
+++ b/docs/subagents_findings/2026-09-04_crew-tickets-fetch.md
@@ -1,0 +1,7 @@
+# Crew tickets GET includes fetched GitHub issues
+
+- **Date:** 2026-09-04
+- **Keywords:** crew, fetch, tickets, hud, issues, claim, issue-164
+- **Main idea:** Tickets HUD was CLAIMS-only so Claim could not bind ecosystem issues /fetch already listed. GET /crew/tickets now adds `issues` (dedup CLAIMS specs). CREW_LIVE_PROBES=0 stays empty.
+- **Verify:** `D:\Cortex\.venv\Scripts\python.exe -m pytest tests/test_crew/test_server.py::test_tickets_lists_fetched_github_issues_minus_claims tests/test_crew -q`
+- **Does not prove:** live `:8020` HUD until founder restart; Control HTML (WIP on another lane).

--- a/docs/subagents_findings/INDEX.md
+++ b/docs/subagents_findings/INDEX.md
@@ -2,6 +2,7 @@
 
 | Date | Topic | Keywords | Main idea | Path |
 |------|-------|----------|-----------|------|
+| 2026-09-04 | crew-tickets-fetch | crew, fetch, tickets, hud, issues, claim, issue-164 | GET /crew/tickets includes fetched GH issues minus CLAIMS specs so HUD Claim can bind them. | `2026-09-04_crew-tickets-fetch.md` |
 | 2026-09-04 | crew-ticket-claim | crew, claim, release, hud, assign, seated, issue-162 | HUD Claim/Release were 404 chrome. Now local /assign bind. SEATED 409. No CLAIMS write. | `2026-09-04_crew-ticket-claim.md` |
 | 2026-09-04 | crew-assign-fetch | crew, assign, fetch, belt, seated, f-0030, issue-160 | Crew /fetch lists open GH issues; /assign binds unseated to a teammate goal. Control display-only. No CLAIMS/GitHub assignee write. | `2026-09-04_crew-assign-fetch.md` |
 | 2026-09-04 | crew-facts-md-hud | crew, facts.md, memory, epic-116, hud, clear-chat | EPIC-CREW-01 leftover was facts.md not on main. Landed durable markdown memory on cursor/crew-facts-md-116. | `2026-09-04_crew-facts-md-hud.md` |

--- a/tests/test_crew/test_server.py
+++ b/tests/test_crew/test_server.py
@@ -115,6 +115,7 @@ def test_ui_index_is_served(client) -> None:
     assert "Claim" in page.text
     assert "Release" in page.text
     assert "Control does not assign" in page.text
+    assert "open GitHub" in page.text
     assert 'id="tabWork"' in page.text
     assert 'data-scope="space"' in page.text
     assert 'data-scope="user"' in page.text
@@ -282,6 +283,8 @@ def test_tickets_skills_and_voice(client, tmp_path, monkeypatch) -> None:
     assert board["unseated"] == 1
     assert board["tickets"][0]["ticket"] == "FF-03"
     assert board["assignments"] == []
+    assert board["issues"] == []
+    assert board["issues_ok"] is False
     assert "cloud agent" in board["law"]
     saved = client.http.post(
         "/crew/skills", json={"title": "monday-briefing", "body": "Goal:\nDo not spawn a cloud swarm.\n"}
@@ -349,6 +352,47 @@ def test_ticket_claim_is_local_assign_and_refuses_seated(
     ).json()
     assert dropped["ok"] is True
     assert client.http.get("/crew/tickets").json()["assignments"] == []
+
+
+def test_tickets_lists_fetched_github_issues_minus_claims(
+    client, tmp_path, monkeypatch
+) -> None:
+    from CortexOS.crew import github as github_mod
+
+    claims = tmp_path / "CLAIMS.json"
+    claims.write_text(
+        '{"tickets":[{"ticket":"Netie-AI/Cortex#128","owner_pr":"Netie-AI/Cortex#128","role":"SEATED"}]}',
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("CREW_CLAIMS", str(claims))
+    monkeypatch.setattr(
+        github_mod,
+        "list_open_issues",
+        lambda **_k: {
+            "ok": True,
+            "detail": "",
+            "issues": [
+                {
+                    "spec": "Netie-AI/Cortex#128",
+                    "title": "seated",
+                    "seated": True,
+                    "ready": False,
+                },
+                {
+                    "spec": "Netie-AI/Cortex#164",
+                    "title": "fetch hud",
+                    "seated": False,
+                    "ready": True,
+                },
+            ],
+        },
+    )
+    board = client.http.get("/crew/tickets").json()
+    specs = [row["spec"] for row in board["issues"]]
+    assert "Netie-AI/Cortex#128" not in specs
+    assert board["issues"][0]["spec"] == "Netie-AI/Cortex#164"
+    assert board["issues"][0]["ready"] is True
+    assert board["issues_ok"] is True
 
 
 def test_operator_can_choose_runtime_backend(client) -> None:


### PR DESCRIPTION
## Summary
- GET `/crew/tickets` now includes `issues` from `github.list_open_issues`. CLAIMS specs are omitted so rows are not doubled.
- `CREW_LIVE_PROBES=0` keeps `issues=[]` (tests do not hang on `gh`).
- Tickets HUD lists those rows. ready -> Claim (local `/assign`). SEATED -> no steal.
- Control stays display-only. No CLAIMS write. No GitHub assignee.

Closes #164

## Test plan
- [x] `pytest tests/test_crew` (190 passed locally)
- [ ] Live GET `/crew/tickets` has `issues` when probes on
- [ ] POST claim of a SEATED spec still 409
