### PR TITLE
RSF-03: OpenVault leave-machine gates and study-tree role lock

### DIFF
--- a/.importlinter
+++ b/.importlinter
@@ -65,6 +65,7 @@ type = forbidden
 source_modules =
     CortexOS.constructor_graph
     CortexOS.execution.distill_options
+    CortexOS.execution.rsf_boundary
 forbidden_modules =
     n8n
     langchain

--- a/CortexOS/execution/rsf_boundary.py
+++ b/CortexOS/execution/rsf_boundary.py
@@ -1,0 +1,166 @@
+"""RSF-03 boundary gates: OpenVault leave-machine + fair-code study trees.
+
+Research egress uses existing OpenVault ``check_gate`` (action=leave,
+destination=freeroute). Unreachable OpenVault fails closed. OmniRoute :20128
+is refused, never vendored.
+
+Distill may list analog study trees (D:\\myn8n, langchain, langflow) but
+must not promote them to Constructor ``product_engine``. RSF-06 owns the
+distill harness; this slice only names the trees and keeps the role lock.
+"""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+from typing import Any
+
+from CortexOS.execution.distill_options import (
+    OMNIROUTE_VENDOR_PORT,
+    PRODUCT_ENGINE_ROLE,
+    get_option,
+)
+
+BAN_FLOORS: tuple[str, ...] = (
+    "silent upstream engine",
+    "skip OpenVault",
+    "n8n/langchain/langflow as product_engine",
+    "vendor OmniRoute :20128",
+)
+
+STUDY_TREE_OPTION_IDS: frozenset[str] = frozenset({"myn8n", "langchain", "langflow"})
+
+_DEFAULT_STUDY_TREES: dict[str, Path] = {
+    "myn8n": Path("D:/myn8n"),
+    "langchain": Path("D:/langchain"),
+    "langflow": Path("D:/langflow"),
+}
+
+_SAMPLE_CAP = 8
+
+
+def is_omniroute_destination(destination: str) -> bool:
+    blob = (destination or "").strip().lower()
+    if not blob:
+        return False
+    if str(OMNIROUTE_VENDOR_PORT) in blob:
+        return True
+    return "omniroute" in blob
+
+
+def study_tree_root(option_id: str, *, root: Path | None = None) -> Path:
+    if root is not None:
+        return Path(root)
+    env = os.environ.get(f"RSF_STUDY_TREE_{option_id.upper()}")
+    if env:
+        return Path(env)
+    return _DEFAULT_STUDY_TREES[option_id]
+
+
+def gate_research_egress(*, destination: str = "freeroute") -> dict[str, Any]:
+    """Ask OpenVault leave-machine. Prefer FreeRoute. Fail closed.
+
+    Does not fetch. RSF-04 owns the orchestrator hop after this gate.
+    """
+    dest = (destination or "").strip() or "freeroute"
+    if is_omniroute_destination(dest):
+        return {
+            "ok": False,
+            "allowed": False,
+            "action": "leave",
+            "requested": dest,
+            "destination": "freeroute",
+            "route": "omniroute_gated",
+            "reasons": [
+                "OmniRoute is gated; prefer FreeRoute. "
+                f"Do not vendor :{OMNIROUTE_VENDOR_PORT}."
+            ],
+        }
+
+    from CortexOS.integrations.openvault_gate import check_gate
+
+    try:
+        gate = check_gate(
+            action="leave",
+            destination="freeroute",
+            required_providers=[],
+        )
+    except Exception as exc:  # noqa: BLE001
+        return {
+            "ok": False,
+            "allowed": False,
+            "action": "leave",
+            "requested": dest,
+            "destination": "freeroute",
+            "route": "freeroute",
+            "reasons": [f"gate error: {exc}"[:240]],
+        }
+
+    allowed = gate.get("allowed") is True
+    reasons = [str(r) for r in (gate.get("reasons") or [])]
+    if not allowed and not reasons:
+        reasons = ["leave-machine gate denied"]
+    return {
+        "ok": bool(gate.get("ok")) and allowed,
+        "allowed": allowed,
+        "action": "leave",
+        "requested": dest,
+        "destination": "freeroute",
+        "route": "freeroute",
+        "reasons": reasons,
+        "openvault_url": gate.get("openvault_url"),
+    }
+
+
+def read_study_tree(option_id: str, *, root: Path | None = None) -> dict[str, Any]:
+    """List a distill analog tree. Never promotes ``engine_role`` to product_engine."""
+    option = get_option(option_id)
+    role = option["engine_role"]
+    if role == PRODUCT_ENGINE_ROLE or (
+        option_id in STUDY_TREE_OPTION_IDS and role != "distill_only"
+    ):
+        return {
+            "ok": False,
+            "allowed": False,
+            "id": option_id,
+            "engine_role": "distill_only",
+            "reasons": ["study tree must not be Constructor product_engine"],
+        }
+    if option_id not in STUDY_TREE_OPTION_IDS:
+        return {
+            "ok": False,
+            "allowed": False,
+            "id": option_id,
+            "engine_role": role if role != PRODUCT_ENGINE_ROLE else "distill_only",
+            "reasons": ["not a distill study analog"],
+        }
+
+    path = study_tree_root(option_id, root=root)
+    exists = path.is_dir()
+    samples: list[str] = []
+    if exists:
+        # Names only. Do not import analog packages. RSF-06 distills later.
+        try:
+            samples = sorted(p.name for p in path.iterdir())[:_SAMPLE_CAP]
+        except OSError as exc:
+            return {
+                "ok": False,
+                "allowed": False,
+                "id": option_id,
+                "engine_role": "distill_only",
+                "path": str(path),
+                "exists": False,
+                "samples": [],
+                "reasons": [f"study tree unreadable: {exc}"[:240]],
+            }
+
+    return {
+        "ok": True,
+        "allowed": True,
+        "id": option_id,
+        "engine_role": "distill_only",
+        "path": str(path),
+        "exists": exists,
+        "samples": samples,
+        "reasons": [],
+    }

--- a/tests/contract/fixtures/rsf03_skip_openvault.py
+++ b/tests/contract/fixtures/rsf03_skip_openvault.py
@@ -1,0 +1,18 @@
+"""R-0007 poison fixture. Parsed as AST only — never imported by production.
+
+If RSF-03 drops the OpenVault leave-machine call, skips the gate, or promotes a
+study tree to product_engine, test_rsf_boundary_ban fails because this file still
+contains the forbidden patterns.
+"""
+
+from __future__ import annotations
+
+
+def _poison_skip_openvault(url: str) -> bytes:
+    import urllib.request
+
+    return urllib.request.urlopen(url).read()  # noqa: S310
+
+
+def _poison_promote_study_tree() -> dict[str, str]:
+    return {"engine_role": "product_engine", "id": "myn8n"}

--- a/tests/contract/test_constructor_engine_ban.py
+++ b/tests/contract/test_constructor_engine_ban.py
@@ -22,6 +22,7 @@ FIXTURE = Path(__file__).resolve().parent / "fixtures" / "rsf01_banned_engine_im
 CONSTRUCTOR_ENGINE_PATHS = (
     ROOT / "CortexOS" / "constructor_graph.py",
     ROOT / "CortexOS" / "execution" / "distill_options.py",
+    ROOT / "CortexOS" / "execution" / "rsf_boundary.py",
     ROOT / "packs" / "dms" / "constructor_routes.py",
     ROOT / "packs" / "dms" / "constructor_fetch.py",
 )
@@ -91,6 +92,7 @@ def test_importlinter_contract_forbids_banned_engines() -> None:
     }
     assert "CortexOS.constructor_graph" in sources
     assert "CortexOS.execution.distill_options" in sources
+    assert "CortexOS.execution.rsf_boundary" in sources
     assert parser.getboolean("importlinter", "include_external_packages") is True
 
 

--- a/tests/contract/test_rsf_boundary_ban.py
+++ b/tests/contract/test_rsf_boundary_ban.py
@@ -1,0 +1,79 @@
+"""RSF-03 BAN floors: skip OpenVault, silent analog engine, OmniRoute vendor.
+
+R-0007: the poison fixture under tests/contract/fixtures/ is the check that
+this gate can fail. Production CortexOS/execution/rsf_boundary.py is scanned
+separately and must keep the leave-machine call.
+"""
+
+from __future__ import annotations
+
+import ast
+from configparser import ConfigParser
+from pathlib import Path
+
+from CortexOS.execution.rsf_boundary import BAN_FLOORS
+
+ROOT = Path(__file__).resolve().parents[2]
+FIXTURE = Path(__file__).resolve().parent / "fixtures" / "rsf03_skip_openvault.py"
+BOUNDARY = ROOT / "CortexOS" / "execution" / "rsf_boundary.py"
+
+
+def _source(path: Path) -> str:
+    return path.read_text(encoding="utf-8")
+
+
+def _imported_modules(path: Path) -> list[str]:
+    tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+    out: list[str] = []
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            out.extend(alias.name for alias in node.names)
+        elif isinstance(node, ast.ImportFrom) and node.module:
+            out.append(node.module)
+    return out
+
+
+def test_ban_floors_are_explicit() -> None:
+    blob = " ".join(BAN_FLOORS).lower()
+    assert "skip openvault" in blob
+    assert "silent upstream engine" in blob
+    assert "product_engine" in blob
+    assert "20128" in blob
+
+
+def test_poison_fixture_still_skips_openvault_and_promotes() -> None:
+    """If BAN assertions are deleted, this fixture still encodes the forbidden path."""
+    src = _source(FIXTURE)
+    assert "urlopen" in src
+    assert "product_engine" in src
+    assert "check_gate" not in src
+    assert "urlopen" in _imported_modules(FIXTURE) or "urllib.request" in _imported_modules(FIXTURE)
+
+
+def test_production_research_egress_calls_leave_machine() -> None:
+    src = _source(BOUNDARY)
+    assert "check_gate" in src
+    assert 'action="leave"' in src
+    assert 'destination="freeroute"' in src
+    assert "urlopen" not in src
+    assert "127.0.0.1:20128" not in src
+    assert "CortexOS.integrations.openvault_gate" in src
+
+
+def test_importlinter_contract_covers_rsf_boundary() -> None:
+    parser = ConfigParser()
+    parser.read(ROOT / ".importlinter", encoding="utf-8")
+    section = "importlinter:contract:3"
+    sources = {
+        line.strip()
+        for line in parser.get(section, "source_modules").splitlines()
+        if line.strip()
+    }
+    assert "CortexOS.execution.rsf_boundary" in sources
+    forbidden = {
+        line.strip()
+        for line in parser.get(section, "forbidden_modules").splitlines()
+        if line.strip()
+    }
+    for name in ("n8n", "langchain", "langflow"):
+        assert name in forbidden

--- a/tests/dms/test_rsf_boundary.py
+++ b/tests/dms/test_rsf_boundary.py
@@ -1,0 +1,101 @@
+"""RSF-03 OpenVault leave-machine + study-tree role lock."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from CortexOS.execution.rsf_boundary import (
+    gate_research_egress,
+    read_study_tree,
+)
+
+
+def test_research_egress_fails_closed_when_openvault_unreachable(monkeypatch):
+    def fake_check(**kwargs):
+        return {
+            "ok": False,
+            "allowed": False,
+            "reasons": ["OpenVault unreachable: timeout"],
+        }
+
+    monkeypatch.setattr(
+        "CortexOS.integrations.openvault_gate.check_gate",
+        fake_check,
+    )
+    out = gate_research_egress()
+    assert out["allowed"] is False
+    assert out["action"] == "leave"
+    assert out["destination"] == "freeroute"
+    assert any("unreachable" in r.lower() for r in out["reasons"])
+
+
+def test_research_egress_asks_leave_freeroute_not_omniroute(monkeypatch):
+    seen: list[dict] = []
+
+    def fake_check(**kwargs):
+        seen.append(kwargs)
+        return {"ok": True, "allowed": True, "openvault_url": "http://127.0.0.1:5000"}
+
+    monkeypatch.setattr(
+        "CortexOS.integrations.openvault_gate.check_gate",
+        fake_check,
+    )
+    out = gate_research_egress(destination="https://example.com/search")
+    assert out["allowed"] is True
+    assert out["route"] == "freeroute"
+    assert len(seen) == 1
+    assert seen[0]["action"] == "leave"
+    assert seen[0]["destination"] == "freeroute"
+
+
+def test_research_egress_gates_omniroute_without_vendoring(monkeypatch):
+    seen: list[dict] = []
+
+    def fake_check(**kwargs):
+        seen.append(kwargs)
+        return {"ok": True, "allowed": True}
+
+    monkeypatch.setattr(
+        "CortexOS.integrations.openvault_gate.check_gate",
+        fake_check,
+    )
+    out = gate_research_egress(destination="http://127.0.0.1:20128")
+    assert out["allowed"] is False
+    assert out["route"] == "omniroute_gated"
+    assert "20128" in " ".join(out["reasons"])
+    assert seen == []
+
+
+def test_study_tree_read_keeps_distill_only(tmp_path: Path):
+    (tmp_path / "README.md").write_text("study analog", encoding="utf-8")
+    out = read_study_tree("myn8n", root=tmp_path)
+    assert out["ok"] is True
+    assert out["allowed"] is True
+    assert out["engine_role"] == "distill_only"
+    assert out["engine_role"] != "product_engine"
+    assert "README.md" in out["samples"]
+
+
+def test_study_tree_missing_dir_is_still_distill_only(tmp_path: Path):
+    missing = tmp_path / "absent"
+    out = read_study_tree("langchain", root=missing)
+    assert out["ok"] is True
+    assert out["engine_role"] == "distill_only"
+    assert out["exists"] is False
+
+
+def test_study_tree_refuses_product_engine_promotion(monkeypatch, tmp_path: Path):
+    monkeypatch.setattr(
+        "CortexOS.execution.rsf_boundary.get_option",
+        lambda oid: {"id": oid, "engine_role": "product_engine"},
+    )
+    out = read_study_tree("myn8n", root=tmp_path)
+    assert out["allowed"] is False
+    assert out["engine_role"] != "product_engine"
+
+
+def test_gencfsm_dag_is_not_a_study_tree():
+    out = read_study_tree("gencfsm_dag")
+    assert out["allowed"] is False
+    assert out["engine_role"] != "product_engine"
+    assert "not a distill study analog" in " ".join(out["reasons"])


### PR DESCRIPTION
## Summary
- Research egress goes through existing OpenVault `check_gate(action=leave, destination=freeroute)` and fails closed when OV is unreachable. Prefer FreeRoute. OmniRoute `:20128` is gated, never vendored.
- Distill may list analog study trees (`D:\myn8n`, langchain, langflow) via the RSF-01 registry. `engine_role` stays `distill_only`. Never `product_engine`.
- Wires to RSF-01 (`distill_options.get_option`). Does not implement RSF-04 orchestrator or RSF-06 distill harness. Does not vendor n8n/LC/LF. Does not widen EPIC-CCA. Does not dual-seat Crew.

## BAN floors (Gating)
- silent upstream engine
- skip OpenVault
- n8n/langchain/langflow as product_engine
- vendor OmniRoute :20128

R-0007: `tests/contract/fixtures/rsf03_skip_openvault.py` still encodes skip-OpenVault + `product_engine` promotion. If those BAN assertions are removed, that fixture stays red-capable.

## Test plan
- [x] `pytest tests/contract/test_rsf_boundary_ban.py tests/dms/test_rsf_boundary.py tests/contract/test_constructor_engine_ban.py tests/dms/test_distill_options.py tests/contract/test_import_boundaries.py tests/test_openvault_gate.py` (32 passed)
- [x] `ruff check` on touched CortexOS + tests/contract
- [x] `lint-imports` 3 kept, 0 broken

Closes #153. Parent EPIC-RSF #151. Depends RSF-01 #181.