### PR TITLE
Crew: /assign starts teammate run after local bind

### DIFF
--- a/CortexOS/crew/assign.py
+++ b/CortexOS/crew/assign.py
@@ -1,7 +1,7 @@
 """Crew-local ticket binds. Not CLAIMS seating. Not GitHub assignees.
 
-Control GET-displays these on the belt. Crew executes via /assign -> teammate
-goal. Ticket Runner still owns CLAIMS.json.
+Control GET-displays these on the belt. Crew executes via /assign: local bind,
+then A2A brief + a run. Ticket Runner still owns CLAIMS.json.
 """
 
 from __future__ import annotations

--- a/CortexOS/crew/commands.py
+++ b/CortexOS/crew/commands.py
@@ -77,7 +77,7 @@ _DESK: tuple[dict[str, Any], ...] = (
         "kind": "desk",
         "action": "assign_issue",
         "title": "Assign teammate (local)",
-        "hint": "/assign owner/repo#n | Name. Local goal bind. Refuses SEATED. No GitHub assignee.",
+        "hint": "/assign owner/repo#n | Name. Local bind then teammate run. Refuses SEATED. No GitHub assignee.",
     },
 )
 

--- a/CortexOS/crew/runtime.py
+++ b/CortexOS/crew/runtime.py
@@ -206,8 +206,11 @@ class CrewRuntime:
         )
         self.bus.emit(space_id, "message", {"message": msg})
 
+        desk_run_id: str | None = None
         if parsed.command and parsed.command.get("kind") == "desk":
-            await self._run_slash_desk(space_id, manager, parsed.command, parsed.rest)
+            desk_run_id = await self._run_slash_desk(
+                space_id, manager, parsed.command, parsed.rest
+            )
         elif parsed.command and parsed.command.get("kind") == "memory":
             self._run_slash_memory(space_id, manager, parsed.command, parsed.rest)
         elif parsed.command and parsed.command.get("kind") == "life":
@@ -246,8 +249,14 @@ class CrewRuntime:
             and parsed.command.get("action") == "assign_issue"
             and not parsed.mentions
         )
-        if desk_only or memory_only or life_only or close_only or fetch_only or assign_only:
+        if desk_only or memory_only or life_only or close_only or fetch_only:
             return {"ok": True, "command": parsed.command.get("slash"), "run_id": None}
+        if assign_only:
+            return {
+                "ok": True,
+                "command": parsed.command.get("slash"),
+                "run_id": desk_run_id,
+            }
 
         turn_provider = (provider or "").strip() or None
         turn_model = (model or "").strip() or None
@@ -343,7 +352,7 @@ class CrewRuntime:
         manager: dict[str, Any],
         command: dict[str, Any],
         rest: str,
-    ) -> None:
+    ) -> str | None:
         action = str(command.get("action") or "")
         text = ""
         args: dict[str, Any] = {}
@@ -447,6 +456,10 @@ class CrewRuntime:
             },
         )
         self.bus.emit(space_id, "message", {"message": msg})
+        if action == "assign_issue" and text.startswith("Assigned"):
+            rid = args.get("run_id")
+            return str(rid) if rid else None
+        return None
 
     async def _assign_issue_slash(
         self, space_id: str, rest: str
@@ -515,10 +528,28 @@ class CrewRuntime:
         }
         if not bound.get("ok"):
             return str(bound.get("detail") or "DENIED: assign failed"), args
+        run_id = self._execute_assigned(space_id, row, goal)
+        args["run_id"] = run_id
         return (
             f"Assigned {canon} to {row.get('name')} mode=goal. {bound.get('law')}",
             args,
         )
+
+    def _execute_assigned(
+        self, space_id: str, row: dict[str, Any], goal: str
+    ) -> str | None:
+        """Operator /assign is spend consent. Brief the teammate and start a run."""
+        agent_id = str(row.get("id") or "")
+        if not agent_id:
+            return None
+        manager = self.ensure_manager(space_id)
+        ctx_id = self._space_run.get(space_id)
+        if ctx_id is None or self._runs.get(ctx_id) is None:
+            ctx_id = self._start_run(space_id, manager)
+        accepted = self.accept_task(agent_id, brief=goal)
+        if isinstance(accepted, dict) and accepted.get("error"):
+            return ctx_id
+        return ctx_id
 
     def _run_slash_memory(
         self,

--- a/CortexOS/crew/server.py
+++ b/CortexOS/crew/server.py
@@ -687,6 +687,7 @@ def build_router(crew: CrewApp) -> APIRouter:
             "ok": True,
             "detail": text,
             "args": args,
+            "run_id": args.get("run_id"),
             "law": "Local bind. Did not write CLAIMS.json. Did not set a GitHub assignee.",
         }
 

--- a/CortexOS/crew/ui/index.html
+++ b/CortexOS/crew/ui/index.html
@@ -926,6 +926,12 @@
           toast((data.detail || ("claim " + resp.status)) + " - no silent retry.", "bad");
           return;
         }
+        toast(
+          act === "claim"
+            ? ((data.detail || "Assigned.") + (data.run_id ? (" run " + data.run_id) : " run none"))
+            : (data.detail || "Released."),
+          "ok"
+        );
         const board = await api("/crew/tickets").catch(() => null);
         if (board) renderTickets(board);
         const belt = await api("/v1/belt").catch(() => api("/crew/belt").catch(() => null));

--- a/tests/test_crew/test_commands.py
+++ b/tests/test_crew/test_commands.py
@@ -260,15 +260,27 @@ async def test_slash_fetch_and_assign_refuse_seated_and_bind_ready(
     deny = [m for m in rig.store.list_messages(space["id"]) if m["role"] == "tool"][-1]
     assert "SEATED" in deny["content"]
     assert rig.store.get_agent_by_name(space["id"], "Scout") is None
+    rig.llm.manager.append(LLMResult(text="Scout is on the ticket."))
+    rig.llm.teammate.append(LLMResult(text="Working Netie-AI/Cortex#160."))
     posted = await rig.runtime.on_user_message(
         space["id"], "/assign Netie-AI/Cortex#160 | Scout"
     )
-    assert posted.get("run_id") is None
+    assert posted.get("run_id")
+    await wait_run_done(rig.runtime, space["id"])
     scout = rig.store.get_agent_by_name(space["id"], "Scout")
     assert scout is not None
     assert "Netie-AI/Cortex#160" in (scout.get("goal_text") or "")
     ok = [m for m in rig.store.list_messages(space["id"]) if m["role"] == "tool"][-1]
     assert "Assigned" in ok["content"] and "Scout" in ok["content"]
+    painted = " ".join(str(m.get("content") or "") for m in rig.store.list_messages(space["id"]))
+    assert "Working Netie-AI/Cortex#160." in painted
+    briefs = [
+        m
+        for m in rig.store.list_messages(space["id"])
+        if (m.get("meta") or {}).get("a2a", {}).get("kind") == "brief"
+        and m.get("to_agent_id") == scout["id"]
+    ]
+    assert briefs
     from CortexOS.crew.assign import public as assignment_public
 
     rows = assignment_public(rig.settings.data_dir)

--- a/tests/test_crew/test_server.py
+++ b/tests/test_crew/test_server.py
@@ -327,6 +327,8 @@ def test_ticket_claim_is_local_assign_and_refuses_seated(
     )
     assert blocked.status_code == 409
     claims.write_text('{"tickets":[]}', encoding="utf-8")
+    client.llm.manager.append(LLMResult(text="Scout is on the ticket."))
+    client.llm.teammate.append(LLMResult(text="Working Netie-AI/Cortex#162."))
     ok = client.http.post(
         "/crew/tickets/claim",
         json={
@@ -336,7 +338,18 @@ def test_ticket_claim_is_local_assign_and_refuses_seated(
         },
     ).json()
     assert ok["ok"] is True
+    assert ok.get("run_id")
     assert "CLAIMS" in ok["law"]
+    deadline = time.time() + 20
+    while client.crew.runtime._space_run.get(space["id"]):
+        if time.time() > deadline:
+            raise AssertionError("assign run did not finish")
+        time.sleep(0.05)
+    painted = " ".join(
+        str(m.get("content") or "")
+        for m in client.http.get(f"/crew/spaces/{space['id']}/messages").json()
+    )
+    assert "Working Netie-AI/Cortex#162." in painted
     board = client.http.get("/crew/tickets").json()
     assert board["assignments"][0]["spec"] == "Netie-AI/Cortex#162"
     assert board["assignments"][0]["agent"] == "Scout"


### PR DESCRIPTION
## Summary

- `/assign` and HUD Claim still bind locally and refuse SEATED seats.
- A successful bind now A2A-briefs the teammate and starts a Crew run so the ticket is worked, not only painted.
- Tests assert operator-visible transcript text (`Working Netie-AI/Cortex#160.`) plus the existing HITL `/done` path.

## Test plan

- [x] `pytest tests/test_crew -q` (190 passed)
- [x] `ruff check` on touched files
- [ ] Live `:8020` still needs a founder restart (`scripts/start_crew.ps1`) before converse serves this tree
- [ ] `/assign` an unseated issue; teammate writes in the log; `/assign` a SEATED spec still 409/DENIED
