### PR TITLE
Crew: request_close HITL same as /done

### DIFF
--- a/CortexOS/crew/policy.py
+++ b/CortexOS/crew/policy.py
@@ -67,6 +67,7 @@ INTERNAL_TOOLS = frozenset(
         "kill_agent",
         "set_agent_mode",
         "show_issue",
+        "request_close",
         "ws_ls",
         "ws_read",
         "ws_write",

--- a/CortexOS/crew/runtime.py
+++ b/CortexOS/crew/runtime.py
@@ -489,7 +489,8 @@ class CrewRuntime:
         title = str(shown.get("title") or canon).strip()
         body = str(shown.get("body") or "").strip()
         goal = (
-            f"{canon}: {title}. Execute this issue. Close with /done after verify. "
+            f"{canon}: {title}. Execute this issue. "
+            "Close with request_close (HITL) or /done after verify. "
             "Do not steal SEATED seats. Do not merge PRs."
         )
         if body:
@@ -768,6 +769,15 @@ class CrewRuntime:
         self, confirm_id: str, approved: bool, *, takeover: bool = False
     ) -> dict[str, Any] | None:
         row = self.store.decide_confirm(confirm_id, approved, takeover=takeover)
+        if row is not None:
+            self.bus.emit(row["space_id"], "confirm", {"confirm": row})
+            if (
+                approved
+                and not takeover
+                and str(row.get("tool") or "") == "close_issue"
+                and str(row.get("status") or "") == "approved"
+            ):
+                self._finish_close_issue(row)
         pair = self._confirms.get(confirm_id)
         if pair is not None:
             event, holder = pair
@@ -778,15 +788,6 @@ class CrewRuntime:
                 holder["verdict"] = "approved" if approved else "denied"
                 holder["approved"] = approved
             event.set()
-        if row is not None:
-            self.bus.emit(row["space_id"], "confirm", {"confirm": row})
-            if (
-                approved
-                and not takeover
-                and str(row.get("tool") or "") == "close_issue"
-                and str(row.get("status") or "") == "approved"
-            ):
-                self._finish_close_issue(row)
         return row
 
     def _finish_close_issue(self, confirm: dict[str, Any]) -> None:
@@ -798,6 +799,7 @@ class CrewRuntime:
         result = github_mod.close_issue(spec, comment=comment)
         space_id = str(confirm.get("space_id") or "")
         manager = self.ensure_manager(space_id)
+        agent_id = str(confirm.get("agent_id") or manager["id"])
         text = result.get("detail") or ("closed " + spec if result.get("ok") else "close failed")
         if result.get("ok"):
             text = f"Closed {result.get('spec')}. {result.get('law')}"
@@ -810,9 +812,13 @@ class CrewRuntime:
             space_id,
             "tool",
             str(text)[:4000],
-            agent_id=manager["id"],
+            agent_id=agent_id,
             to_agent_id=manager["id"],
-            meta={"tool": "close_issue", "args": args, "slash": True},
+            meta={
+                "tool": "close_issue",
+                "args": args,
+                "slash": confirm.get("run_id") is None,
+            },
         )
         self.bus.emit(space_id, "message", {"message": msg})
 
@@ -1321,6 +1327,17 @@ class CrewRuntime:
                 ["spec"],
             ),
             spec(
+                "request_close",
+                "Ask the operator to close a GitHub issue (owner/repo#n) after verify. "
+                "Parks the same HITL as /done. Refuses SEATED claims. Never merges PRs. "
+                "Never sets GitHub assignees. Do not call this on Ticket Runner seats.",
+                {
+                    "spec": {"type": "string", "description": "owner/repo#n"},
+                    "comment": {"type": "string", "description": "close comment"},
+                },
+                ["spec"],
+            ),
+            spec(
                 "ws_ls",
                 "List files in this space's jailed workspace. Paths cannot escape the jail. "
                 "Use this to keep ticket notes and patches. Do not write the Cortex engine tree.",
@@ -1688,6 +1705,44 @@ class CrewRuntime:
                 lines.append(str(shown.get("detail") or "unread"))
             text = "\n".join(p for p in lines if p)
             self._persist_tool(ctx, row, "show_issue", {"spec": shown.get("spec")}, text)
+            return text
+
+        if name == "request_close":
+            from CortexOS.crew import github as github_mod
+
+            spec = str(args.get("spec") or "")
+            comment = str(args.get("comment") or "")
+            parsed = github_mod.parse_issue_spec(spec)
+            seated = github_mod.seated_claim(spec) if parsed else None
+            if parsed is None:
+                text = "DENIED: request_close owner/repo#n. Crew does not merge PRs."
+                self._persist_tool(ctx, row, "request_close", args, text)
+                return text
+            if seated is not None:
+                text = (
+                    f"DENIED: {seated.get('ticket')} is SEATED "
+                    f"({seated.get('owner_pr')}). Ticket Runner owns the seat. "
+                    "Crew does not steal it."
+                )
+                self._persist_tool(ctx, row, "request_close", args, text)
+                return text
+            canon = github_mod.canonical_spec(spec)
+            payload = {"spec": canon, "comment": comment}
+            verdict = await self._await_confirm(ctx, row, "close_issue", payload)
+            if verdict != "approved":
+                text = (
+                    "DENIED: operator kept the issue open (or approval timed out). "
+                    "Crew does not merge PRs."
+                )
+                self._persist_tool(ctx, row, "request_close", payload, text)
+                return text
+            closed = [
+                m
+                for m in self.store.list_messages(ctx.space_id)
+                if m.get("role") == "tool"
+                and (m.get("meta") or {}).get("tool") == "close_issue"
+            ]
+            text = str(closed[-1]["content"]) if closed else f"Closed {canon}."
             return text
 
         if name in {"ws_ls", "ws_read", "ws_write", "ws_edit", "ws_glob"}:

--- a/tests/test_crew/test_config_policy.py
+++ b/tests/test_crew/test_config_policy.py
@@ -99,6 +99,7 @@ def test_policy_master_switch_and_arming_fail_closed() -> None:
     assert policy.decide("estate_status", server=None, armed=False, master_on=False)[0] == policy.ALLOW
     assert policy.decide("ship_gate", server=None, armed=False, master_on=False)[0] == policy.ALLOW
     assert policy.decide("show_issue", server=None, armed=False, master_on=False)[0] == policy.ALLOW
+    assert policy.decide("request_close", server=None, armed=False, master_on=False)[0] == policy.ALLOW
     assert policy.decide("ws_ls", server=None, armed=False, master_on=False)[0] == policy.ALLOW
     assert policy.decide("ws_write", server=None, armed=False, master_on=False)[0] == policy.ALLOW
     assert policy.decide("rm_rf", server=None, armed=False, master_on=False)[0] == policy.DENY

--- a/tests/test_crew/test_runtime.py
+++ b/tests/test_crew/test_runtime.py
@@ -331,6 +331,121 @@ async def test_show_issue_tool_paints_body_in_transcript(rig, monkeypatch) -> No
     assert "Issue body is Bind then execute." in painted
 
 
+async def test_request_close_refuses_seated_and_hitl_closes_unseated(
+    rig, tmp_path, monkeypatch
+) -> None:
+    from CortexOS.crew import github as github_mod
+
+    claims = tmp_path / "CLAIMS.json"
+    claims.write_text(
+        '{"tickets":[{"ticket":"Netie-AI/Cortex#128","owner_pr":"Netie-AI/Cortex#128","role":"SEATED"}]}',
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("CREW_CLAIMS", str(claims))
+    closed: dict[str, str] = {}
+
+    def fake_close(spec, *, comment="", runner=None):  # noqa: ANN001, ARG001
+        closed["spec"] = spec
+        closed["comment"] = comment
+        return {
+            "ok": True,
+            "spec": spec,
+            "detail": "Closed",
+            "law": "Closed the issue. Did not merge a PR. Ticket Runner seats writers.",
+        }
+
+    monkeypatch.setattr(github_mod, "close_issue", fake_close)
+    space = rig.store.create_space("HQ")
+    rig.llm.manager.extend(
+        [
+            LLMResult(
+                tool_calls=[_tc("request_close", spec="Netie-AI/Cortex#128", comment="no")]
+            ),
+            LLMResult(text="Left the seated ticket alone."),
+        ]
+    )
+    await rig.runtime.on_user_message(space["id"], "close 128")
+    await wait_run_done(rig.runtime, space["id"])
+    painted = " ".join(str(m.get("content") or "") for m in rig.store.list_messages(space["id"]))
+    assert "SEATED" in painted
+    assert "Left the seated ticket alone." in painted
+    assert closed == {}
+    assert rig.store.pending_confirms(space["id"]) == []
+
+    claims.write_text('{"tickets":[]}', encoding="utf-8")
+    rig.llm.manager.extend(
+        [
+            LLMResult(
+                tool_calls=[
+                    _tc(
+                        "request_close",
+                        spec="Netie-AI/Cortex#99",
+                        comment="verified on desk",
+                    )
+                ]
+            ),
+            LLMResult(text="Issue closed after you approved."),
+        ]
+    )
+
+    async def auto_approve() -> None:
+        for _ in range(200):
+            pending = rig.store.pending_confirms(space["id"])
+            if pending:
+                rig.runtime.decide_confirm(pending[0]["id"], True)
+                return
+            await asyncio.sleep(0.01)
+        raise AssertionError("confirm never appeared")
+
+    waiter = asyncio.create_task(auto_approve())
+    await rig.runtime.on_user_message(space["id"], "close 99")
+    await wait_run_done(rig.runtime, space["id"])
+    await waiter
+    assert closed["spec"] == "Netie-AI/Cortex#99"
+    assert "verified" in closed["comment"]
+    painted = " ".join(str(m.get("content") or "") for m in rig.store.list_messages(space["id"]))
+    assert "Closed" in painted
+    assert "Issue closed after you approved." in painted
+    assert "Did not merge" in painted
+
+
+async def test_request_close_deny_keeps_issue_open(rig, monkeypatch) -> None:
+    from CortexOS.crew import github as github_mod
+
+    called: list[str] = []
+
+    def fake_close(spec, *, comment="", runner=None):  # noqa: ANN001, ARG001
+        called.append(spec)
+        return {"ok": True, "spec": spec, "detail": "Closed", "law": "no"}
+
+    monkeypatch.setattr(github_mod, "close_issue", fake_close)
+    space = rig.store.create_space("HQ")
+    rig.llm.manager.extend(
+        [
+            LLMResult(tool_calls=[_tc("request_close", spec="Netie-AI/Cortex#99")]),
+            LLMResult(text="Kept it open."),
+        ]
+    )
+
+    async def auto_deny() -> None:
+        for _ in range(200):
+            pending = rig.store.pending_confirms(space["id"])
+            if pending:
+                rig.runtime.decide_confirm(pending[0]["id"], False)
+                return
+            await asyncio.sleep(0.01)
+        raise AssertionError("confirm never appeared")
+
+    waiter = asyncio.create_task(auto_deny())
+    await rig.runtime.on_user_message(space["id"], "close 99")
+    await wait_run_done(rig.runtime, space["id"])
+    await waiter
+    assert called == []
+    painted = " ".join(str(m.get("content") or "") for m in rig.store.list_messages(space["id"]))
+    assert "DENIED" in painted
+    assert "Kept it open." in painted
+
+
 async def test_ws_write_then_read_paints_in_transcript(rig) -> None:
     space = rig.store.create_space("HQ")
     rig.llm.manager.append(


### PR DESCRIPTION
## Summary
- Assigned teammates can call `request_close` to park the same HITL confirm as `/done`.
- SEATED claims refuse with no confirm. Approve runs `gh issue close` only; Crew never merges.
- `/assign` brief now tells the teammate to use `request_close` (HITL) or `/done` after verify.

## Test plan
- [x] `pytest tests/test_crew -q` (197 passed locally)
- [ ] CI lint-type-test / base-install / protected-paths / rls-proof / secrets-scan
- [ ] Live `GET /v1/belt` and `/crew/*` after founder rebind of `:8020` (do not agent-start that port)

Closes #173
