### PR TITLE
Crew: show_issue reads ticket body into /assign brief

### DIFF
--- a/CortexOS/crew/github.py
+++ b/CortexOS/crew/github.py
@@ -264,6 +264,105 @@ def issue_title(spec: str, *, runner: RunFn | None = None) -> str:
     return title or canonical_spec(spec)
 
 
+def show_issue(spec: str, *, runner: RunFn | None = None) -> dict[str, Any]:
+    """Read-only issue title and body. Never assigns, closes, or merges."""
+    law = (
+        "Read only. Crew does not set GitHub assignees. "
+        "SEATED tickets stay with Ticket Runner."
+    )
+    parsed = parse_issue_spec(spec)
+    if parsed is None:
+        return {
+            "ok": False,
+            "spec": (spec or "").strip(),
+            "title": "",
+            "body": "",
+            "state": "",
+            "seated": False,
+            "ready": False,
+            "detail": "DENIED: owner/repo#n",
+            "law": law,
+        }
+    canon = canonical_spec(spec)
+    seated = seated_claim(canon)
+    if os.environ.get("CREW_LIVE_PROBES", "1") == "0":
+        return {
+            "ok": False,
+            "spec": canon,
+            "title": canon,
+            "body": "",
+            "state": "",
+            "seated": seated is not None,
+            "ready": seated is None,
+            "detail": "CREW_LIVE_PROBES=0",
+            "law": law,
+        }
+    owner, repo, number = parsed
+    run = runner or _run
+    argv = [
+        "gh",
+        "issue",
+        "view",
+        str(number),
+        "--repo",
+        f"{owner}/{repo}",
+        "--json",
+        "title,body,state",
+    ]
+    try:
+        result = run(argv, timeout=_gh_wait_s())
+    except (FileNotFoundError, OSError, subprocess.TimeoutExpired) as exc:
+        return {
+            "ok": False,
+            "spec": canon,
+            "title": canon,
+            "body": "",
+            "state": "",
+            "seated": seated is not None,
+            "ready": seated is None,
+            "detail": f"{type(exc).__name__}",
+            "law": law,
+        }
+    if result.returncode != 0:
+        return {
+            "ok": False,
+            "spec": canon,
+            "title": canon,
+            "body": "",
+            "state": "",
+            "seated": seated is not None,
+            "ready": seated is None,
+            "detail": (result.stderr or result.stdout or "gh failed")[:400],
+            "law": law,
+        }
+    try:
+        blob = json.loads(result.stdout or "{}")
+    except ValueError:
+        blob = {}
+    if not isinstance(blob, dict):
+        blob = {}
+    title = str(blob.get("title") or "").strip() or canon
+    body = str(blob.get("body") or "")[:4000]
+    state = str(blob.get("state") or "").strip()
+    detail = ""
+    if seated is not None:
+        detail = (
+            f"SEATED ({seated.get('owner_pr')}). Do not implement. "
+            "Ticket Runner owns the seat."
+        )
+    return {
+        "ok": True,
+        "spec": canon,
+        "title": title,
+        "body": body,
+        "state": state,
+        "seated": seated is not None,
+        "ready": seated is None,
+        "detail": detail,
+        "law": law,
+    }
+
+
 def list_open_issues(limit: int = 20, *, runner: RunFn | None = None) -> dict[str, Any]:
     """Open GitHub *issues* for CLAIMS repos. Marks SEATED. Never assigns on GitHub."""
     law = (

--- a/CortexOS/crew/policy.py
+++ b/CortexOS/crew/policy.py
@@ -66,6 +66,7 @@ INTERNAL_TOOLS = frozenset(
         "stop_agent",
         "kill_agent",
         "set_agent_mode",
+        "show_issue",
     }
 )
 

--- a/CortexOS/crew/runtime.py
+++ b/CortexOS/crew/runtime.py
@@ -485,11 +485,15 @@ class CrewRuntime:
         if agent_name.lower() == "manager":
             return "DENIED: assign a teammate, not Manager", args
         canon = github_mod.canonical_spec(spec)
-        title = github_mod.issue_title(canon)
+        shown = github_mod.show_issue(canon)
+        title = str(shown.get("title") or canon).strip()
+        body = str(shown.get("body") or "").strip()
         goal = (
             f"{canon}: {title}. Execute this issue. Close with /done after verify. "
             "Do not steal SEATED seats. Do not merge PRs."
         )
+        if body:
+            goal = f"{goal}\n\n{body[:2000]}"
         row = self.store.get_agent_by_name(space_id, agent_name)
         if row is None:
             spawned = await self.operator_spawn(
@@ -1309,6 +1313,14 @@ class CrewRuntime:
                 ["repo"],
             ),
             spec(
+                "show_issue",
+                "Read a GitHub issue title and body (owner/repo#n). Read only. "
+                "If SEATED, report that and do not implement; Ticket Runner owns the seat. "
+                "Do not merge PRs. Do not set assignees.",
+                {"spec": {"type": "string", "description": "owner/repo#n"}},
+                ["spec"],
+            ),
+            spec(
                 "cortex_ask",
                 "Ask the governed Cortex engine a data question. Returns the answer with its"
                 " badge, sources and audit id. The engine may abstain; report that honestly.",
@@ -1617,6 +1629,25 @@ class CrewRuntime:
             repo = str(args.get("repo", "")).strip() or "all"
             text = render_slug(repo)
             self._persist_tool(ctx, row, "ship_gate", {"repo": repo}, text)
+            return text
+
+        if name == "show_issue":
+            from CortexOS.crew import github as github_mod
+
+            shown = github_mod.show_issue(str(args.get("spec") or ""))
+            mark = "SEATED" if shown.get("seated") else "ready"
+            lines = [
+                f"{shown.get('spec')} {shown.get('state') or ''} {mark}".strip(),
+                str(shown.get("title") or ""),
+            ]
+            if shown.get("detail"):
+                lines.append(str(shown["detail"]))
+            if shown.get("body"):
+                lines.append(str(shown["body"]))
+            elif not shown.get("ok"):
+                lines.append(str(shown.get("detail") or "unread"))
+            text = "\n".join(p for p in lines if p)
+            self._persist_tool(ctx, row, "show_issue", {"spec": shown.get("spec")}, text)
             return text
 
         if name == "cortex_ask":

--- a/tests/test_crew/test_commands.py
+++ b/tests/test_crew/test_commands.py
@@ -246,7 +246,21 @@ async def test_slash_fetch_and_assign_refuse_seated_and_bind_ready(
             ],
         },
     )
-    monkeypatch.setattr(github_mod, "issue_title", lambda spec, **_k: spec)
+    monkeypatch.setattr(
+        github_mod,
+        "show_issue",
+        lambda spec, **_k: {
+            "ok": True,
+            "spec": spec,
+            "title": spec,
+            "body": "Bind then execute." if str(spec).endswith("#160") else "",
+            "state": "OPEN",
+            "seated": str(spec).endswith("#128"),
+            "ready": str(spec).endswith("#160"),
+            "detail": "",
+            "law": "Read only.",
+        },
+    )
     space = rig.store.create_space("HQ")
     fetched = await rig.runtime.on_user_message(space["id"], "/fetch")
     assert fetched.get("run_id") is None
@@ -270,6 +284,7 @@ async def test_slash_fetch_and_assign_refuse_seated_and_bind_ready(
     scout = rig.store.get_agent_by_name(space["id"], "Scout")
     assert scout is not None
     assert "Netie-AI/Cortex#160" in (scout.get("goal_text") or "")
+    assert "Bind then execute." in (scout.get("goal_text") or "")
     ok = [m for m in rig.store.list_messages(space["id"]) if m["role"] == "tool"][-1]
     assert "Assigned" in ok["content"] and "Scout" in ok["content"]
     painted = " ".join(str(m.get("content") or "") for m in rig.store.list_messages(space["id"]))
@@ -281,6 +296,7 @@ async def test_slash_fetch_and_assign_refuse_seated_and_bind_ready(
         and m.get("to_agent_id") == scout["id"]
     ]
     assert briefs
+    assert "Bind then execute." in (briefs[0].get("content") or "")
     from CortexOS.crew.assign import public as assignment_public
 
     rows = assignment_public(rig.settings.data_dir)

--- a/tests/test_crew/test_config_policy.py
+++ b/tests/test_crew/test_config_policy.py
@@ -98,6 +98,7 @@ def test_policy_master_switch_and_arming_fail_closed() -> None:
     assert policy.decide("desk_status", server=None, armed=False, master_on=False)[0] == policy.ALLOW
     assert policy.decide("estate_status", server=None, armed=False, master_on=False)[0] == policy.ALLOW
     assert policy.decide("ship_gate", server=None, armed=False, master_on=False)[0] == policy.ALLOW
+    assert policy.decide("show_issue", server=None, armed=False, master_on=False)[0] == policy.ALLOW
     assert policy.decide("rm_rf", server=None, armed=False, master_on=False)[0] == policy.DENY
     denied, reason = policy.decide(
         "click",

--- a/tests/test_crew/test_connectors_import.py
+++ b/tests/test_crew/test_connectors_import.py
@@ -218,6 +218,50 @@ def test_github_list_open_issues_marks_seated(tmp_path, monkeypatch) -> None:
     assert "does not assign" in body["law"].lower() or "Control does not assign" in body["law"]
 
 
+def test_github_show_issue_is_read_only_and_marks_seated(tmp_path, monkeypatch) -> None:
+    from types import SimpleNamespace
+
+    from CortexOS.crew import github as github_mod
+
+    claims = tmp_path / "CLAIMS.json"
+    claims.write_text(
+        '{"tickets":[{"ticket":"Netie-AI/Cortex#128","owner_pr":"Netie-AI/Cortex#128","role":"SEATED"}]}',
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("CREW_CLAIMS", str(claims))
+    monkeypatch.setenv("CREW_LIVE_PROBES", "1")
+    monkeypatch.setenv("CREW_GH_WAIT_S", "1.5")
+
+    def runner(argv, timeout=1.5):  # noqa: ANN001, ARG001
+        assert timeout <= 8.0
+        assert argv[:3] == ["gh", "issue", "view"]
+        assert "--json" in argv and "title,body,state" in argv
+        payload = '{"title":"seated work","body":"Do C7-06.","state":"OPEN"}'
+        return SimpleNamespace(returncode=0, stdout=payload, stderr="")
+
+    seated = github_mod.show_issue("Netie-AI/Cortex#128", runner=runner)
+    assert seated["ok"] is True
+    assert seated["seated"] is True
+    assert seated["ready"] is False
+    assert "Do C7-06." in seated["body"]
+    assert "SEATED" in seated["detail"]
+    assert "assignees" in seated["law"].lower()
+
+    def runner_ready(argv, timeout=1.5):  # noqa: ANN001, ARG001
+        payload = '{"title":"assign slice","body":"Bind then execute.","state":"OPEN"}'
+        return SimpleNamespace(returncode=0, stdout=payload, stderr="")
+
+    ready = github_mod.show_issue("Netie-AI/Cortex#160", runner=runner_ready)
+    assert ready["ok"] is True
+    assert ready["ready"] is True
+    assert ready["seated"] is False
+    assert "Bind then execute." in ready["body"]
+    monkeypatch.setenv("CREW_LIVE_PROBES", "0")
+    dark = github_mod.show_issue("Netie-AI/Cortex#160", runner=runner_ready)
+    assert dark["ok"] is False
+    assert dark["detail"] == "CREW_LIVE_PROBES=0"
+
+
 def test_inbox_without_creds_tells_operator_to_drop(monkeypatch) -> None:
     from CortexOS.crew import inbox as inbox_mod
 

--- a/tests/test_crew/test_runtime.py
+++ b/tests/test_crew/test_runtime.py
@@ -298,3 +298,34 @@ async def test_takeover_skips_mutating_click(settings, crew_env) -> None:
     tools = [m for m in store.list_messages(space["id"]) if m["role"] == "tool"]
     assert tools and "TOOK OVER" in tools[0]["content"]
     store.close()
+
+
+async def test_show_issue_tool_paints_body_in_transcript(rig, monkeypatch) -> None:
+    from CortexOS.crew import github as github_mod
+
+    monkeypatch.setenv("CREW_LIVE_PROBES", "1")
+
+    def fake_show(spec, *, runner=None):  # noqa: ANN001, ARG001
+        return {
+            "ok": True,
+            "spec": spec,
+            "title": "assign slice",
+            "body": "Bind then execute.",
+            "state": "OPEN",
+            "seated": False,
+            "ready": True,
+            "detail": "",
+            "law": "Read only.",
+        }
+
+    monkeypatch.setattr(github_mod, "show_issue", fake_show)
+    space = rig.store.create_space("HQ")
+    rig.llm.manager.append(
+        LLMResult(tool_calls=[_tc("show_issue", spec="Netie-AI/Cortex#160")])
+    )
+    rig.llm.manager.append(LLMResult(text="Issue body is Bind then execute."))
+    await rig.runtime.on_user_message(space["id"], "read Cortex#160")
+    await wait_run_done(rig.runtime, space["id"])
+    painted = " ".join(str(m.get("content") or "") for m in rig.store.list_messages(space["id"]))
+    assert "Bind then execute." in painted
+    assert "Issue body is Bind then execute." in painted


### PR DESCRIPTION
## Summary

- New read-only `show_issue` tool (`gh issue view`) returns title and body, marks SEATED, never assigns or closes.
- Successful `/assign` copies that body (capped) into the teammate goal/brief so the run has the ticket text, not only the spec.
- Tests assert operator-visible transcript text and SEATED vs ready.

## Test plan

- [x] `pytest tests/test_crew -q` (192 passed)
- [x] `ruff check` on touched files
- [ ] Live `:8020` still needs a founder restart before converse serves this tree
- [ ] `/assign` an unseated issue; goal/brief contains the GitHub body; SEATED specs still refuse
