### PR TITLE
RSF-01: distill-options registry and Constructor engine BAN

### DIFF
--- a/.importlinter
+++ b/.importlinter
@@ -2,7 +2,10 @@
 root_packages =
     CortexOS
     packs
-include_external_packages = False
+# Required so contract 3 can forbid n8n/langchain/langflow/gencfsm without
+# vendoring them. Contract 1 then also sees function-level packs imports that
+# grimp previously skipped; those already live on the AST C2 allowlist.
+include_external_packages = True
 
 [importlinter:contract:1]
 name = the engine never reaches into a pack (C2 boundary)
@@ -39,6 +42,7 @@ ignore_imports =
     CortexOS.api.context_routes -> packs.**
     CortexOS.dms.query_service -> packs.**
     CortexOS.dms.seed_demo -> packs.**
+    CortexOS.dms.answer_engine -> packs
     CortexOS.nlp.local_inference -> packs.**
     CortexOS.execution.tool_runner -> packs.**
     CortexOS.ponytail.middleware -> packs.**
@@ -54,3 +58,18 @@ independent_from =
     CortexOS.execution.dag_runner
     CortexOS.execution.osr
     CortexOS.execution.seeker
+
+[importlinter:contract:3]
+name = constructor engine never imports n8n/langchain/langflow/gencfsm as engine
+type = forbidden
+source_modules =
+    CortexOS.constructor_graph
+    CortexOS.execution.distill_options
+forbidden_modules =
+    n8n
+    langchain
+    langchain_core
+    langchain_community
+    langflow
+    langgraph
+    gencfsm

--- a/CortexOS/api/engine_routes.py
+++ b/CortexOS/api/engine_routes.py
@@ -16,7 +16,7 @@ from fastapi import APIRouter, Depends, HTTPException
 from netie.engine import registry
 from pydantic import BaseModel, Field
 
-from CortexOS.execution import architecture_presets
+from CortexOS.execution import architecture_presets, distill_options
 from CortexOS.execution.preset_router import plan_for_request
 from CortexOS.execution.run_plan import execute_run_plan
 from CortexOS.paths import data_path
@@ -138,6 +138,7 @@ async def engine_backends(caller: Caller = Depends(require_role("viewer"))) -> d
              "blurb": "Chain/tool runtime — install via marketplace, runs behind the Cortex gate."},
         ],
         "architecture_presets": architecture_presets.catalog(),
+        "distill_options": distill_options.catalog(),
         "coordination_patterns_hint": (
             "GET /api/engine/coordination-patterns — Anthropic multi-agent "
             "pattern catalog mapped to Cortex runners"

--- a/CortexOS/constructor_graph.py
+++ b/CortexOS/constructor_graph.py
@@ -25,6 +25,9 @@ _KINDS = frozenset(
     }
 )
 
+# Distill-option ids / analog engines. Not Constructor canvas kinds.
+_BANNED_ENGINE_KINDS = frozenset({"n8n", "myn8n", "langchain", "langflow", "gencfsm_dag"})
+
 _KIND_TO_TYPE = {
     "ingest": NodeType.DOCUMENT_REF,
     "connector": NodeType.DOCUMENT_REF,
@@ -59,6 +62,10 @@ def compile_constructor_graph(payload: dict[str, Any]) -> AgenticDSLProgram:
         if not isinstance(raw, dict) or not isinstance(raw.get("id"), str):
             raise ConstructorGraphError("each node needs a string id")
         kind = raw.get("kind")
+        if kind in _BANNED_ENGINE_KINDS:
+            raise ConstructorGraphError(
+                f"{kind!r} is a distill-only analog; not a Constructor engine kind"
+            )
         if kind not in _KINDS:
             raise ConstructorGraphError(f"unknown kind {kind!r}")
         if raw["id"] in by_id:

--- a/CortexOS/execution/architecture_presets.py
+++ b/CortexOS/execution/architecture_presets.py
@@ -2,6 +2,10 @@
 
 Does not execute a new orchestrator. Maps preset id → existing Cortex paths
 (dag_runner, memory/RAG assemble, marketplace adapters behind the Cortex gate).
+
+Constructor distill-options (myn8n / langchain / langflow / gencfsm_dag) are
+not product presets. See ``CortexOS.execution.distill_options`` — route table
+only, engine_role never product_engine.
 """
 
 from __future__ import annotations

--- a/CortexOS/execution/distill_options.py
+++ b/CortexOS/execution/distill_options.py
@@ -1,0 +1,189 @@
+"""Constructor distill-options registry (RSF-01).
+
+Orchestrator-of-orchestrators contract: this is a meta-router route table,
+not a Constructor embed and not a third orchestrator daemon.
+
+Option ids may be distill_only / compete / learn. They are never
+product_engine. Cortex Constructor remains the only product engine.
+
+myn8n / langchain / langflow are listed so we can distill and compete against
+them. Do not vendor those upstream trees into Constructor.
+
+gencfsm_dag routes at the existing Cortex compile path
+``CortexOS.execution.gen_cfsm`` → ``CortexOS.execution.dag_runner``.
+
+Egress for option runs is OpenVault FreeRoute (config key / path only).
+OmniRoute on :20128 is vendor/study (DR-0003 / TAS-OPENVAULT §10) — do not
+vendor it.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Any, Literal
+
+EngineRole = Literal["distill_only", "compete", "learn"]
+
+ALLOWED_ENGINE_ROLES: frozenset[str] = frozenset({"distill_only", "compete", "learn"})
+PRODUCT_ENGINE_ROLE = "product_engine"
+
+# Upstream packages that must never be imported as Constructor engine.
+# CortexOS.execution.gen_cfsm is Cortex's own module and is allowed.
+BANNED_ENGINE_IMPORT_PREFIXES: tuple[str, ...] = (
+    "n8n",
+    "langchain",
+    "langchain_core",
+    "langchain_community",
+    "langflow",
+    "langgraph",
+    "gencfsm",
+)
+
+REQUIRED_OPTION_IDS: tuple[str, ...] = (
+    "myn8n",
+    "langchain",
+    "langflow",
+    "gencfsm_dag",
+)
+
+# OpenVault FreeRoute — comment + config key only. Do not vendor :20128.
+EGRESS_CONFIG_KEY = "OPENVAULT_URL"
+FREEROUTE_PATH = "/api/freeroute/ratelimit"
+OMNIROUTE_VENDOR_PORT = 20128
+
+_EGRESS = {
+    "config_key": EGRESS_CONFIG_KEY,
+    "freeroute_path": FREEROUTE_PATH,
+    "note": (
+        "Option-run egress is OpenVault FreeRoute via OPENVAULT_URL. "
+        "OmniRoute :20128 stays vendor/study; do not vendor it."
+    ),
+}
+
+_GENCFSM_ROUTE = {
+    "kind": "meta_router_route",
+    "module": "CortexOS.execution.gen_cfsm",
+    "via": "CortexOS.execution.dag_runner",
+    "note": "Existing Cortex compile path. No third orchestrator daemon.",
+}
+
+_DISTILL_ROUTE = {
+    "kind": "meta_router_route",
+    "module": None,
+    "via": None,
+    "note": "Distill-only analog. Not a Constructor engine import.",
+}
+
+
+def _option(
+    option_id: str,
+    *,
+    name: str,
+    engine_role: EngineRole,
+    route: dict[str, Any],
+    blurb: str,
+) -> dict[str, Any]:
+    return {
+        "id": option_id,
+        "name": name,
+        "engine_role": engine_role,
+        "adapter": "meta_router",
+        "route": dict(route),
+        "egress": dict(_EGRESS),
+        "blurb": blurb,
+    }
+
+
+_BUILTIN: list[dict[str, Any]] = [
+    _option(
+        "myn8n",
+        name="n8n (distill)",
+        engine_role="distill_only",
+        route=_DISTILL_ROUTE,
+        blurb="Analog workflow UI to distill. Never the Constructor engine.",
+    ),
+    _option(
+        "langchain",
+        name="LangChain (distill)",
+        engine_role="distill_only",
+        route=_DISTILL_ROUTE,
+        blurb="Analog chain/tool runtime to distill. Never the Constructor engine.",
+    ),
+    _option(
+        "langflow",
+        name="LangFlow (distill)",
+        engine_role="distill_only",
+        route=_DISTILL_ROUTE,
+        blurb="Analog flow canvas to distill. Never the Constructor engine.",
+    ),
+    _option(
+        "gencfsm_dag",
+        name="gen-cFSM DAG (learn)",
+        engine_role="learn",
+        route=_GENCFSM_ROUTE,
+        blurb="Learn/bake-off via CortexOS.execution.gen_cfsm → dag_runner.",
+    ),
+]
+
+_REGISTRY: list[dict[str, Any]] = [dict(row) for row in _BUILTIN]
+
+
+def _validate(entry: Mapping[str, Any]) -> None:
+    option_id = entry.get("id")
+    if not isinstance(option_id, str) or not option_id.strip():
+        raise ValueError("distill option needs a string id")
+    role = entry.get("engine_role")
+    if role == PRODUCT_ENGINE_ROLE or role not in ALLOWED_ENGINE_ROLES:
+        raise ValueError(
+            f"{option_id!r} engine_role must be one of {sorted(ALLOWED_ENGINE_ROLES)}; "
+            "never product_engine"
+        )
+    adapter = entry.get("adapter")
+    if adapter != "meta_router":
+        raise ValueError(f"{option_id!r} adapter must be meta_router (route table, not a daemon)")
+
+
+def catalog() -> list[dict[str, Any]]:
+    return [dict(row) for row in _REGISTRY]
+
+
+def option_ids() -> frozenset[str]:
+    return frozenset(str(row["id"]) for row in _REGISTRY)
+
+
+def get_option(option_id: str) -> dict[str, Any]:
+    for row in _REGISTRY:
+        if row["id"] == option_id:
+            return dict(row)
+    raise KeyError(option_id)
+
+
+def register_option(entry: Mapping[str, Any]) -> None:
+    """RSF-03/04/06 hook: extra distill options. Does not start those slices."""
+    _validate(entry)
+    oid = str(entry["id"])
+    if any(row["id"] == oid for row in _REGISTRY):
+        raise ValueError(f"distill option {oid!r} already registered")
+    _REGISTRY.append(dict(entry))
+
+
+def reset_registry() -> None:
+    """Test helper. Restores the built-in table."""
+    _REGISTRY.clear()
+    _REGISTRY.extend(dict(row) for row in _BUILTIN)
+
+
+def is_banned_engine_import(module: str) -> bool:
+    """True if ``module`` would mean shipping an analog as Constructor engine."""
+    if module == "CortexOS.execution.gen_cfsm" or module.startswith(
+        "CortexOS.execution.gen_cfsm."
+    ):
+        return False
+    root = module.split(".", 1)[0]
+    if root.startswith("langchain"):
+        return True
+    return any(root == prefix or module.startswith(prefix + ".") for prefix in BANNED_ENGINE_IMPORT_PREFIXES)
+
+
+for _row in _BUILTIN:
+    _validate(_row)

--- a/tests/contract/fixtures/rsf01_banned_engine_import.py
+++ b/tests/contract/fixtures/rsf01_banned_engine_import.py
@@ -1,0 +1,15 @@
+"""R-0007 poison fixture. Parsed as AST only — never imported by production.
+
+If the Constructor-engine BAN list is emptied, test_constructor_engine_ban
+fails because this file still contains these imports.
+"""
+
+# ruff: noqa: F401
+
+
+def _poison_constructor_engine_import() -> None:
+    import gencfsm
+    import langchain
+    import langflow
+    import n8n
+    from langchain_core import agents as _langchain_core_agents

--- a/tests/contract/test_constructor_engine_ban.py
+++ b/tests/contract/test_constructor_engine_ban.py
@@ -1,0 +1,103 @@
+"""Constructor engine must not import n8n/langchain/langflow/gencfsm as engine.
+
+R-0007: the poison fixture under tests/contract/fixtures/ is the check that
+this gate can fail. Production CortexOS is scanned separately and must stay
+clean. Upstream trees are not vendored.
+"""
+
+from __future__ import annotations
+
+import ast
+from configparser import ConfigParser
+from pathlib import Path
+
+from CortexOS.execution.distill_options import (
+    BANNED_ENGINE_IMPORT_PREFIXES,
+    REQUIRED_OPTION_IDS,
+    is_banned_engine_import,
+)
+
+ROOT = Path(__file__).resolve().parents[2]
+FIXTURE = Path(__file__).resolve().parent / "fixtures" / "rsf01_banned_engine_import.py"
+CONSTRUCTOR_ENGINE_PATHS = (
+    ROOT / "CortexOS" / "constructor_graph.py",
+    ROOT / "CortexOS" / "execution" / "distill_options.py",
+    ROOT / "packs" / "dms" / "constructor_routes.py",
+    ROOT / "packs" / "dms" / "constructor_fetch.py",
+)
+
+
+def _imported_modules(path: Path) -> list[str]:
+    tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+    out: list[str] = []
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            out.extend(alias.name for alias in node.names)
+        elif isinstance(node, ast.ImportFrom) and node.module:
+            out.append(node.module)
+    return out
+
+
+def _violations(path: Path) -> list[str]:
+    return [mod for mod in _imported_modules(path) if is_banned_engine_import(mod)]
+
+
+def test_ban_prefixes_cover_required_analogs() -> None:
+    locked = {prefix.split("_", 1)[0] for prefix in BANNED_ENGINE_IMPORT_PREFIXES}
+    assert {"n8n", "langchain", "langflow", "gencfsm"} <= locked
+
+
+def test_poison_fixture_is_caught() -> None:
+    """If BAN is removed, this assertion fails — the fixture still imports analogs."""
+    hits = _violations(FIXTURE)
+    assert "n8n" in hits
+    assert "langchain" in hits
+    assert "langflow" in hits
+    assert "gencfsm" in hits
+    assert any(is_banned_engine_import(mod) for mod in hits)
+
+
+def test_constructor_engine_modules_have_no_banned_imports() -> None:
+    offenders: list[str] = []
+    for path in CONSTRUCTOR_ENGINE_PATHS:
+        if not path.is_file():
+            offenders.append(f"{path.as_posix()} (missing)")
+            continue
+        offenders.extend(f"{path.relative_to(ROOT).as_posix()}:{mod}" for mod in _violations(path))
+    assert not offenders, "Constructor engine imported a banned analog:\n" + "\n".join(offenders)
+
+
+def test_cortex_gen_cfsm_is_not_a_banned_import() -> None:
+    assert not is_banned_engine_import("CortexOS.execution.gen_cfsm")
+    assert not is_banned_engine_import("CortexOS.execution.gen_cfsm.compile_ir")
+
+
+def test_importlinter_contract_forbids_banned_engines() -> None:
+    parser = ConfigParser()
+    parser.read(ROOT / ".importlinter", encoding="utf-8")
+    section = "importlinter:contract:3"
+    assert parser.has_section(section), "missing import-linter Constructor engine BAN contract"
+    forbidden = {
+        line.strip()
+        for line in parser.get(section, "forbidden_modules").splitlines()
+        if line.strip()
+    }
+    for name in ("n8n", "langchain", "langflow", "gencfsm"):
+        assert name in forbidden, f"{name} missing from import-linter contract 3"
+    sources = {
+        line.strip()
+        for line in parser.get(section, "source_modules").splitlines()
+        if line.strip()
+    }
+    assert "CortexOS.constructor_graph" in sources
+    assert "CortexOS.execution.distill_options" in sources
+    assert parser.getboolean("importlinter", "include_external_packages") is True
+
+
+def test_required_option_ids_cannot_be_product_engine() -> None:
+    from CortexOS.execution.distill_options import catalog
+
+    by_id = {row["id"]: row for row in catalog()}
+    for option_id in REQUIRED_OPTION_IDS:
+        assert by_id[option_id]["engine_role"] != "product_engine"
+        assert by_id[option_id]["engine_role"] in {"distill_only", "compete", "learn"}

--- a/tests/dms/test_architecture_presets.py
+++ b/tests/dms/test_architecture_presets.py
@@ -46,6 +46,11 @@ def test_engine_backends_lists_architecture_presets(engine_client):
     assert res.status_code == 200
     data = res.json()
     assert any(p["id"] == "minimal" for p in data["architecture_presets"])
+    option_ids = {row["id"] for row in data["distill_options"]}
+    assert {"myn8n", "langchain", "langflow", "gencfsm_dag"} <= option_ids
+    by_id = {row["id"]: row for row in data["distill_options"]}
+    assert by_id["myn8n"]["engine_role"] == "distill_only"
+    assert by_id["gencfsm_dag"]["engine_role"] != "product_engine"
 
 
 def test_engine_config_architecture_preset_roundtrip(engine_client):

--- a/tests/dms/test_constructor_graph.py
+++ b/tests/dms/test_constructor_graph.py
@@ -67,6 +67,12 @@ def test_compile_rejects_unknown_kind():
         compile_constructor_graph({"nodes": [{"id": "x", "kind": "n8n"}], "edges": []})
 
 
+def test_compile_rejects_banned_engine_kinds():
+    for kind in ("n8n", "myn8n", "langchain", "langflow", "gencfsm_dag"):
+        with pytest.raises(ConstructorGraphError, match="distill-only analog"):
+            compile_constructor_graph({"nodes": [{"id": "x", "kind": kind}], "edges": []})
+
+
 def test_compile_enhance_kind_is_document_ref():
     from netie.fabrication.dsl_parser import NodeType
 

--- a/tests/dms/test_distill_options.py
+++ b/tests/dms/test_distill_options.py
@@ -1,0 +1,96 @@
+"""Constructor distill-options registry schema (RSF-01)."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from CortexOS.execution.distill_options import (
+    ALLOWED_ENGINE_ROLES,
+    EGRESS_CONFIG_KEY,
+    FREEROUTE_PATH,
+    OMNIROUTE_VENDOR_PORT,
+    PRODUCT_ENGINE_ROLE,
+    REQUIRED_OPTION_IDS,
+    catalog,
+    get_option,
+    register_option,
+    reset_registry,
+)
+
+DISTILL_OPTIONS_PY = (
+    Path(__file__).resolve().parents[2] / "CortexOS" / "execution" / "distill_options.py"
+)
+
+
+@pytest.fixture(autouse=True)
+def _restore_registry():
+    yield
+    reset_registry()
+
+
+def test_required_ids_are_present_and_extensible():
+    ids = {row["id"] for row in catalog()}
+    assert set(REQUIRED_OPTION_IDS) <= ids
+    register_option(
+        {
+            "id": "rsf_hook",
+            "name": "RSF hook",
+            "engine_role": "compete",
+            "adapter": "meta_router",
+            "route": {"kind": "meta_router_route", "module": None, "via": None},
+            "egress": {"config_key": EGRESS_CONFIG_KEY},
+            "blurb": "Tiny RSF-03/04/06 hook. Not a product engine.",
+        }
+    )
+    assert "rsf_hook" in {row["id"] for row in catalog()}
+
+
+def test_required_roles_never_product_engine():
+    for row in catalog():
+        if row["id"] not in REQUIRED_OPTION_IDS:
+            continue
+        assert row["engine_role"] in ALLOWED_ENGINE_ROLES
+        assert row["engine_role"] != PRODUCT_ENGINE_ROLE
+        assert row["adapter"] == "meta_router"
+
+
+def test_analogs_are_distill_only():
+    for option_id in ("myn8n", "langchain", "langflow"):
+        assert get_option(option_id)["engine_role"] == "distill_only"
+        assert get_option(option_id)["route"]["module"] is None
+
+
+def test_gencfsm_dag_points_at_existing_gen_cfsm_dag_runner():
+    row = get_option("gencfsm_dag")
+    assert row["engine_role"] == "learn"
+    assert row["route"]["module"] == "CortexOS.execution.gen_cfsm"
+    assert row["route"]["via"] == "CortexOS.execution.dag_runner"
+    gen_cfsm_py = DISTILL_OPTIONS_PY.parent / "gen_cfsm.py"
+    assert gen_cfsm_py.is_file()
+    source = gen_cfsm_py.read_text(encoding="utf-8")
+    assert "from CortexOS.execution.dag_runner import" in source
+    assert "No third orchestrator" in source
+
+
+def test_register_option_rejects_product_engine():
+    with pytest.raises(ValueError, match="product_engine"):
+        register_option(
+            {
+                "id": "evil",
+                "engine_role": "product_engine",
+                "adapter": "meta_router",
+            }
+        )
+
+
+def test_freeroute_egress_is_config_key_only():
+    source = DISTILL_OPTIONS_PY.read_text(encoding="utf-8")
+    for row in catalog():
+        assert row["egress"]["config_key"] == EGRESS_CONFIG_KEY
+        assert row["egress"]["freeroute_path"] == FREEROUTE_PATH
+        assert "20128" in row["egress"]["note"]
+    assert OMNIROUTE_VENDOR_PORT == 20128
+    assert "127.0.0.1:20128" not in source
+    assert "do not vendor" in source.lower()


### PR DESCRIPTION
## Summary
- Constructor distill-options registry (`myn8n`, `langchain`, `langflow`, `gencfsm_dag`) with `engine_role` in `{distill_only, compete, learn}` and never `product_engine`.
- Adapters are a meta-router route table. `gencfsm_dag` points at existing `CortexOS.execution.gen_cfsm` -> `dag_runner`. FreeRoute is `OPENVAULT_URL` / `/api/freeroute/ratelimit` only (no OmniRoute `:20128`).
- CI/import-linter BAN: contract 3 plus AST poison fixture (R-0007) without vendoring n8n/LC/LF/GenCFSM. Closes #152. Parent EPIC-RSF #151.

## Test plan
- [x] `pytest tests/contract/test_constructor_engine_ban.py tests/dms/test_distill_options.py tests/dms/test_constructor_graph.py tests/dms/test_architecture_presets.py tests/contract/test_import_boundaries.py` (54 passed)
- [x] `ruff check` on touched CortexOS + tests/contract
- [x] `lint-imports` 3 kept, 0 broken

Made with [Cursor](https://cursor.com)