### PR TITLE
C7-05: serve L2_VALIDATED only after plausibility (#104)

### DIFF
--- a/CortexOS/dms/answer_engine.py
+++ b/CortexOS/dms/answer_engine.py
@@ -8,7 +8,8 @@ abstains rather than guess. This is the "adaptive, fail-then-escalate" core:
   L1 METRIC      rule-based intent+slot routing → compile a governed metric
                  template (Q1) → guardrail-verified SQL. Deterministic.
   L2 FREEFORM    (flag DMS_L2_ENABLED, default OFF) sampled LLM SQL →
-                 parse+allowlist+execute+vote+rails. Not wired until a model is.
+                 parse+allowlist+execute+plausibility. Badge L2_VALIDATED only
+                 after plausibility. Not the process default (C7-05).
   L3 ABSTAIN     no trustworthy layer fired → clarify + suggest nearest
                  answerable questions. Never the old confident-wrong fallback.
 
@@ -1829,10 +1830,14 @@ def answer(
         # the space-scoped document stub; keyword RAG never runs first.
         from CortexOS.dms.l2_generation import L2_MANIFEST_REASON_PREFIX, attempt_l2
 
-        l2_out = attempt_l2(question, verified=verified)
+        # promote=False: steward recording waits until plausibility passes.
+        l2_out = attempt_l2(question, verified=verified, promote=False)
         if l2_out is not None and l2_out.sql:
             sql = l2_out.sql
-            layer, badge = l2_out.layer, l2_out.badge
+            layer = "generated"
+            # Fail closed: L2Attempt.badge is L2_VALIDATED before execute.
+            # Serve that token only after assess_plausibility (below).
+            badge = "abstain"
             assumptions = l2_out.assumptions
             l2_retrieved = tuple(l2_out.retrieved_tables)
             from CortexOS.dms.l2_plausibility import sql_table_names
@@ -1949,6 +1954,7 @@ def answer(
         return _abs(f"internal SQL failed guardrail {guard_result.violations}")
 
     if layer == "generated":
+        from CortexOS.dms.l2_generation import resolve_l2_generation
         from CortexOS.dms.l2_plausibility import (
             assess_plausibility,
             leftover_literals_via_port,
@@ -1964,6 +1970,14 @@ def answer(
         )
         if not trip.ok:
             return _abs(trip.reason)
+        badge = "L2_VALIDATED"
+        try:
+            resolve_l2_generation().record_validated(question, used_sql)
+        except Exception:  # noqa: BLE001 — promotion must not block a gated serve
+            pass
+
+    if layer == "generated" and badge != "L2_VALIDATED":
+        return _abs("L2 serve blocked: plausibility did not pass")
 
     truncated = total_count is not None and len(rows) >= MAX_LIMIT and total_count > len(rows)
     answer_text = synthesize_answer(rows, question)

--- a/CortexOS/dms/l2_generation.py
+++ b/CortexOS/dms/l2_generation.py
@@ -128,6 +128,8 @@ def attempt_l2(
 
     ``force=True`` runs even when ``DMS_L2_ENABLED`` is unset (shadow).
     ``promote=False`` skips steward recording so shadow cannot mutate L0.
+    Serve (``answer``) must pass ``promote=False`` and stamp ``L2_VALIDATED``
+    only after plausibility — this return is not the customer envelope.
     Lives here so ``answer_engine`` never names pack generation modules.
     """
     if not force and not _env_on("DMS_L2_ENABLED"):

--- a/tests/dms/test_c7_05_serve.py
+++ b/tests/dms/test_c7_05_serve.py
@@ -1,0 +1,169 @@
+"""C7-05 — L2 serve only after plausibility; flag-off by default.
+
+Held-out G-sh/G-err are not green on published reports, so this does not
+flip DMS_L2_ENABLED as a process default or set bench cutover true.
+"""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+from CortexOS.dms.l2_plausibility import PlausibilityResult
+
+ROOT = Path(__file__).resolve().parents[2]
+ANSWER_ENGINE = ROOT / "CortexOS" / "dms" / "answer_engine.py"
+
+
+class _InventoryPort:
+    def is_configured(self) -> bool:
+        return True
+
+    def retrieve_schema(self, question: str) -> dict:
+        del question
+        return {"tables": {"inventory": {}}}
+
+    def generate_candidates(self, question, schema, *, prior_violations=None):
+        del question, schema, prior_violations
+        return ["SELECT sku FROM inventory LIMIT 5"]
+
+    def record_validated(self, question, sql):
+        del question, sql
+        return None
+
+
+def _force_l0_l1_miss(monkeypatch) -> None:
+    monkeypatch.setattr("CortexOS.dms.answer_engine.match_certified", lambda q: None)
+    monkeypatch.setattr("CortexOS.dms.answer_engine.route_to_metric", lambda q: None)
+    monkeypatch.setattr("CortexOS.dms.answer_engine.undefined_subject", lambda q: None)
+    monkeypatch.setattr("CortexOS.dms.answer_engine._shape_refusal", lambda q: None)
+    monkeypatch.setattr("packs.dms.semantic.query_skills.find", lambda *a, **k: None)
+    monkeypatch.setattr(
+        "packs.dms.semantic.catalog_answer.is_catalog_intent", lambda q: False
+    )
+
+
+def _ask_l2(monkeypatch, port, *, enabled: str | None = "1"):
+    from CortexOS.dms import l2_generation
+    from CortexOS.dms.answer_engine import answer
+
+    if enabled is None:
+        monkeypatch.delenv("DMS_L2_ENABLED", raising=False)
+    else:
+        monkeypatch.setenv("DMS_L2_ENABLED", enabled)
+    from bench.accuracy import _ensure_db_loaded
+
+    _ensure_db_loaded()
+    monkeypatch.setattr(l2_generation, "resolve_l2_generation", lambda: port)
+    _force_l0_l1_miss(monkeypatch)
+    return answer("list some skus from inventory stock")
+
+
+def test_l2_flag_off_cannot_serve_generated(monkeypatch):
+    r = _ask_l2(monkeypatch, _InventoryPort(), enabled=None)
+    assert r.get("layer") != "generated"
+    assert r.get("badge") != "L2_VALIDATED"
+    assert r.get("rows") == []
+    assert r["route"] != "sql"
+
+
+def test_plausibility_trip_stays_abstain_not_l2(monkeypatch):
+    from CortexOS.dms import l2_plausibility
+
+    monkeypatch.setattr(
+        l2_plausibility,
+        "assess_plausibility",
+        lambda *a, **k: PlausibilityResult(
+            ok=False, code="implausible_empty", reason="empty-success: forced"
+        ),
+    )
+    r = _ask_l2(monkeypatch, _InventoryPort())
+    assert r["badge"] == "abstain"
+    assert r["layer"] == "abstain"
+    assert r["rows"] == []
+    assert r.get("sql_used") is None
+    assert "empty-success" in (r.get("assumptions") or "")
+    assert "empty-success" in (r.get("answer") or "")
+    assert r.get("badge") != "L2_VALIDATED"
+
+
+def test_gated_serve_calls_plausibility_before_l2_validated(monkeypatch):
+    from CortexOS.dms import l2_plausibility
+
+    calls: list[int] = []
+    real = l2_plausibility.assess_plausibility
+
+    def wrapped(*args, **kwargs):
+        calls.append(1)
+        return real(*args, **kwargs)
+
+    monkeypatch.setattr(l2_plausibility, "assess_plausibility", wrapped)
+    r = _ask_l2(monkeypatch, _InventoryPort())
+    assert calls, "serve path skipped assess_plausibility"
+    assert r["layer"] == "generated"
+    assert r["badge"] == "L2_VALIDATED"
+    assert r["route"] == "sql"
+    rows = r.get("rows") or []
+    assert rows
+    rendered = r.get("answer") or ""
+    assert rendered.strip()
+    for row in rows:
+        sku = str(row.get("sku") or "")
+        assert sku
+        assert sku in rendered
+
+
+def test_answer_engine_stamps_l2_validated_only_after_plausibility():
+    """Deleting the plausibility call must not leave an earlier L2_VALIDATED copy."""
+    text = ANSWER_ENGINE.read_text(encoding="utf-8")
+    start = text.index("def answer(")
+    body = text[start:]
+    assert "l2_out.badge" not in body
+    assert 'badge = "L2_VALIDATED"' in body
+    assert body.index("assess_plausibility(") < body.index('badge = "L2_VALIDATED"')
+    assert 'layer == "generated" and badge != "L2_VALIDATED"' in body
+    assert "promote=False" in body
+
+    tree = ast.parse(text, filename=str(ANSWER_ENGINE))
+    leaked = []
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            leaked.extend(
+                alias.name
+                for alias in node.names
+                if alias.name == "packs" or alias.name.startswith("packs.")
+            )
+        elif isinstance(node, ast.ImportFrom) and node.module:
+            if node.module == "packs" or node.module.startswith("packs."):
+                leaked.append(node.module)
+    # answer_engine already imports packs.dms.semantic (pre-C2). Do not add generative.
+    assert "packs.dms.generative" not in leaked
+    src = text
+    assert "packs.dms.generative" not in src
+    assert "sql_generator" not in src
+
+
+def test_score_engine_cutover_stays_false_when_l2_flag_on():
+    from bench.heldout import HeldoutItem, score_engine
+
+    item = HeldoutItem(
+        id="abs",
+        split="must_abstain",
+        provenance="different_model_abstain",
+        question="berlin weather esg 1997",
+        expect="abstain",
+    )
+
+    def ask(question: str) -> dict:
+        del question
+        return {
+            "answer": "I can't answer that.",
+            "rows": [],
+            "badge": "abstain",
+            "route": "needs_clarification",
+        }
+
+    report = score_engine([item], ask=ask, enable_l2=True, count_shadow=False)
+    assert report["cutover"] is False
+    assert report["l2_enabled_for_run"] is True
+    assert report["gates"]["g_sh"] is False


### PR DESCRIPTION
## Summary
- Parent **EPIC-006 / Cortex#17**. Ticket **Cortex#104**. Does not implement C7-06 (#105). Ignores draft PR #128. Does not delete the 25 `_metric_plan` branches.
- `DMS_L2_ENABLED=1` may serve `layer=generated` / `badge=L2_VALIDATED` only after execute + `assess_plausibility`. A plausibility trip stays `badge=abstain` with empty rows (C7-03). `attempt_l2` no longer copies `L2_VALIDATED` onto the customer envelope, and promote waits until plausibility passes.
- **Did not** set `DMS_L2_ENABLED` as the process default. `bench.heldout.score_engine` still forces `cutover=False`.

## C7-04 harness
- Issue **#103 CLOSED**, PR **#121 merged**. `tests/dms/test_c7_heldout.py` is the frozen harness.
- Held-out G-gates are **not** all green on published reports, so default serve stays off.

## Held-out numbers (not re-run live this PR)
This session did **not** run `python -m bench.heldout --engine --enable-l2` (needs FreeRoute / leave-machine). Numbers below are last published, not invented.

| Gate | Need | Last published | This PR |
|---|---|---|---|
| G-abs | must_abstain recall = 1.0 | true (PR #126 / L1 after #149) | not re-scored live |
| G-err | incorrect_rate < 0.02 | PR #126 L1: 10 incorrect / 28. After #149 L1: 1 correct / 27 abstained / 0 incorrect. No L2-on-miss serve report with G-err < 2%. | not claimed |
| G-env | 0 empty-success hits | true on those L1 reports | not re-scored live |
| G-man | `pytest tests/test_execution` | harness sets `g_man = None` | not run in this PR |
| G-sh | shadow_lines >= 500 | 0 on PR #126 and draft #128 | not claimed |
| cutover | serve L2 after full pipeline | hardcoded false | still false |

## Test plan
- [x] `pytest tests/dms/test_c7_05_serve.py tests/dms/test_l2_plausibility.py tests/dms/test_c7_heldout.py tests/dms/test_c7_l2_shadow.py tests/dms/test_q2_answer_engine.py::test_l2_disabled_by_default -q` (39 passed)
- [x] `pytest tests/dms/test_c7_02_manifest_before_explain.py tests/dms/test_sql_validate_gate.py tests/dms/test_c7_full_generation.py -q` (32 passed)
- [ ] Live `python -m bench.heldout --engine --enable-l2` plus G-sh >= 500 before treating #104 as closable
- [ ] Do not merge C7-06 #128 from this ticket

## What this does not prove
G-sh >= 500, L2-on-miss G-err < 2% on FreeRoute, or SHADOW-off p95 vs a prior live baseline. Flag-off L0/L1 path is unchanged except a cheap generated-layer guard.

Made with [Cursor](https://cursor.com)