### PR TITLE
RSF-02: Cortex consumer refuses invent-green artifacts

### DIFF
--- a/CortexOS/rsf.py
+++ b/CortexOS/rsf.py
@@ -1,0 +1,67 @@
+"""RSF-02 Cortex consumer. Schema of record: DMS dms_core.rsf (HTTP JSON).
+
+Inbound body fields: artifact_id, stage, question, options, chosen_option,
+route_trace, evidence, status, reasons. No dms_core import, no CCA, no
+cortex_contract bump, no /v1/rsf route -- RSF-04 calls parse_rsf_artifact.
+
+Analog reuse: TAS-CONSTRUCTOR. Live: tests/dms/test_constructor_graph.py
+(kind n8n refused). Analog read-only: none.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from dataclasses import dataclass
+from typing import Any
+
+RSF_STAGES = ("research", "segment", "classify", "filter")
+RSF_STATUSES = frozenset({"CERTIFIED", "ABSTAIN", "REFUSE"})
+
+
+class RsfConsumerError(ValueError):
+    """Invent-green or unknown RSF wire shape. Fail closed."""
+
+
+@dataclass(frozen=True)
+class RsfArtifact:
+    status: str
+    options: tuple[str, ...]
+    chosen_option: str | None = None
+    evidence: tuple[str, ...] = ()
+    stage: str = "research"
+
+    def __post_init__(self) -> None:
+        object.__setattr__(self, "options", tuple(self.options))
+        object.__setattr__(self, "evidence", tuple(self.evidence))
+        if self.stage not in RSF_STAGES:
+            raise RsfConsumerError(f"unknown RSF stage {self.stage!r}")
+        if self.status not in RSF_STATUSES:
+            raise RsfConsumerError(f"unknown status {self.status!r}")
+        if self.status == "CERTIFIED":
+            if not self.chosen_option or self.chosen_option not in self.options:
+                raise RsfConsumerError("CERTIFIED requires chosen_option in options")
+            if not self.evidence:
+                raise RsfConsumerError("CERTIFIED requires evidence")
+        elif self.chosen_option is not None:
+            raise RsfConsumerError(f"{self.status} must not carry a chosen_option")
+
+
+def parse_rsf_artifact(raw: Any) -> RsfArtifact:
+    if not isinstance(raw, Mapping):
+        raise RsfConsumerError("RSF artifact must be an object")
+    chosen = raw.get("chosen_option")
+    if chosen is not None and not isinstance(chosen, str):
+        raise RsfConsumerError("chosen_option must be a string or null")
+    options = raw.get("options") or ()
+    evidence = raw.get("evidence") or ()
+    if not isinstance(options, (list, tuple)) or not all(isinstance(x, str) for x in options):
+        raise RsfConsumerError("options must be a list of strings")
+    if not isinstance(evidence, (list, tuple)) or not all(isinstance(x, str) for x in evidence):
+        raise RsfConsumerError("evidence must be a list of strings")
+    return RsfArtifact(
+        status=str(raw.get("status") or ""),
+        options=tuple(options),
+        chosen_option=chosen,
+        evidence=tuple(evidence),
+        stage=str(raw.get("stage") or ""),
+    )

--- a/tests/test_rsf_consumer.py
+++ b/tests/test_rsf_consumer.py
@@ -1,0 +1,20 @@
+"""RSF-02 Cortex consumer: invent-green CERTIFIED must raise, not type-check."""
+
+from __future__ import annotations
+
+import pytest
+
+from CortexOS.rsf import RsfConsumerError, parse_rsf_artifact
+
+
+def test_certified_without_chosen_option_is_refused() -> None:
+    with pytest.raises(RsfConsumerError, match="chosen_option"):
+        parse_rsf_artifact(
+            {
+                "stage": "segment",
+                "status": "CERTIFIED",
+                "chosen_option": None,
+                "options": ["region", "country"],
+                "evidence": ["column=sales_fact.region"],
+            }
+        )


### PR DESCRIPTION
## Summary
- Thin Cortex consumer for the DMS RSF wire (dms_core.rsf): CortexOS/rsf.py parse_rsf_artifact.
- Refuses invent-green (CERTIFIED with no chosen_option). No dms_core import, no CCA, no contract/OpenAPI bump, no /v1/rsf route.
- Serves Netie-AI/dms#140 Cortex half and Cortex#151. RSF-04 can call this in-process.

## Test plan
- [x] python -m pytest tests/test_rsf_consumer.py -q (1 passed)
- [ ] CI ruff/mypy/pytest on this branch

Made with [Cursor](https://cursor.com)