### PR TITLE
Scheduled routines dispatch real operator work instead of echoing the prompt

### DIFF
--- a/CortexOS/crew/github.py
+++ b/CortexOS/crew/github.py
@@ -534,3 +534,82 @@ def close_issue(
         "detail": (result.stdout or "").strip()[:400],
         "law": "Closed the issue. Did not merge a PR. Ticket Runner seats writers.",
     }
+
+
+def pr_diff(
+    number: int | None = None,
+    *,
+    repo: str = "",
+    runner: RunFn | None = None,
+    timeout: float | None = None,
+) -> dict[str, Any]:
+    """Read a PR diff. Review material only — never merge."""
+    if os.environ.get("CREW_LIVE_PROBES", "1") == "0" and runner is None:
+        return {"ok": False, "detail": "CREW_LIVE_PROBES=0", "diff": ""}
+    run = runner or _run
+    wait = max(_gh_wait_s(), 3.0) if timeout is None else float(timeout)
+    argv = ["gh", "pr", "diff"]
+    if number is not None:
+        argv.append(str(int(number)))
+    if repo:
+        argv.extend(["--repo", repo])
+    try:
+        result = run(argv, timeout=wait)
+    except FileNotFoundError:
+        return {"ok": False, "detail": "gh not installed", "diff": ""}
+    except (OSError, subprocess.TimeoutExpired) as exc:
+        return {"ok": False, "detail": type(exc).__name__, "diff": ""}
+    if result.returncode != 0:
+        return {
+            "ok": False,
+            "detail": (result.stderr or result.stdout or "gh failed")[:200],
+            "diff": "",
+        }
+    return {
+        "ok": True,
+        "diff": (result.stdout or "")[:12000],
+        "number": number,
+        "repo": repo,
+        "law": "Report in chat. Do not auto-merge.",
+    }
+
+
+def create_pr(
+    *,
+    title: str = "",
+    body: str = "",
+    repo: str = "",
+    runner: RunFn | None = None,
+) -> dict[str, Any]:
+    """Open a PR with gh. Never merges. Skip when live probes are off."""
+    if os.environ.get("CREW_LIVE_PROBES", "1") == "0" and runner is None:
+        return {"ok": False, "detail": "CREW_LIVE_PROBES=0", "url": ""}
+    run = runner or _run
+    argv = ["gh", "pr", "create"]
+    title = (title or "").strip()
+    if title:
+        argv.extend(["--title", title[:200], "--body", (body or title)[:2000]])
+    else:
+        argv.append("--fill")
+    if repo:
+        argv.extend(["--repo", repo])
+    try:
+        result = run(argv, timeout=max(_gh_wait_s(), 3.0))
+    except FileNotFoundError:
+        return {"ok": False, "detail": "gh not installed", "url": ""}
+    except (OSError, subprocess.TimeoutExpired) as exc:
+        return {"ok": False, "detail": type(exc).__name__, "url": ""}
+    text = (result.stdout or result.stderr or "")[:500]
+    if result.returncode != 0:
+        return {"ok": False, "detail": text or "gh failed", "url": ""}
+    url = ""
+    for token in text.split():
+        if token.startswith("https://") and "/pull/" in token:
+            url = token.strip()
+            break
+    return {
+        "ok": True,
+        "url": url or text.strip(),
+        "detail": text.strip(),
+        "law": "Do not auto-merge. Ticket Runner seats existing writers.",
+    }

--- a/CortexOS/execution/routine_composer.py
+++ b/CortexOS/execution/routine_composer.py
@@ -138,6 +138,10 @@ def compose(goal: str, *, now: float | None = None) -> dict[str, Any]:
         f"and pause the routine if it spends more than RM{DEPTH_COST_CAPS[depth]:g} in a day."
     )
     assumptions.append("If it fails 3 times in a row I'll pause it and tell you.")
+    from CortexOS.execution import scheduled_work
+
+    kinds = scheduled_work.classify(goal)
+    assumptions.append(scheduled_work.explain_kinds(kinds))
 
     return {
         "name": suggest_name(goal),
@@ -153,12 +157,13 @@ def compose(goal: str, *, now: float | None = None) -> dict[str, Any]:
         "daily_cost_cap_myr": DEPTH_COST_CAPS[depth],
         "assumptions": assumptions,
         "schedule_recognized": parsed["matched"],
+        "work_kinds": sorted(kinds),
     }
 
 
 SUGGESTIONS: list[str] = [
     "Summarize my open PRs every weekday morning",
-    "Check the site is up every 15 minutes",
-    "Draft release notes every Friday at 5pm",
+    "Run the AirGPT ship-gate every weekday",
+    "Email me a daily inbox digest every morning",
     "Deep research on our competitors every Monday morning",
 ]

--- a/CortexOS/execution/routine_scheduler.py
+++ b/CortexOS/execution/routine_scheduler.py
@@ -231,6 +231,12 @@ def create_from_goal(goal: str, **overrides: Any) -> dict[str, Any]:
         # An explicit interval beats an inferred calendar schedule.
         draft["schedule"] = None
     draft.update(explicit)
+    vars_merged = dict(draft.get("vars") or {})
+    if "vars" in explicit and isinstance(explicit.get("vars"), dict):
+        vars_merged.update(explicit["vars"])
+    kinds = draft.get("work_kinds") or []
+    if kinds:
+        vars_merged["work_kinds"] = kinds
     routine = create_routine(
         draft["name"],
         draft["prompt"],
@@ -241,8 +247,10 @@ def create_from_goal(goal: str, **overrides: Any) -> dict[str, Any]:
         timeout_seconds=draft["timeout_seconds"],
         schedule=draft["schedule"],
         predicates=draft["predicates"],
+        vars=vars_merged or None,
     )
     routine["assumptions"] = draft["assumptions"]
+    routine["work_kinds"] = kinds
     return routine
 
 
@@ -255,7 +263,12 @@ def get_routine(rid: str) -> dict[str, Any] | None:
 def list_routines() -> list[dict[str, Any]]:
     with _conn() as conn:
         rows = conn.execute("SELECT * FROM routines ORDER BY created_at").fetchall()
-    return [_row_to_dict(r) for r in rows]
+    out = [_row_to_dict(r) for r in rows]
+    for item in out:
+        runs = list_runs(item["id"], limit=1)
+        if runs:
+            item["last_run"] = _public_run(runs[0])
+    return out
 
 
 def update_routine(rid: str, **fields: Any) -> dict[str, Any] | None:
@@ -292,6 +305,33 @@ def pause(rid: str, reason: str = "user") -> dict[str, Any] | None:
 
 def resume(rid: str) -> dict[str, Any] | None:
     return update_routine(rid, status="idle", paused_reason="", error_streak=0)
+
+
+def _public_run(row: dict[str, Any]) -> dict[str, Any]:
+    raw = row.get("output") or ""
+    text = str(raw)
+    steps: list[dict[str, Any]] = []
+    kinds: list[str] = []
+    try:
+        parsed = json.loads(raw) if isinstance(raw, str) and raw[:1] in "{[" else None
+    except Exception:
+        parsed = None
+    if isinstance(parsed, dict):
+        text = str(parsed.get("text") or parsed.get("output") or "")
+        steps = list(parsed.get("steps") or [])
+        kinds = list(parsed.get("work_kinds") or [])
+        if not text and parsed.get("text") is None:
+            text = json.dumps(parsed, default=str)[:4000]
+    elif isinstance(parsed, str):
+        text = parsed
+    return {
+        "status": row.get("status"),
+        "finished_at": row.get("finished_at"),
+        "error": row.get("error") or "",
+        "text": text[:4000],
+        "steps": steps,
+        "work_kinds": kinds,
+    }
 
 
 def list_runs(rid: str, limit: int = 20) -> list[dict[str, Any]]:
@@ -377,6 +417,14 @@ async def _dispatch(
     predicates: list[dict[str, Any]] | None,
 ) -> dict[str, Any]:
     """'auto' means the engine picks — first run races, later runs reuse the winner."""
+    from CortexOS.execution import scheduled_work
+
+    kinds = scheduled_work.classify(prompt)
+    stored = (routine.get("vars") or {}).get("work_kinds") or []
+    if stored:
+        kinds = frozenset(str(k) for k in stored) | kinds
+    if scheduled_work.is_operator_work(kinds):
+        return await asyncio.to_thread(scheduled_work.run, prompt, kinds=kinds)
     if str(routine.get("preset") or "") == "auto":
         from CortexOS.execution import race_router
 
@@ -505,7 +553,16 @@ async def run_once(
                 "ok" if ok else "error",
                 started,
                 finished,
-                json.dumps(result.get("output"), default=str)[:4000],
+                json.dumps(
+                    {
+                        "text": result.get("output"),
+                        "steps": result.get("steps") or [],
+                        "work_kinds": result.get("work_kinds") or [],
+                    },
+                    default=str,
+                )[:20000]
+                if result.get("steps") is not None
+                else json.dumps(result.get("output"), default=str)[:20000],
                 str(result.get("error") or "")[:1000],
                 cost,
             ),
@@ -533,6 +590,9 @@ async def run_once(
         "cost_myr": cost,
         "governor": governor_action,
         "next_run_at": next_run_at,
+        "output": result.get("output"),
+        "steps": result.get("steps") or [],
+        "work_kinds": result.get("work_kinds") or [],
     }
 
 

--- a/CortexOS/execution/scheduled_work.py
+++ b/CortexOS/execution/scheduled_work.py
@@ -1,0 +1,316 @@
+"""Scheduled operator work: GitHub, ship-gate, mail digest.
+
+Default Cortex routines still dispatch through execute_run_plan. A "hello"
+prompt on the minimal DAG only echoes the prompt — that is not GitHub, review,
+build, or email. This module is the path those goals take: Crew gh/ship-gate,
+IMAP read, optional SMTP send. Not a second orchestrator.
+"""
+
+from __future__ import annotations
+
+import os
+import re
+import smtplib
+from collections.abc import Callable
+from email.message import EmailMessage
+from typing import Any
+
+OPERATOR_KINDS = frozenset({"github", "pr_create", "review", "build", "email"})
+
+_PR_CREATE = re.compile(
+    r"\b(?:open|create|file|cut)\b.{0,32}\b(?:pr|pull request)s?\b|\bgh pr create\b",
+    re.I,
+)
+_GITHUB = re.compile(
+    r"\b(?:github|gh pr|pull requests?|open prs?|my prs?)\b",
+    re.I,
+)
+_REVIEW = re.compile(
+    r"\b(?:code review|pr review|review (?:the )?(?:pr|pull|diff|code|repo)s?)\b",
+    re.I,
+)
+_BUILD = re.compile(
+    r"\b(?:ship[- ]?gate|pytest|github actions|\bci\b|run tests|test suite)\b",
+    re.I,
+)
+_FORGE = re.compile(r"\b(?:openforge|3d mesh|netlist)\b", re.I)
+_EMAIL = re.compile(
+    r"\b(?:e-?mail|gmail|inbox|daily digest|send me (?:an? )?(?:e-?mail|digest)|imap)\b",
+    re.I,
+)
+
+ListPrsFn = Callable[..., dict[str, Any]]
+CreatePrFn = Callable[..., dict[str, Any]]
+PrDiffFn = Callable[..., dict[str, Any]]
+ShipFn = Callable[[str], str]
+InboxFn = Callable[..., dict[str, Any]]
+MailFn = Callable[[str, str], dict[str, Any]]
+
+
+def classify(goal: str) -> frozenset[str]:
+    text = goal or ""
+    found: set[str] = set()
+    if _PR_CREATE.search(text):
+        found.add("pr_create")
+        found.add("github")
+    if _GITHUB.search(text):
+        found.add("github")
+    if _REVIEW.search(text):
+        found.add("review")
+        found.add("github")
+    if _BUILD.search(text) or _FORGE.search(text):
+        found.add("build")
+    if _EMAIL.search(text):
+        found.add("email")
+    if not found:
+        found.add("web")
+    return frozenset(found)
+
+
+def is_operator_work(kinds: frozenset[str] | set[str]) -> bool:
+    return bool(frozenset(kinds) & OPERATOR_KINDS)
+
+
+def explain_kinds(kinds: frozenset[str] | set[str]) -> str:
+    k = frozenset(kinds)
+    if not is_operator_work(k):
+        return "This stays a Cortex engine run (search/generate), not an echo-only chip."
+    bits: list[str] = []
+    if "github" in k or "review" in k:
+        bits.append("list open PRs with gh")
+    if "review" in k:
+        bits.append("read PR diffs")
+    if "pr_create" in k:
+        bits.append("open a PR with gh (never merge)")
+    if "build" in k:
+        bits.append("run the Crew ship-gate")
+    if "email" in k:
+        bits.append("read IMAP and send a digest if SMTP/Gmail app password is set")
+    return "This run will " + ", ".join(bits) + "."
+
+
+def _step(tool: str, ok: bool, summary: str) -> dict[str, Any]:
+    return {"tool": tool[:80], "ok": bool(ok), "summary": str(summary or "")[:400]}
+
+
+def _fmt_prs(blob: dict[str, Any]) -> str:
+    rows = blob.get("prs") or []
+    if not rows:
+        return str(blob.get("detail") or "No open pull requests.")[:2000]
+    lines = ["Open pull requests:"]
+    for pr in rows[:20]:
+        if not isinstance(pr, dict):
+            continue
+        lines.append(
+            f"- #{pr.get('number')} {pr.get('title') or ''} {pr.get('url') or ''} "
+            f"review={pr.get('review') or ''}"
+        )
+    law = str(blob.get("law") or "")
+    if law:
+        lines.append(law)
+    return "\n".join(lines)[:8000]
+
+
+def _build_slug(prompt: str) -> str:
+    lowered = (prompt or "").lower()
+    try:
+        from CortexOS.crew.estate import CATALOG
+
+        for fp in CATALOG:
+            slug = str(getattr(fp, "slug", "") or "")
+            full = str(getattr(fp, "full_name", "") or "")
+            if slug and slug.lower() in lowered:
+                return slug
+            if full and full.lower() in lowered:
+                return slug
+    except Exception:
+        pass
+    if _FORGE.search(prompt or ""):
+        return "OpenForge"
+    return "AirGPT"
+
+
+def send_digest(subject: str, body: str) -> dict[str, Any]:
+    """Outbound digest. Crew inbox.py still never sends; the engine may."""
+    user = (os.environ.get("SMTP_USER") or os.environ.get("GMAIL_IMAP_USER") or "").strip()
+    password = (os.environ.get("SMTP_PASS") or os.environ.get("GMAIL_APP_PASSWORD") or "").strip()
+    to = (os.environ.get("SMTP_TO") or user).strip()
+    host = (os.environ.get("SMTP_HOST") or "").strip()
+    if not host and user.lower().endswith("@gmail.com"):
+        host = "smtp.gmail.com"
+    port = int(os.environ.get("SMTP_PORT") or (587 if host else 0) or 0)
+    if not (user and password and to and host and port):
+        return {
+            "ok": False,
+            "sent": False,
+            "error": "no_smtp",
+            "detail": "Set GMAIL_IMAP_USER+GMAIL_APP_PASSWORD (Gmail SMTP) or SMTP_HOST/USER/PASS/TO.",
+        }
+    msg = EmailMessage()
+    msg["Subject"] = (subject or "Netie digest")[:200]
+    msg["From"] = user
+    msg["To"] = to
+    msg.set_content((body or "")[:20000])
+    try:
+        with smtplib.SMTP(host, port, timeout=8) as smtp:
+            smtp.ehlo()
+            if port == 587:
+                smtp.starttls()
+                smtp.ehlo()
+            smtp.login(user, password)
+            smtp.send_message(msg)
+    except Exception as exc:
+        return {"ok": False, "sent": False, "error": type(exc).__name__, "detail": str(exc)[:240]}
+    return {"ok": True, "sent": True, "to": to}
+
+
+def run(
+    prompt: str,
+    *,
+    kinds: frozenset[str] | set[str] | None = None,
+    list_prs_fn: ListPrsFn | None = None,
+    create_pr_fn: CreatePrFn | None = None,
+    pr_diff_fn: PrDiffFn | None = None,
+    ship_fn: ShipFn | None = None,
+    inbox_fn: InboxFn | None = None,
+    mail_send_fn: MailFn | None = None,
+) -> dict[str, Any]:
+    kinds = frozenset(kinds or classify(prompt))
+    if not is_operator_work(kinds):
+        return {
+            "ok": False,
+            "error": "not_operator_work",
+            "output": "",
+            "steps": [],
+            "work_kinds": sorted(kinds),
+            "chosen": "scheduled_work",
+        }
+
+    steps: list[dict[str, Any]] = []
+    chunks: list[str] = []
+    errors: list[str] = []
+    did = False
+
+    if kinds & {"github", "review", "pr_create"}:
+        if list_prs_fn is None:
+            from CortexOS.crew import github as github_mod
+
+            list_prs_fn = github_mod.list_prs
+        listed = list_prs_fn()
+        ok = bool(listed.get("ok") or listed.get("prs"))
+        did = True
+        steps.append(_step("gh_pr_list", ok, f"{len(listed.get('prs') or [])} open PRs"))
+        chunks.append(_fmt_prs(listed if isinstance(listed, dict) else {}))
+        if not ok:
+            errors.append(str(listed.get("detail") or listed.get("error") or "gh_pr_list failed")[:300])
+
+        if "review" in kinds:
+            if pr_diff_fn is None:
+                from CortexOS.crew import github as github_mod
+
+                pr_diff_fn = github_mod.pr_diff
+            prs = [p for p in (listed.get("prs") or []) if isinstance(p, dict)][:2]
+            if not prs:
+                steps.append(_step("gh_pr_diff", True, "no open PR to review"))
+            for pr in prs:
+                num = pr.get("number")
+                diff = pr_diff_fn(number=num, repo=str(pr.get("repo") or ""))
+                dok = bool(diff.get("ok"))
+                text = str(diff.get("diff") or diff.get("detail") or "")[:4000]
+                steps.append(_step("gh_pr_diff", dok, f"PR #{num} {len(text)} chars"))
+                chunks.append(f"## Review diff PR #{num}\n{text or '(empty diff)'}")
+                if not dok:
+                    errors.append(str(diff.get("detail") or "gh_pr_diff failed")[:300])
+
+        if "pr_create" in kinds:
+            if create_pr_fn is None:
+                from CortexOS.crew import github as github_mod
+
+                create_pr_fn = github_mod.create_pr
+            created = create_pr_fn(title=(prompt or "Scheduled PR")[:120])
+            cok = bool(created.get("ok"))
+            did = True
+            steps.append(
+                _step(
+                    "gh_pr_create",
+                    cok,
+                    str(created.get("url") or created.get("detail") or created.get("error") or "")[:240],
+                )
+            )
+            chunks.append(
+                "PR create: "
+                + str(created.get("url") or created.get("detail") or created.get("error") or "")
+            )
+            if not cok:
+                errors.append(str(created.get("detail") or created.get("error") or "gh_pr_create failed")[:300])
+
+    if "build" in kinds:
+        slug = _build_slug(prompt)
+        if ship_fn is None:
+            from CortexOS.crew.ship_gate import render_slug
+
+            ship_fn = render_slug
+        try:
+            report = ship_fn(slug)
+            did = True
+            steps.append(_step("ship_gate", True, f"{slug}: {str(report)[:120]}"))
+            chunks.append(str(report)[:8000])
+        except Exception as exc:
+            steps.append(_step("ship_gate", False, type(exc).__name__))
+            errors.append(str(exc)[:300])
+
+    if "email" in kinds:
+        if inbox_fn is None:
+            from CortexOS.crew import inbox as inbox_mod
+
+            inbox_fn = inbox_mod.fetch
+        mail = inbox_fn(limit=8)
+        mok = bool(mail.get("ok") or mail.get("messages"))
+        msgs = mail.get("messages") or []
+        did = True
+        steps.append(_step("imap_fetch", mok, f"{len(msgs)} headers"))
+        digest_lines = ["Inbox digest:"]
+        for row in msgs[:8]:
+            if not isinstance(row, dict):
+                continue
+            digest_lines.append(
+                f"- {row.get('date') or ''} | {row.get('from') or ''} | {row.get('subject') or ''}"
+            )
+        if not msgs:
+            digest_lines.append(str(mail.get("detail") or "No IMAP messages."))
+        digest = "\n".join(digest_lines)[:8000]
+        chunks.append(digest)
+        if not mok:
+            errors.append(str(mail.get("detail") or "imap_fetch failed")[:300])
+        sender = mail_send_fn or send_digest
+        sent = sender("Netie daily digest", digest)
+        sok = bool(sent.get("ok") and sent.get("sent"))
+        steps.append(_step("smtp_send", sok, str(sent.get("to") or sent.get("error") or sent.get("detail") or "")[:240]))
+        if sok:
+            chunks.append(f"Sent digest to {sent.get('to')}.")
+        else:
+            chunks.append("Digest not sent: " + str(sent.get("detail") or sent.get("error") or "no_smtp"))
+            if sent.get("error") != "no_smtp":
+                errors.append(str(sent.get("detail") or sent.get("error") or "smtp failed")[:300])
+
+    output = "\n\n".join(c for c in chunks if c).strip()
+    ok = did and bool(output) and not (
+        kinds <= {"email"} and not any(s.get("ok") for s in steps)
+    )
+    if did and output and "github" in kinds:
+        ok = any(s.get("tool") == "gh_pr_list" and s.get("ok") for s in steps) or any(
+            s.get("tool") == "gh_pr_create" and s.get("ok") for s in steps
+        )
+    if did and "build" in kinds:
+        ok = ok or any(s.get("tool") == "ship_gate" and s.get("ok") for s in steps)
+    if did and "email" in kinds:
+        ok = any(s.get("tool") in ("imap_fetch", "smtp_send") and s.get("ok") for s in steps)
+    return {
+        "ok": bool(ok),
+        "status": "ok" if ok else "error",
+        "output": output,
+        "error": "; ".join(errors)[:1000],
+        "steps": steps,
+        "work_kinds": sorted(kinds & OPERATOR_KINDS or kinds),
+        "chosen": "scheduled_work",
+    }

--- a/tests/dms/test_scheduled_work.py
+++ b/tests/dms/test_scheduled_work.py
@@ -1,0 +1,135 @@
+"""Operator scheduled work: gh/ship-gate/mail, not prompt echo."""
+
+from __future__ import annotations
+
+import pytest
+
+from CortexOS.execution import routine_composer, scheduled_work
+from CortexOS.execution import routine_scheduler as rs
+
+
+@pytest.fixture(autouse=True)
+def _isolate(tmp_path, monkeypatch):
+    from CortexOS.execution import action_event, action_value, scoreboard
+
+    monkeypatch.setattr(rs, "DB_PATH", tmp_path / "routines.db")
+    monkeypatch.setattr(scoreboard, "DB_PATH", tmp_path / "scoreboard.db")
+    monkeypatch.setattr(action_event, "DB_PATH", tmp_path / "action_events.db")
+    monkeypatch.setattr(action_value, "DB_PATH", tmp_path / "action_value.db")
+    rs.init()
+    scoreboard.init()
+
+
+def test_classify_open_prs_is_github():
+    kinds = scheduled_work.classify("Summarize my open PRs every weekday morning")
+    assert "github" in kinds
+    assert scheduled_work.is_operator_work(kinds)
+
+
+def test_classify_hello_is_not_operator_work():
+    kinds = scheduled_work.classify("hello routine")
+    assert kinds == frozenset({"web"})
+    assert not scheduled_work.is_operator_work(kinds)
+
+
+def test_classify_email_and_ship_gate():
+    assert "email" in scheduled_work.classify("Email me a daily inbox digest")
+    assert "build" in scheduled_work.classify("Run the AirGPT ship-gate every weekday")
+    assert "pr_create" in scheduled_work.classify("open a pull request for the current branch daily")
+
+
+def test_draft_names_github_work():
+    draft = routine_composer.compose("Summarize my open PRs every weekday morning")
+    assert "github" in draft["work_kinds"]
+    assert any("gh" in a.lower() or "pr" in a.lower() for a in draft["assumptions"])
+
+
+def test_github_run_is_not_prompt_echo():
+    listed = {
+        "ok": True,
+        "prs": [
+            {
+                "number": 12,
+                "title": "crew drop",
+                "url": "https://example.test/12",
+                "review": "REVIEW_REQUIRED",
+            }
+        ],
+        "law": "Do not auto-merge.",
+    }
+    out = scheduled_work.run(
+        "Summarize my open PRs every weekday morning",
+        list_prs_fn=lambda **k: listed,
+    )
+    assert out["ok"] is True
+    assert "crew drop" in out["output"]
+    assert "Summarize my open PRs every weekday morning" != out["output"]
+    assert out["steps"][0]["tool"] == "gh_pr_list"
+    assert out["chosen"] == "scheduled_work"
+
+
+def test_review_fetches_diff():
+    listed = {
+        "ok": True,
+        "prs": [{"number": 4, "title": "fix", "url": "https://x/4", "repo": "acme/x"}],
+    }
+    out = scheduled_work.run(
+        "code review open PRs daily",
+        list_prs_fn=lambda **k: listed,
+        pr_diff_fn=lambda **k: {"ok": True, "diff": "+def foo():\n+    return 1\n"},
+    )
+    assert out["ok"] is True
+    assert any(s["tool"] == "gh_pr_diff" and s["ok"] for s in out["steps"])
+    assert "def foo" in out["output"]
+
+
+def test_email_digest_sends_when_injected():
+    inbox = {
+        "ok": True,
+        "messages": [{"from": "a@b", "subject": "hello", "date": "Sat"}],
+    }
+    sent = {"ok": True, "sent": True, "to": "ops@example.test"}
+    out = scheduled_work.run(
+        "Email me a daily inbox digest",
+        inbox_fn=lambda **k: inbox,
+        mail_send_fn=lambda subject, body: sent,
+    )
+    assert out["ok"] is True
+    assert "hello" in out["output"]
+    assert any(s["tool"] == "smtp_send" and s["ok"] for s in out["steps"])
+
+
+def test_email_without_creds_still_records_the_attempt():
+    out = scheduled_work.run(
+        "Email me a daily inbox digest",
+        inbox_fn=lambda **k: {"ok": False, "messages": [], "detail": "no IMAP"},
+        mail_send_fn=lambda *_a: {"ok": False, "sent": False, "error": "no_smtp"},
+    )
+    assert out["ok"] is False
+    assert any(s["tool"] == "imap_fetch" for s in out["steps"])
+
+
+@pytest.mark.asyncio
+async def test_pr_routine_dispatch_uses_github(monkeypatch):
+    monkeypatch.setattr(
+        "CortexOS.execution.scheduled_work.run",
+        lambda prompt, kinds=None, **k: {
+            "ok": True,
+            "status": "ok",
+            "output": "Open pull requests:\n- #9 real work",
+            "error": "",
+            "steps": [{"tool": "gh_pr_list", "ok": True, "summary": "1 open PRs"}],
+            "work_kinds": ["github"],
+            "chosen": "scheduled_work",
+        },
+    )
+    routine = rs.create_from_goal("Summarize my open PRs every weekday morning")
+    rs.update_routine(routine["id"], next_run_at=0)
+    out = await rs.run_once(routine["id"])
+    assert out["ok"] is True
+    assert out["chosen"] == "scheduled_work"
+    assert out["steps"][0]["tool"] == "gh_pr_list"
+    runs = rs.list_runs(routine["id"])
+    assert "real work" in (runs[0]["output"] or "")
+    listed_rt = rs.list_routines()
+    assert listed_rt[0]["last_run"]["steps"][0]["tool"] == "gh_pr_list"

--- a/tests/test_crew/test_connectors_import.py
+++ b/tests/test_crew/test_connectors_import.py
@@ -305,3 +305,48 @@ def test_discover_exports_skips_appdata(tmp_path) -> None:
     msgs = store.list_messages(result["spaces"][0]["id"])
     assert any("hey" in m["content"] for m in msgs)
     assert (skills / "chat.md").exists()
+
+
+def test_github_pr_diff_uses_injected_runner(monkeypatch) -> None:
+    from CortexOS.crew import github as github_mod
+
+    monkeypatch.setenv("CREW_LIVE_PROBES", "1")
+
+    class Result:
+        def __init__(self, code: int, stdout: str) -> None:
+            self.returncode = code
+            self.stdout = stdout
+            self.stderr = ""
+
+    def runner(argv, timeout=20):  # noqa: ANN001, ARG001
+        assert "pr" in argv and "diff" in argv
+        assert "12" in argv
+        return Result(0, "+hello\n")
+
+    out = github_mod.pr_diff(number=12, repo="acme/cortex", runner=runner)
+    assert out["ok"] is True
+    assert "+hello" in out["diff"]
+
+
+def test_github_create_pr_uses_injected_runner(monkeypatch) -> None:
+    from CortexOS.crew import github as github_mod
+
+    monkeypatch.setenv("CREW_LIVE_PROBES", "1")
+
+    class Result:
+        def __init__(self, code: int, stdout: str) -> None:
+            self.returncode = code
+            self.stdout = stdout
+            self.stderr = ""
+
+    def runner(argv, timeout=20):  # noqa: ANN001, ARG001
+        assert "pr" in argv and "create" in argv
+        assert "--title" in argv
+        return Result(0, "https://github.com/acme/cortex/pull/99\n")
+
+    out = github_mod.create_pr(title="crew drop", runner=runner)
+    assert out["ok"] is True
+    assert "/pull/99" in out["url"]
+    assert "auto-merge" in out["law"].lower()
+
+


### PR DESCRIPTION
## What

A routine whose goal is GitHub, review, ship-gate, or email now dispatches
`CortexOS/execution/scheduled_work.py`, which routes to Crew `gh` / `ship_gate` / IMAP.
The minimal-DAG echo remains only for plain prompts. `STATUS.md` has named this the
active feature since 2026-09-05; the code had never reached a branch.

`scheduled_work` calls `github.pr_diff` and `github.create_pr`, so both land in this PR.
Without them the review and PR paths raise `AttributeError` at run time.

## Why it looks like a recovery

The module and its test were found in an uncommitted working tree, present in **no commit,
no branch and no reflog** - 456 lines that a `stash`, `checkout` or `clean` would have
destroyed with no recovery path. They are re-landed here on a fresh branch off `main`.

## Scope discipline

- `list_prs` keeps main's signature and its `timeout=20` call site. The recovered patch
  widened that public signature; that was dropped as scope creep. This change is additive only.
- The recovered `pr_diff` / `create_pr` referenced a module constant `GH_WAIT_S` that main
  has since replaced with the env-driven `_gh_wait_s()`. Both were adapted; a straight port
  would have raised `NameError`.
- No protected path is touched - `tests/contract/**`, `tests/invariants/**` and
  `.importlinter` are untouched, so no `INVARIANT-CHANGE:` trailer applies.
- `CortexOS` gains no `packs.*` import; `scheduled_work` imports only stdlib plus
  `CortexOS.crew.*`.

## Verification

| Gate | Result |
|---|---|
| `pytest tests/dms/test_scheduled_work.py tests/test_crew/test_connectors_import.py` | 26 passed |
| `pytest tests/test_crew` | 202 passed |
| `pytest tests/test_execution` | 229 passed |
| `pytest tests/contract tests/invariants` | 92 passed |
| `ruff check CortexOS tests/test_crew tests/dms/test_scheduled_work.py` | clean |
| `lint-imports` | 3 contracts kept, 0 broken |

Not verified: no live `gh`, IMAP or ship-gate call was exercised - every test injects a
runner. A different run should verify the live dispatch path (R-0003).

🤖 Generated with [Claude Code](https://claude.com/claude-code)