### PR TITLE
Crew: belt shows cached fetched unseated issues

### DIFF
--- a/CortexOS/crew/github.py
+++ b/CortexOS/crew/github.py
@@ -7,11 +7,15 @@ import os
 import re
 import subprocess
 from collections.abc import Callable
+from pathlib import Path
 from typing import Any
 
 from CortexOS.crew.board import snapshot as board_snapshot
 
 RunFn = Callable[..., subprocess.CompletedProcess[str]]
+
+_FETCH_FILE = "fetched_issues.json"
+_FETCH_CAP = 80
 
 
 def _run(argv: list[str], timeout: float = 20.0) -> subprocess.CompletedProcess[str]:
@@ -444,6 +448,38 @@ def list_open_issues(limit: int = 20, *, runner: RunFn | None = None) -> dict[st
         "repos": repos,
         "law": law,
     }
+
+
+def remember_fetched(data_dir: Path, payload: dict[str, Any]) -> None:
+    """Cache /fetch results so GET /v1/belt stays off the gh path (Control 1.5s)."""
+    data_dir.mkdir(parents=True, exist_ok=True)
+    issues = [
+        row for row in (payload.get("issues") or []) if isinstance(row, dict)
+    ][:_FETCH_CAP]
+    blob = {
+        "issues": issues,
+        "detail": str(payload.get("detail") or "")[:400],
+        "ok": bool(payload.get("ok")),
+    }
+    (data_dir / _FETCH_FILE).write_text(
+        json.dumps(blob, ensure_ascii=False), encoding="utf-8"
+    )
+
+
+def remembered_issues(data_dir: Path) -> list[dict[str, Any]]:
+    path = data_dir / _FETCH_FILE
+    if not path.is_file():
+        return []
+    try:
+        blob = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, ValueError):
+        return []
+    rows = blob.get("issues") if isinstance(blob, dict) else blob
+    out: list[dict[str, Any]] = []
+    for row in rows or []:
+        if isinstance(row, dict) and str(row.get("spec") or "").strip():
+            out.append(row)
+    return out[:_FETCH_CAP]
 
 
 def close_issue(

--- a/CortexOS/crew/github.py
+++ b/CortexOS/crew/github.py
@@ -482,6 +482,11 @@ def remembered_issues(data_dir: Path) -> list[dict[str, Any]]:
     return out[:_FETCH_CAP]
 
 
+def warm_fetched(data_dir: Path) -> None:
+    """Fill the belt cache once. Belt GETs stay off gh."""
+    remember_fetched(data_dir, list_open_issues())
+
+
 def close_issue(
     spec: str,
     *,

--- a/CortexOS/crew/runtime.py
+++ b/CortexOS/crew/runtime.py
@@ -426,6 +426,7 @@ class CrewRuntime:
             from CortexOS.crew import github as github_mod
 
             fetched = github_mod.list_open_issues()
+            github_mod.remember_fetched(self.settings.data_dir, fetched)
             lines = [
                 f"{len(fetched.get('issues') or [])} open issues. {fetched.get('law')}"
             ]

--- a/CortexOS/crew/server.py
+++ b/CortexOS/crew/server.py
@@ -115,6 +115,7 @@ class CrewApp:
             self.queue,
             mailbox_nonempty=self.mailbox_nonempty(),
             assignments=assignment_public(self.settings.data_dir),
+            data_dir=self.settings.data_dir,
         )
 
     async def startup(self) -> None:
@@ -660,6 +661,7 @@ def build_router(crew: CrewApp) -> APIRouter:
             if isinstance(row, dict)
         )
         fetched = github_mod.list_open_issues()
+        github_mod.remember_fetched(crew.settings.data_dir, fetched)
         issues = []
         for row in fetched.get("issues") or []:
             if not isinstance(row, dict):

--- a/CortexOS/crew/server.py
+++ b/CortexOS/crew/server.py
@@ -75,6 +75,7 @@ class CrewApp:
         self.shell = CrewShell(self.settings)
         self.wakes = WakeBoard()
         self.queue = JobQueue()
+        self._fetch_warm: asyncio.Task[None] | None = None
 
     def mailbox_nonempty(self) -> bool:
         """True when any A2A mailbox still holds unread envelopes.
@@ -135,8 +136,18 @@ class CrewApp:
         # Armed servers do not stay resident. The reaper suspends one once it
         # goes quiet; the next approved tool call starts it again.
         self.mcp.start_reaper()
+        from CortexOS.crew import github as github_mod
+
+        # Off the GET /v1/belt path so Control's 1.5s proxy does not wait on gh.
+        self._fetch_warm = asyncio.create_task(
+            asyncio.to_thread(github_mod.warm_fetched, self.settings.data_dir)
+        )
 
     async def shutdown(self) -> None:
+        if self._fetch_warm is not None:
+            self._fetch_warm.cancel()
+            with contextlib.suppress(asyncio.CancelledError):
+                await self._fetch_warm
         await self.runtime.shutdown()
         await self.mcp.stop_all()
         self.store.close()

--- a/CortexOS/crew/wakes.py
+++ b/CortexOS/crew/wakes.py
@@ -13,6 +13,7 @@ does not HTTP-ping Cortex; ``cortex.detail`` is ``not probed``.
 from __future__ import annotations
 
 import uuid
+from pathlib import Path
 from typing import Any
 
 from CortexOS.crew.queue import JobQueue
@@ -79,6 +80,29 @@ def _ticket_item(row: dict[str, Any]) -> dict[str, Any]:
     }
 
 
+def _fetched_item(row: dict[str, Any]) -> dict[str, Any]:
+    spec = str(row.get("spec") or "").strip()
+    repo = str(row.get("repo") or "").strip()
+    number: int | None = None
+    raw = row.get("number")
+    if isinstance(raw, int):
+        number = raw
+    elif isinstance(raw, str) and raw.isdigit():
+        number = int(raw)
+    elif "#" in spec:
+        right = spec.rsplit("#", 1)[-1]
+        if right.isdigit():
+            number = int(right)
+    return {
+        "repo": repo or (spec.rsplit("#", 1)[0] if "#" in spec else ""),
+        "number": number,
+        "title": str(row.get("title") or spec),
+        "ready": True,
+        "url": str(row.get("url") or ""),
+        "spec": spec,
+    }
+
+
 def conveyor(
     store: CrewStore,
     wakes: WakeBoard,
@@ -86,17 +110,37 @@ def conveyor(
     *,
     mailbox_nonempty: bool = False,
     assignments: list[dict[str, Any]] | None = None,
+    data_dir: Path | None = None,
 ) -> dict[str, Any]:
     """Display JSON for ``GET /v1/belt`` and ``GET /crew/belt``.
 
     Control proxies this as display-only. Crew owns leases and the tick.
     ``plan_for_next.decides_work_shape`` stays false: this snapshot does not
     pick the next writer. Cortex is not probed from the belt.
+    Fetched GitHub issues come from the last /fetch cache on disk, not a live
+    gh call (Control belt GET is 1.5s).
     """
+    from CortexOS.crew import github as github_mod
     from CortexOS.crew.board import snapshot as board_snapshot
 
     board = board_snapshot()
     items = [_ticket_item(t) for t in board.get("tickets") or [] if isinstance(t, dict)]
+    claimed = {
+        str(row.get("ticket") or "")
+        for row in (board.get("tickets") or [])
+        if isinstance(row, dict)
+    }
+    claimed.update(
+        str(row.get("owner_pr") or "")
+        for row in (board.get("tickets") or [])
+        if isinstance(row, dict)
+    )
+    if data_dir is not None:
+        for row in github_mod.remembered_issues(data_dir):
+            spec = str(row.get("spec") or "")
+            if not spec or spec in claimed or row.get("seated"):
+                continue
+            items.append(_fetched_item(row))
     spaces = store.list_spaces()
     confirms: list[dict[str, Any]] = []
     agents: list[dict[str, Any]] = []

--- a/tests/test_crew/test_server.py
+++ b/tests/test_crew/test_server.py
@@ -393,6 +393,8 @@ def test_tickets_lists_fetched_github_issues_minus_claims(
                 },
                 {
                     "spec": "Netie-AI/Cortex#164",
+                    "repo": "Netie-AI/Cortex",
+                    "number": 164,
                     "title": "fetch hud",
                     "seated": False,
                     "ready": True,
@@ -406,6 +408,13 @@ def test_tickets_lists_fetched_github_issues_minus_claims(
     assert board["issues"][0]["spec"] == "Netie-AI/Cortex#164"
     assert board["issues"][0]["ready"] is True
     assert board["issues_ok"] is True
+    belt = client.http.get("/v1/belt").json()
+    ready = [row for row in belt["tickets"]["items"] if row.get("ready")]
+    assert any(
+        row.get("spec") == "Netie-AI/Cortex#164" or row.get("title") == "fetch hud"
+        for row in ready
+    )
+    assert not any(row.get("ready") and row.get("number") == 128 for row in belt["tickets"]["items"])
 
 
 def test_operator_can_choose_runtime_backend(client) -> None:

--- a/tests/test_crew/test_wakes.py
+++ b/tests/test_crew/test_wakes.py
@@ -78,3 +78,52 @@ def test_conveyor_skips_cortex_ping_and_does_not_decide_shape(tmp_path, monkeypa
     assert body["assignments"] == []
     assert "Control does not assign" in body["assign_owner"]
     assert "dag_runner" not in body
+
+
+def test_conveyor_adds_cached_unseated_issues(tmp_path, monkeypatch) -> None:
+    from CortexOS.crew import github as github_mod
+
+    claims = tmp_path / "CLAIMS.json"
+    claims.write_text(
+        '{"tickets":[{"ticket":"Netie-AI/Cortex#128","owner_pr":"Netie-AI/Cortex#128","role":"SEATED","repo":"Netie-AI/Cortex"}]}',
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("CREW_CLAIMS", str(claims))
+    monkeypatch.setenv("CREW_RUNTIME", str(tmp_path / "missing-runtime.md"))
+    data_dir = tmp_path / "crew"
+    github_mod.remember_fetched(
+        data_dir,
+        {
+            "ok": True,
+            "issues": [
+                {
+                    "spec": "Netie-AI/Cortex#128",
+                    "repo": "Netie-AI/Cortex",
+                    "number": 128,
+                    "title": "seated",
+                    "seated": True,
+                },
+                {
+                    "spec": "Netie-AI/Cortex#173",
+                    "repo": "Netie-AI/Cortex",
+                    "number": 173,
+                    "title": "request_close",
+                    "seated": False,
+                },
+            ],
+        },
+    )
+    store = CrewStore(tmp_path / "crew.db")
+    body = conveyor(store, WakeBoard(), JobQueue(), data_dir=data_dir)
+    ready = [row for row in body["tickets"]["items"] if row.get("ready")]
+    assert ready == [
+        {
+            "repo": "Netie-AI/Cortex",
+            "number": 173,
+            "title": "request_close",
+            "ready": True,
+            "url": "",
+            "spec": "Netie-AI/Cortex#173",
+        }
+    ]
+    store.close()

--- a/tests/test_crew/test_wakes.py
+++ b/tests/test_crew/test_wakes.py
@@ -127,3 +127,32 @@ def test_conveyor_adds_cached_unseated_issues(tmp_path, monkeypatch) -> None:
         }
     ]
     store.close()
+
+
+def test_warm_fetched_writes_cache_for_belt(tmp_path, monkeypatch) -> None:
+    from CortexOS.crew import github as github_mod
+
+    monkeypatch.setenv("CREW_CLAIMS", str(tmp_path / "missing-claims.json"))
+    monkeypatch.setenv("CREW_RUNTIME", str(tmp_path / "missing-runtime.md"))
+    monkeypatch.setattr(
+        github_mod,
+        "list_open_issues",
+        lambda **_k: {
+            "ok": True,
+            "issues": [
+                {
+                    "spec": "Netie-AI/Cortex#175",
+                    "repo": "Netie-AI/Cortex",
+                    "number": 175,
+                    "title": "belt cache",
+                    "seated": False,
+                }
+            ],
+        },
+    )
+    github_mod.warm_fetched(tmp_path / "crew")
+    store = CrewStore(tmp_path / "crew.db")
+    body = conveyor(store, WakeBoard(), JobQueue(), data_dir=tmp_path / "crew")
+    ready = [row for row in body["tickets"]["items"] if row.get("ready")]
+    assert ready[0]["spec"] == "Netie-AI/Cortex#175"
+    store.close()


### PR DESCRIPTION
## Summary
- `/fetch` and `GET /crew/tickets` cache open issues to `fetched_issues.json`.
- `GET /v1/belt` appends those as READY items, skipping SEATED/CLAIMS specs. No live `gh` on the belt path (Control times out at 1.5s).
- Control still display-only. Crew `/assign` executes.

## Test plan
- [x] `pytest tests/test_crew/test_wakes.py tests/test_crew/test_server.py::test_tickets_lists_fetched_github_issues_minus_claims`
- [ ] CI lint-type-test / base-install / protected-paths / rls-proof / secrets-scan
- [ ] After founder rebind of `:8020`, `/fetch` then Control `GET /v1/belt` shows READY unseated issues

Closes #175
