### PR TITLE
Crew: jailed ws_* tools (rebase onto show_issue)

### DIFF
--- a/CortexOS/crew/policy.py
+++ b/CortexOS/crew/policy.py
@@ -67,6 +67,11 @@ INTERNAL_TOOLS = frozenset(
         "kill_agent",
         "set_agent_mode",
         "show_issue",
+        "ws_ls",
+        "ws_read",
+        "ws_write",
+        "ws_edit",
+        "ws_glob",
     }
 )
 

--- a/CortexOS/crew/runtime.py
+++ b/CortexOS/crew/runtime.py
@@ -1321,6 +1321,46 @@ class CrewRuntime:
                 ["spec"],
             ),
             spec(
+                "ws_ls",
+                "List files in this space's jailed workspace. Paths cannot escape the jail. "
+                "Use this to keep ticket notes and patches. Do not write the Cortex engine tree.",
+                {"path": {"type": "string", "description": "relative path; default ."}},
+                [],
+            ),
+            spec(
+                "ws_read",
+                "Read a file from this space's jailed workspace. Escape attempts are denied.",
+                {
+                    "path": {"type": "string"},
+                    "offset": {"type": "integer", "description": "start line, 0-based"},
+                    "limit": {"type": "integer", "description": "max lines"},
+                },
+                ["path"],
+            ),
+            spec(
+                "ws_write",
+                "Write a file in this space's jailed workspace. Creates parents. Size-capped. "
+                "Does not touch CLAIMS.json or merge PRs.",
+                {"path": {"type": "string"}, "content": {"type": "string"}},
+                ["path", "content"],
+            ),
+            spec(
+                "ws_edit",
+                "Replace one unique old_string with new_string in a jailed workspace file.",
+                {
+                    "path": {"type": "string"},
+                    "old": {"type": "string"},
+                    "new": {"type": "string"},
+                },
+                ["path", "old", "new"],
+            ),
+            spec(
+                "ws_glob",
+                "Find files in this space's jailed workspace by glob pattern.",
+                {"pattern": {"type": "string"}},
+                [],
+            ),
+            spec(
                 "cortex_ask",
                 "Ask the governed Cortex engine a data question. Returns the answer with its"
                 " badge, sources and audit id. The engine may abstain; report that honestly.",
@@ -1648,6 +1688,34 @@ class CrewRuntime:
                 lines.append(str(shown.get("detail") or "unread"))
             text = "\n".join(p for p in lines if p)
             self._persist_tool(ctx, row, "show_issue", {"spec": shown.get("spec")}, text)
+            return text
+
+        if name in {"ws_ls", "ws_read", "ws_write", "ws_edit", "ws_glob"}:
+            from CortexOS.crew import workspace as ws_mod
+
+            ws = ws_mod.workspace_for(self.settings.data_dir, ctx.space_id)
+            try:
+                if name == "ws_ls":
+                    text = ws.ls(str(args.get("path") or "."))
+                elif name == "ws_read":
+                    text = ws.read(
+                        str(args.get("path") or ""),
+                        offset=int(args.get("offset") or 0),
+                        limit=int(args.get("limit") or 200),
+                    )
+                elif name == "ws_write":
+                    text = ws.write(str(args.get("path") or ""), str(args.get("content") or ""))
+                elif name == "ws_edit":
+                    text = ws.edit(
+                        str(args.get("path") or ""),
+                        str(args.get("old") or ""),
+                        str(args.get("new") or ""),
+                    )
+                else:
+                    text = ws.glob(str(args.get("pattern") or "*"))
+            except (ws_mod.WorkspaceError, TypeError, ValueError) as exc:
+                text = ws_mod.as_error(exc)
+            self._persist_tool(ctx, row, name, args, text)
             return text
 
         if name == "cortex_ask":

--- a/tests/test_crew/test_config_policy.py
+++ b/tests/test_crew/test_config_policy.py
@@ -99,6 +99,8 @@ def test_policy_master_switch_and_arming_fail_closed() -> None:
     assert policy.decide("estate_status", server=None, armed=False, master_on=False)[0] == policy.ALLOW
     assert policy.decide("ship_gate", server=None, armed=False, master_on=False)[0] == policy.ALLOW
     assert policy.decide("show_issue", server=None, armed=False, master_on=False)[0] == policy.ALLOW
+    assert policy.decide("ws_ls", server=None, armed=False, master_on=False)[0] == policy.ALLOW
+    assert policy.decide("ws_write", server=None, armed=False, master_on=False)[0] == policy.ALLOW
     assert policy.decide("rm_rf", server=None, armed=False, master_on=False)[0] == policy.DENY
     denied, reason = policy.decide(
         "click",

--- a/tests/test_crew/test_runtime.py
+++ b/tests/test_crew/test_runtime.py
@@ -329,3 +329,34 @@ async def test_show_issue_tool_paints_body_in_transcript(rig, monkeypatch) -> No
     painted = " ".join(str(m.get("content") or "") for m in rig.store.list_messages(space["id"]))
     assert "Bind then execute." in painted
     assert "Issue body is Bind then execute." in painted
+
+
+async def test_ws_write_then_read_paints_in_transcript(rig) -> None:
+    space = rig.store.create_space("HQ")
+    rig.llm.manager.append(
+        LLMResult(
+            tool_calls=[
+                _tc("ws_write", path="ticket.md", content="working Netie-AI/Cortex#160"),
+            ]
+        )
+    )
+    rig.llm.manager.append(
+        LLMResult(tool_calls=[_tc("ws_read", path="ticket.md")])
+    )
+    rig.llm.manager.append(LLMResult(text="Notes are in the workspace."))
+    await rig.runtime.on_user_message(space["id"], "keep notes on the ticket")
+    await wait_run_done(rig.runtime, space["id"])
+    painted = " ".join(str(m.get("content") or "") for m in rig.store.list_messages(space["id"]))
+    assert "working Netie-AI/Cortex#160" in painted
+    assert "Notes are in the workspace." in painted
+
+
+async def test_ws_read_escape_is_denied_in_transcript(rig) -> None:
+    space = rig.store.create_space("HQ")
+    rig.llm.manager.append(LLMResult(tool_calls=[_tc("ws_read", path="../secrets.txt")]))
+    rig.llm.manager.append(LLMResult(text="Jail held."))
+    await rig.runtime.on_user_message(space["id"], "read outside the jail")
+    await wait_run_done(rig.runtime, space["id"])
+    painted = " ".join(str(m.get("content") or "") for m in rig.store.list_messages(space["id"]))
+    assert "DENIED" in painted
+    assert "Jail held." in painted

--- a/tests/test_crew/test_workspace.py
+++ b/tests/test_crew/test_workspace.py
@@ -1,0 +1,21 @@
+"""Jailed per-space workspace. Escape attempts fail closed."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from CortexOS.crew.workspace import WorkspaceError, as_error, workspace_for
+
+
+def test_workspace_write_read_and_refuses_escape(tmp_path: Path) -> None:
+    ws = workspace_for(tmp_path / "crew", "space-1")
+    assert "wrote notes.md" in ws.write("notes.md", "ticket body here")
+    assert "ticket body here" in ws.read("notes.md")
+    assert "notes.md" in ws.glob("*.md")
+    with pytest.raises(WorkspaceError, match="escape"):
+        ws.read("../secrets.txt")
+    with pytest.raises(WorkspaceError, match="absolute"):
+        ws.write("C:/Windows/x.txt", "no")
+    assert "DENIED" in as_error(WorkspaceError("path escapes workspace"))


### PR DESCRIPTION
## Summary

- Rebases #171 onto main after #169 (`show_issue`).
- Assigned teammates get jailed `ws_ls` / `ws_read` / `ws_write` / `ws_edit` / `ws_glob`.
- Escape paths return DENIED. Does not write CLAIMS.json or the engine tree.

## Test plan

- [x] Conflict resolved: `show_issue` + `ws_*` both present
- [x] Targeted pytest + ruff on the touched files
- [ ] Live `:8020` needs founder `scripts/start_crew.ps1` (R-0015; do not agent-start)
