### PR TITLE
CREW-MEMORY-API: collection-scoped memory CRUD (parent #116)

### DIFF
--- a/CHANGELOG_DMS.md
+++ b/CHANGELOG_DMS.md
@@ -10,7 +10,7 @@ UI-derived capped facts. Space remains `memory/facts.md`. user/agent/run persist
 under `spaces/<id>/collections/<scope>/<owner>/` and survive Clear chat. Recall
 payloads stay inside the untrusted wrapper. Slash remember/recall/forget still
 write only the space collection (no dual-write with standing-policy or CLAIMS).
-Control not touched. Local `pytest tests/test_crew` is the gate; not a CI claim.
+Control not touched. Local `pytest tests/test_crew -q`: **211 passed**. Not a CI claim.
 
 ## CREW-POLICY-STANDING server ladder on CortexOS/crew — 2026-09-06
 

--- a/CHANGELOG_DMS.md
+++ b/CHANGELOG_DMS.md
@@ -2,6 +2,16 @@
 
 Agents append one section per shipped feature. Sequential build log.
 
+## CREW-MEMORY-API collection scopes on CortexOS/crew — 2026-09-06
+
+Collection-scoped markdown memory (parent Cortex #116). HUD Save / Search / Export
+use `/crew/spaces/{id}/memory` with `scope=space|user|agent|run` instead of
+UI-derived capped facts. Space remains `memory/facts.md`. user/agent/run persist
+under `spaces/<id>/collections/<scope>/<owner>/` and survive Clear chat. Recall
+payloads stay inside the untrusted wrapper. Slash remember/recall/forget still
+write only the space collection (no dual-write with standing-policy or CLAIMS).
+Control not touched. Local `pytest tests/test_crew` is the gate; not a CI claim.
+
 ## CREW-POLICY-STANDING server ladder on CortexOS/crew — 2026-09-06
 
 Standing allowlist / session / one-off from Settings is Crew policy SoT, not

--- a/CortexOS/crew/memory.py
+++ b/CortexOS/crew/memory.py
@@ -2,9 +2,14 @@
 
 Absorbs the DeepAgents MIT persistent-memory pattern - a directory of named
 notes, each with a one-line description, plus an index - as original Cortex
-code, so a space that is reopened tomorrow does not restart cold. It does not
-decide work shape (dag_runner + manifest + ledger still own that) and it never
-opens DuckDB: files only, under the same per-space jail as the workspace.
+code, so a space that is reopened tomorrow does not restart cold. Collections
+are scoped space|user|agent|run; only the space collection uses ``memory/``.
+Slash remember/recall/forget stay on that space writer - no dual-write into
+user/agent/run files or CLAIMS.json.
+
+It does not decide work shape (dag_runner + manifest + ledger still own that)
+and it never opens DuckDB: files only, under the same per-space jail as the
+workspace.
 
 Three failures this module exists to prevent:
 
@@ -51,6 +56,13 @@ INDEX_FILE = "INDEX.md"
 FACTS_NAME = "facts"
 FACTS_FILE = "facts.md"
 UNTRUSTED_SOURCE = "crew-memory"
+SCOPES = ("space", "user", "agent", "run")
+DEFAULT_OWNERS = {
+    "space": "",
+    "user": "operator",
+    "agent": "crew",
+    "run": "session",
+}
 
 _NAME_RE = re.compile(r"[a-z0-9][a-z0-9._-]*\Z")
 _TOKEN_RE = re.compile(r"[a-z0-9]+")
@@ -96,11 +108,15 @@ class CrewMemory:
         *,
         max_facts: int = MAX_FACTS,
         max_body_bytes: int = MAX_BODY_BYTES,
+        scope: str = "space",
+        owner: str = "",
     ) -> None:
         self._ws = SpaceWorkspace(root)
         self.root = self._ws.root
         self.max_facts = max(1, int(max_facts))
         self.max_body_bytes = max(1, int(max_body_bytes))
+        self.scope = (scope or "space").strip().lower() or "space"
+        self.owner = (owner or "").strip().lower()
 
     # ---- naming and paths -------------------------------------------------
 
@@ -198,6 +214,26 @@ class CrewMemory:
             for fact in self.list_facts()
         ]
 
+    def export_filename(self) -> str:
+        """Download name. Space keeps facts.md; other scopes do not collide with it."""
+        if self.scope == "space" or not self.owner:
+            return FACTS_FILE
+        return f"{self.scope}-{self.owner}.md"
+
+    def public_payload(self, facts: list[MemoryFact] | None = None) -> dict[str, object]:
+        """List/search JSON. ``file`` stays facts.md so existing HUD pins keep working."""
+        rows = facts if facts is not None else self.list_facts()
+        return {
+            "facts": [
+                {"name": fact.name, "description": fact.description, "body": fact.body}
+                for fact in rows
+            ],
+            "file": FACTS_FILE,
+            "filename": self.export_filename(),
+            "scope": self.scope,
+            "owner": self.owner,
+        }
+
     def export_markdown(self) -> str:
         """Operator-visible facts.md. Rebuilt from the named notes, never patched."""
         self._write_facts_md()
@@ -291,6 +327,13 @@ class CrewMemory:
         """One markdown file the operator can export. Chat clear does not touch it."""
         facts = self.list_facts()
         parts = ["# Crew facts", ""]
+        if self.scope != "space":
+            parts = [
+                "# Crew facts",
+                f"scope: {self.scope}",
+                f"owner: {self.owner}",
+                "",
+            ]
         if not facts:
             parts.append("(empty)")
         for fact in facts:
@@ -307,8 +350,61 @@ class CrewMemory:
 
 
 def memory_for(data_dir: Path, space_id: str) -> CrewMemory:
-    """Sibling of :func:`CortexOS.crew.workspace.workspace_for` - same per-space jail."""
-    return CrewMemory(data_dir / "spaces" / space_id / "memory")
+    """Space collection. Slash/tools keep writing here; other scopes use collection_for."""
+    return collection_for(data_dir, space_id, scope="space")
+
+
+def collection_for(
+    data_dir: Path,
+    space_id: str,
+    *,
+    scope: str = "space",
+    owner: str = "",
+) -> CrewMemory:
+    """One markdown collection. Space stays under memory/; others are siblings.
+
+    user/agent/run live in ``spaces/<id>/collections/<scope>/<owner>/`` so a
+    space remember cannot dual-write into them, and chat clear (transcript
+    only) cannot delete them.
+    """
+    kind = _scope_name(scope)
+    if kind == "space":
+        return CrewMemory(
+            data_dir / "spaces" / space_id / "memory",
+            scope="space",
+            owner="",
+        )
+    who = _owner_slug(owner) if (owner or "").strip() else DEFAULT_OWNERS[kind]
+    return CrewMemory(
+        data_dir / "spaces" / space_id / "collections" / kind / who,
+        scope=kind,
+        owner=who,
+    )
+
+
+def _scope_name(scope: str) -> str:
+    raw = (scope or "space").strip().lower()
+    if raw not in SCOPES:
+        raise CrewMemoryError(
+            f"unknown memory scope {scope!r}; use space, user, agent or run"
+        )
+    return raw
+
+
+def _owner_slug(owner: str) -> str:
+    raw = (owner or "").strip().lower()
+    if not raw:
+        raise CrewMemoryError("a collection needs an owner")
+    if len(raw) > MAX_NAME_CHARS:
+        raise CrewMemoryError(
+            f"owner is {len(raw)} chars; the cap is {MAX_NAME_CHARS}"
+        )
+    if not _NAME_RE.match(raw):
+        raise CrewMemoryError(
+            f"bad collection owner {owner!r}: use lowercase letters, digits, '.', '_' or '-' "
+            "(no slashes, no '..', no drive letters)"
+        )
+    return raw
 
 
 def as_error(exc: BaseException) -> str:

--- a/CortexOS/crew/runtime.py
+++ b/CortexOS/crew/runtime.py
@@ -2458,8 +2458,12 @@ class CrewRuntime:
             return ""
         return "Tone (from skills/tone.md):\n" + body[:4000]
 
-    def _mem(self, space_id: str) -> crew_memory.CrewMemory:
-        return crew_memory.memory_for(self.settings.data_dir, space_id)
+    def _mem(
+        self, space_id: str, scope: str = "space", owner: str = ""
+    ) -> crew_memory.CrewMemory:
+        return crew_memory.collection_for(
+            self.settings.data_dir, space_id, scope=scope, owner=owner
+        )
 
     def _manager_history(self, space_id: str, limit: int = 40) -> list[dict[str, Any]]:
         rows = self.store.list_messages(space_id, limit=10_000)

--- a/CortexOS/crew/server.py
+++ b/CortexOS/crew/server.py
@@ -198,6 +198,8 @@ class MemoryIn(BaseModel):
     name: str
     description: str
     body: str = ""
+    scope: str = "space"
+    owner: str = ""
 
 
 class ArmIn(BaseModel):
@@ -477,40 +479,82 @@ def build_router(crew: CrewApp) -> APIRouter:
             raise HTTPException(400, str(accepted["error"]))
         return {"ok": True, "agent": accepted}
 
-    @router.get("/spaces/{space_id}/memory")
-    async def list_memory(space_id: str, q: str = "") -> dict[str, Any]:
+    def _space_mem(space_id: str, scope: str = "space", owner: str = "") -> Any:
+        from CortexOS.crew.memory import CrewMemoryError
+
         if crew.store.get_space(space_id) is None:
             raise HTTPException(404, "unknown space")
-        mem = crew.runtime._mem(space_id)
+        try:
+            return crew.runtime._mem(space_id, scope=scope, owner=owner)
+        except CrewMemoryError as exc:
+            raise HTTPException(400, str(exc)) from exc
+
+    @router.get("/spaces/{space_id}/memory")
+    async def list_memory(
+        space_id: str, q: str = "", scope: str = "space", owner: str = ""
+    ) -> dict[str, Any]:
+        mem = _space_mem(space_id, scope, owner)
         query = q.strip()
         facts = mem.search(query) if query else mem.list_facts()
-        return {
-            "facts": [
-                {"name": f.name, "description": f.description, "body": f.body}
-                for f in facts
-            ],
-            "file": "facts.md",
-        }
+        return mem.public_payload(facts)
+
+    @router.get("/spaces/{space_id}/memory/search")
+    async def search_memory(
+        space_id: str, q: str = "", scope: str = "space", owner: str = ""
+    ) -> dict[str, Any]:
+        mem = _space_mem(space_id, scope, owner)
+        payload = mem.public_payload(mem.search(q))
+        payload["query"] = q
+        return payload
 
     @router.post("/spaces/{space_id}/memory")
     async def save_memory(space_id: str, body: MemoryIn) -> dict[str, Any]:
-        if crew.store.get_space(space_id) is None:
-            raise HTTPException(404, "unknown space")
         from CortexOS.crew.memory import CrewMemoryError
 
-        mem = crew.runtime._mem(space_id)
+        mem = _space_mem(space_id, body.scope, body.owner)
         try:
             detail = mem.remember(body.name, body.description, body.body)
         except CrewMemoryError as exc:
             raise HTTPException(400, str(exc)) from exc
-        return {"ok": True, "detail": detail, "facts": mem.public_facts()}
+        return {
+            "ok": True,
+            "detail": detail,
+            "facts": mem.public_facts(),
+            "scope": mem.scope,
+            "owner": mem.owner,
+            "file": "facts.md",
+        }
 
     @router.get("/spaces/{space_id}/memory/export")
-    async def export_memory(space_id: str) -> dict[str, Any]:
-        if crew.store.get_space(space_id) is None:
-            raise HTTPException(404, "unknown space")
-        mem = crew.runtime._mem(space_id)
-        return {"filename": "facts.md", "markdown": mem.export_markdown()}
+    async def export_memory(
+        space_id: str, scope: str = "space", owner: str = ""
+    ) -> dict[str, Any]:
+        mem = _space_mem(space_id, scope, owner)
+        return {
+            "filename": mem.export_filename(),
+            "markdown": mem.export_markdown(),
+            "scope": mem.scope,
+            "owner": mem.owner,
+        }
+
+    @router.delete("/spaces/{space_id}/memory/{name}")
+    async def forget_memory(
+        space_id: str, name: str, scope: str = "space", owner: str = ""
+    ) -> dict[str, Any]:
+        from CortexOS.crew.memory import CrewMemoryError
+
+        mem = _space_mem(space_id, scope, owner)
+        try:
+            detail = mem.forget(name)
+        except CrewMemoryError as exc:
+            raise HTTPException(400, str(exc)) from exc
+        return {
+            "ok": True,
+            "detail": detail,
+            "facts": mem.public_facts(),
+            "scope": mem.scope,
+            "owner": mem.owner,
+        }
 
     @router.post("/spaces/{space_id}/clear")
     async def clear_chat(space_id: str) -> dict[str, Any]:

--- a/CortexOS/crew/ui/index.html
+++ b/CortexOS/crew/ui/index.html
@@ -118,7 +118,7 @@
             <button class="scope-chip" type="button" data-scope="agent">agent</button>
             <button class="scope-chip" type="button" data-scope="run">run</button>
           </div>
-          <p class="hint">Space scope is facts.md. Survives Clear chat. Recall payloads are untrusted. Not orders.</p>
+          <p class="hint">space|user|agent|run collections persist as markdown. Survives Clear chat. Recall payloads are untrusted. Not orders.</p>
           <input id="memSearch" placeholder="search facts" />
           <div class="life-spawn">
             <input id="memName" placeholder="name" />
@@ -129,7 +129,7 @@
             <button class="ghost" id="memSave" type="button">Save fact</button>
             <button class="ghost" id="memExport" type="button">Export facts.md</button>
           </div>
-          <div id="memory" class="empty empty--orb">No facts in this space.</div>
+          <div id="memory" class="empty empty--orb">No facts in this collection.</div>
           <h2>Collections <span class="scope">crew</span></h2>
           <div id="skills" class="empty">loading...</div>
         </div>
@@ -946,48 +946,31 @@
         state.claimBusy = null;
       }
     }
+    function memoryQuery(scope) {
+      const kind = scope || state.memScope || "space";
+      return "scope=" + encodeURIComponent(kind);
+    }
     async function renderMemory() {
       const scope = state.memScope || "space";
-      if (scope === "space") {
-        if (!state.spaceId) {
-          $("memory").innerHTML = `<div class="empty empty--orb">No facts in this space.</div>`;
-          return;
-        }
-        try {
-          const q = ($("memSearch") && $("memSearch").value || "").trim();
-          const path = "/crew/spaces/" + state.spaceId + "/memory" + (q ? ("?q=" + encodeURIComponent(q)) : "");
-          const data = await api(path);
-          const facts = data.facts || [];
-          $("memory").innerHTML = facts.length
-            ? facts.map((f) => `<div class="row">${esc(f.name)} <span class="scope">facts.md</span><div class="hint">${esc(f.description)}</div></div>`).join("")
-            : `<div class="empty empty--orb">No facts in this space.</div>`;
-        } catch (err) {
-          $("memory").innerHTML = `<div class="empty empty--orb">${esc(err.message)}</div>`;
-        }
+      if (!state.spaceId) {
+        $("memory").innerHTML = `<div class="empty empty--orb">No facts in this collection.</div>`;
         return;
       }
-      const facts = [];
-      if (scope === "space") {
-        (state.skills || []).slice(0, 6).forEach((s) => facts.push({ k: s.title, v: s.head || "skill", id: s.path || "" }));
-        const space = state.spaces.find((s) => s.id === state.spaceId);
-        if (space) facts.push({ k: "space", v: space.title, id: space.id });
-      } else if (scope === "user") {
-        state.messages.filter((m) => m.role === "user").slice(-4).forEach((m) =>
-          facts.push({ k: "you", v: String(m.content || "").slice(0, 80), id: m.id }));
-      } else if (scope === "agent") {
-        state.agents.slice(0, 8).forEach((a) => facts.push({
-          k: a.name,
-          v: (a.mode || "active") + " / " + (a.status || "idle") + (a.goal_text ? " goal=" + a.goal_text : "") + (a.stop_reason ? " DENIED: " + a.stop_reason : ""),
-          id: a.id
-        }));
-      } else if (scope === "run") {
-        facts.push({ k: "run", v: $("runStatus").textContent || "idle", id: state.runId || "" });
-        facts.push({ k: "seq", v: String(state.seq || 0), id: "seq" });
+      try {
+        const q = ($("memSearch") && $("memSearch").value || "").trim();
+        const base = "/crew/spaces/" + state.spaceId + "/memory";
+        const path = q
+          ? base + "/search?" + memoryQuery(scope) + "&q=" + encodeURIComponent(q)
+          : base + "?" + memoryQuery(scope);
+        const data = await api(path);
+        const facts = data.facts || [];
+        const label = data.scope || scope;
+        $("memory").innerHTML = facts.length
+          ? facts.map((f) => `<div class="row">${esc(f.name)} <span class="scope">${esc(label)}</span><div class="hint">${esc(f.description)}</div></div>`).join("")
+          : `<div class="empty empty--orb">No facts in this collection.</div>`;
+      } catch (err) {
+        $("memory").innerHTML = `<div class="empty empty--orb">${esc(err.message)}</div>`;
       }
-      const capped = facts.slice(0, 8);
-      $("memory").innerHTML = capped.length
-        ? capped.map((f) => `<div class="row">${esc(f.k)} <span class="scope">${esc(scope)}</span><small class="id">${esc(f.id)}</small><div class="hint">${esc(f.v)}</div></div>`).join("")
-        : `<div class="empty empty--orb">No facts in this scope.</div>`;
     }
     function renderDesk(desk) {
       if (!desk) { $("desk").innerHTML = `<div class="empty">Desk unavailable.</div>`; return; }
@@ -1456,7 +1439,7 @@
       try {
         await api("/crew/spaces/" + state.spaceId + "/clear", { method: "POST", body: "{}" });
         await selectSpace(state.spaceId);
-        toast("Chat cleared. Goal mode and facts.md stayed.");
+        toast("Chat cleared. Goal mode and memory collections stayed.");
       } catch (err) { toast(err.message, "bad"); }
     };
     $("toggleRail").onclick = () => {
@@ -1508,20 +1491,21 @@
           body: JSON.stringify({
             name: $("memName").value.trim(),
             description: $("memDesc").value.trim(),
-            body: $("memBody").value
+            body: $("memBody").value,
+            scope: state.memScope || "space"
           })
         });
         $("memName").value = "";
         $("memDesc").value = "";
         $("memBody").value = "";
         await renderMemory();
-        toast("Saved to facts.md.");
+        toast("Saved to " + (state.memScope || "space") + " collection.");
       } catch (err) { toast(err.message, "bad"); }
     };
     $("memExport").onclick = async () => {
       if (!state.spaceId) return;
       try {
-        const data = await api("/crew/spaces/" + state.spaceId + "/memory/export");
+        const data = await api("/crew/spaces/" + state.spaceId + "/memory/export?" + memoryQuery(state.memScope || "space"));
         const blob = new Blob([data.markdown || ""], { type: "text/markdown" });
         const a = document.createElement("a");
         a.href = URL.createObjectURL(blob);

--- a/STATUS.md
+++ b/STATUS.md
@@ -1,6 +1,15 @@
 # STATUS.md
 **Last updated:** 2026-09-06 | **Gate:** G2.3 OSR **SHIPPED** | **Active:** C7-02..06; EPIC-015 RAG served-path; GOLD-01 founder TTY; **RSF-04 orchestrator**
 
+> **2026-09-06 (CREW-MEMORY-API):** Collection-scoped Crew memory under Cortex #116.
+> `GET/POST /crew/spaces/{id}/memory`, `GET .../memory/search`, `GET .../memory/export`,
+> `DELETE .../memory/{name}` take `scope=space|user|agent|run`. Space stays
+> `spaces/<id>/memory/facts.md`. user/agent/run write sibling collection dirs.
+> HUD chips call those endpoints (not derived chat/agent/run state). Clear chat
+> does not delete collection files. Recall stays untrusted-wrapped. Slash remember
+> still writes only the space collection. Control untouched. Local pytest
+> `tests/test_crew` after this slice; this line is not a GitHub CI claim.
+>
 > **2026-09-06 (CREW-POLICY-STANDING):** Standing allowlist / session / one-off
 > is Crew policy SoT (`CortexOS/crew/approvals.py`), not localStorage.
 > `policy.decide` / `decide_with_approvals` apply the ladder; standing and

--- a/STATUS.md
+++ b/STATUS.md
@@ -7,8 +7,8 @@
 > `spaces/<id>/memory/facts.md`. user/agent/run write sibling collection dirs.
 > HUD chips call those endpoints (not derived chat/agent/run state). Clear chat
 > does not delete collection files. Recall stays untrusted-wrapped. Slash remember
-> still writes only the space collection. Control untouched. Local pytest
-> `tests/test_crew` after this slice; this line is not a GitHub CI claim.
+> still writes only the space collection. Control untouched. Local `pytest tests/test_crew -q`
+> **211 passed**. This line is not a GitHub CI claim.
 >
 > **2026-09-06 (CREW-POLICY-STANDING):** Standing allowlist / session / one-off
 > is Crew policy SoT (`CortexOS/crew/approvals.py`), not localStorage.

--- a/docs/subagents_findings/2026-09-06_crew-memory-api.md
+++ b/docs/subagents_findings/2026-09-06_crew-memory-api.md
@@ -1,0 +1,40 @@
+```yaml
+keywords: [crew, memory, collection, facts.md, scope, user, agent, run, epic-116]
+main_idea: "CREW-MEMORY-API: space|user|agent|run collections persist markdown and survive chat clear. HUD uses list/search/export API, not derived chat state."
+models: [grok-4.6]
+workflow: goal-crew-control
+reuse: 2026-09-04_crew-facts-md-hud
+status: verified
+cite: agent: crew-memory-api
+repo: Cortex
+date: 2026-09-06
+```
+
+# CREW-MEMORY-API collection scopes
+
+PREFLIGHT: PARTIAL
+reuse: 2026-09-04_crew-facts-md-hud, crew-belt-claim
+spawn: skip
+
+## Gap
+
+Chrome already painted space|user|agent|run chips. Only space hit `/crew/spaces/{id}/memory`. user/agent/run were derived from messages/agents/runStatus and vanished on Clear chat.
+
+## Landed (branch `cursor/crew-memory-api-6ce8`)
+
+- `collection_for(data_dir, space_id, scope=, owner=)` — space stays `memory/`; others `collections/<scope>/<owner>/`
+- Defaults: user=operator, agent=crew, run=session
+- HTTP: list `GET .../memory?scope=`, search `GET .../memory/search`, save POST, export GET, forget DELETE
+- HUD chips/search/save/export call those endpoints
+- Recall still `wrap_untrusted_payload`
+- Slash remember remains the space writer (no dual-write)
+
+## Verify
+
+```
+python -m pytest tests/test_crew -q
+```
+
+## Not this slice
+
+Control stays display-only. CLAIMS.json not written. Standing-approval ladder untouched. Live `:8020` needs founder restart. GitHub CI not claimed.

--- a/docs/subagents_findings/2026-09-06_crew-memory-api.md
+++ b/docs/subagents_findings/2026-09-06_crew-memory-api.md
@@ -35,6 +35,8 @@ Chrome already painted space|user|agent|run chips. Only space hit `/crew/spaces/
 python -m pytest tests/test_crew -q
 ```
 
+Local: 211 passed. Not a GitHub CI claim.
+
 ## Not this slice
 
 Control stays display-only. CLAIMS.json not written. Standing-approval ladder untouched. Live `:8020` needs founder restart. GitHub CI not claimed.

--- a/docs/subagents_findings/INDEX.md
+++ b/docs/subagents_findings/INDEX.md
@@ -2,6 +2,7 @@
 
 | Date | Topic | Keywords | Main idea | Path |
 |------|-------|----------|-----------|------|
+| 2026-09-06 | crew-memory-api | crew, memory, collection, facts.md, scope, epic-116 | Collection-scoped Crew memory (space|user|agent|run). HUD uses list/search/export API; files survive chat clear. | `2026-09-06_crew-memory-api.md` |
 | 2026-09-06 | crew-policy-standing | crew, policy, standing, allowlist, session, one-off, circuit-breaker, epic-116 | Settings ladder is Crew policy SoT. decide/decide_with_approvals enforce standing/session/one-off. Repeated deny trips circuit. Per-agent grants only tighten. | `2026-09-06_crew-policy-standing.md` |
 | 2026-09-06 | rsf-04-orchestrator | rsf, rsf-04, orchestrator, certified, abstain, #154 | In-process run_rsf certifies research→segment→classify→filter. Priors from RSF_STAGES. No invent-green downstream. Options advisory. | `2026-09-06_rsf-04-orchestrator.md` |
 | 2026-09-06 | crew-belt-claim | crew, belt, claim, release, lease, ttl, 409, epic-116 | Chrome Claim/Release is Crew lease SoT (worker+TTL). 409 held/SEATED. 403 non-holder release. Control display-only. | `2026-09-06_crew-belt-claim.md` |

--- a/tests/test_crew/test_memory.py
+++ b/tests/test_crew/test_memory.py
@@ -16,6 +16,7 @@ from CortexOS.crew.memory import (
     INDEX_PROMPT_MAX_CHARS,
     CrewMemory,
     CrewMemoryError,
+    collection_for,
     memory_for,
 )
 from CortexOS.execution.untrusted_payload import BEGIN, END, is_wrapped
@@ -228,6 +229,54 @@ def test_memory_for_mirrors_the_workspace_jail_layout(tmp_path: Path) -> None:
     assert mem.root == (tmp_path / "crew" / "spaces" / "space-7" / "memory").resolve()
     mem.remember("hello", "a greeting", "hi")
     assert (tmp_path / "crew" / "spaces" / "space-7" / "memory" / "hello.md").is_file()
+
+
+def test_collection_for_isolates_scopes_and_survives_a_fresh_process(
+    tmp_path: Path,
+) -> None:
+    data = tmp_path / "crew"
+    space = collection_for(data, "s1", scope="space")
+    user = collection_for(data, "s1", scope="user")
+    agent = collection_for(data, "s1", scope="agent")
+    run = collection_for(data, "s1", scope="run")
+    assert user.owner == "operator"
+    assert agent.owner == "crew"
+    assert run.owner == "session"
+
+    user.remember("tz", "founder timezone", "MYT")
+    agent.remember("voice", "how this teammate talks", "short")
+    run.remember("pass", "current pass name", "CREW-MEMORY-API")
+    space.remember("port", "which port crew listens on", "8020")
+
+    # a brand new object, as if chat clear + process restart
+    again = collection_for(data, "s1", scope="user")
+    assert [f.name for f in again.list_facts()] == ["tz"]
+    assert "MYT" in again.recall("timezone")
+    assert is_wrapped(again.recall("timezone"))
+
+    space_files = {p.name for p in space.root.glob("*.md")}
+    assert "tz.md" not in space_files
+    assert "port.md" in space_files
+    assert (user.root / "facts.md").is_file()
+    assert (agent.root / "facts.md").is_file()
+    assert (run.root / "facts.md").is_file()
+    assert not list(tmp_path.rglob("CLAIMS.json"))
+
+
+def test_collection_owner_and_scope_are_jailed(tmp_path: Path) -> None:
+    data = tmp_path / "crew"
+    with pytest.raises(CrewMemoryError) as scope_exc:
+        collection_for(data, "s1", scope="global")
+    assert "space, user, agent or run" in str(scope_exc.value)
+
+    with pytest.raises(CrewMemoryError) as owner_exc:
+        collection_for(data, "s1", scope="user", owner="../escape")
+    assert str(owner_exc.value).strip()
+
+    collection_for(data, "s1", scope="user").remember("kept", "must survive", "yes")
+    written = {p for p in tmp_path.rglob("*.md")}
+    roots = tmp_path / "crew" / "spaces" / "s1" / "collections" / "user" / "operator"
+    assert written == {roots / "kept.md", roots / "INDEX.md", roots / "facts.md"}
 
 
 def test_the_module_opens_no_database() -> None:

--- a/tests/test_crew/test_server.py
+++ b/tests/test_crew/test_server.py
@@ -109,7 +109,8 @@ def test_ui_index_is_served(client) -> None:
     assert 'id="memSave"' in page.text
     assert 'id="memExport"' in page.text
     assert "/crew/spaces/" in page.text
-    assert "/memory/search" in page.text
+    assert 'base + "/search?"' in page.text
+    assert "memoryQuery" in page.text
     assert 'filter((m) => m.role === "user")' not in page.text
     assert "No facts in this collection." in page.text
     assert "Standing approvals" in page.text
@@ -722,7 +723,8 @@ def test_collection_memory_api_survives_clear_and_does_not_dual_write(client) ->
     assert missing.status_code == 404
 
     page = client.http.get("/")
-    assert "/memory/search" in page.text
+    assert 'base + "/search?"' in page.text
+    assert "memoryQuery" in page.text
     assert 'filter((m) => m.role === "user")' not in page.text
     claims = list(client.crew.settings.data_dir.rglob("CLAIMS.json"))
     assert claims == []

--- a/tests/test_crew/test_server.py
+++ b/tests/test_crew/test_server.py
@@ -109,6 +109,9 @@ def test_ui_index_is_served(client) -> None:
     assert 'id="memSave"' in page.text
     assert 'id="memExport"' in page.text
     assert "/crew/spaces/" in page.text
+    assert "/memory/search" in page.text
+    assert 'filter((m) => m.role === "user")' not in page.text
+    assert "No facts in this collection." in page.text
     assert "Standing approvals" in page.text
     assert "one-off" in page.text
     assert "circuit-breaker" in page.text
@@ -618,6 +621,111 @@ def test_operator_life_routes_spawn_kill_clear(client) -> None:
     )
     assert refuse.status_code == 400
     assert "DENIED" in refuse.json()["detail"]
+
+
+def test_collection_memory_api_survives_clear_and_does_not_dual_write(client) -> None:
+    space = client.http.post("/crew/spaces", json={"title": "Collections"}).json()
+    sid = space["id"]
+    saved = client.http.post(
+        f"/crew/spaces/{sid}/memory",
+        json={
+            "name": "tz",
+            "description": "founder timezone",
+            "body": "MYT",
+            "scope": "user",
+        },
+    ).json()
+    assert saved["ok"] is True
+    assert saved["scope"] == "user"
+    assert saved["owner"] == "operator"
+
+    listed = client.http.get(f"/crew/spaces/{sid}/memory", params={"scope": "user"}).json()
+    assert listed["scope"] == "user"
+    assert listed["owner"] == "operator"
+    assert listed["file"] == "facts.md"
+    assert listed["facts"][0]["name"] == "tz"
+    assert listed["facts"][0]["body"] == "MYT"
+
+    space_listed = client.http.get(f"/crew/spaces/{sid}/memory").json()
+    assert space_listed["scope"] == "space"
+    assert space_listed["facts"] == []
+
+    searched = client.http.get(
+        f"/crew/spaces/{sid}/memory/search",
+        params={"scope": "user", "q": "timezone"},
+    ).json()
+    assert searched["query"] == "timezone"
+    assert searched["facts"][0]["name"] == "tz"
+
+    for scope, body in (
+        ("agent", "keep answers short"),
+        ("run", "CREW-MEMORY-API"),
+    ):
+        row = client.http.post(
+            f"/crew/spaces/{sid}/memory",
+            json={
+                "name": "note",
+                "description": f"{scope} notebook",
+                "body": body,
+                "scope": scope,
+            },
+        ).json()
+        assert row["ok"] is True
+        assert row["scope"] == scope
+
+    client.http.post(
+        f"/crew/spaces/{sid}/messages",
+        json={"text": "throw away"},
+    )
+    deadline = time.time() + 5
+    while client.crew.runtime._space_run.get(sid):
+        if time.time() > deadline:
+            break
+        time.sleep(0.02)
+    cleared = client.http.post(f"/crew/spaces/{sid}/clear").json()
+    assert cleared["ok"] is True
+
+    for scope, expected in (
+        ("user", "MYT"),
+        ("agent", "keep answers short"),
+        ("run", "CREW-MEMORY-API"),
+    ):
+        after = client.http.get(
+            f"/crew/spaces/{sid}/memory", params={"scope": scope}
+        ).json()
+        assert after["facts"][0]["body"] == expected
+
+    exported = client.http.get(
+        f"/crew/spaces/{sid}/memory/export", params={"scope": "user"}
+    ).json()
+    assert exported["filename"] == "user-operator.md"
+    assert exported["scope"] == "user"
+    assert "# Crew facts" in exported["markdown"]
+    assert "scope: user" in exported["markdown"]
+    assert "MYT" in exported["markdown"]
+
+    forgotten = client.http.delete(
+        f"/crew/spaces/{sid}/memory/tz", params={"scope": "user"}
+    ).json()
+    assert forgotten["ok"] is True
+    empty = client.http.get(f"/crew/spaces/{sid}/memory", params={"scope": "user"}).json()
+    assert empty["facts"] == []
+
+    bad = client.http.post(
+        f"/crew/spaces/{sid}/memory",
+        json={"name": "x", "description": "nope", "body": "x", "scope": "global"},
+    )
+    assert bad.status_code == 400
+    assert "space, user, agent or run" in bad.json()["detail"]
+
+    missing = client.http.get("/crew/spaces/no-such-space/memory/search", params={"q": "x"})
+    assert missing.status_code == 404
+
+    page = client.http.get("/")
+    assert "/memory/search" in page.text
+    assert 'filter((m) => m.role === "user")' not in page.text
+    claims = list(client.crew.settings.data_dir.rglob("CLAIMS.json"))
+    assert claims == []
 
 
 def test_threads_hud_paints_pending_and_dead_on_switchboard(client) -> None:


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
CREW-MEMORY-API follow-up under parent #116.

Rebased onto `origin/main` @ `ef1e61af` (CREW-POLICY-STANDING #187). Crew code auto-merged: collection memory API and ApprovalBook stay separate writers. Doc conflicts in STATUS/CHANGELOG/INDEX kept both slices.

## What landed

- Collection roots: space stays `spaces/<id>/memory/facts.md`. user/agent/run write sibling `spaces/<id>/collections/<scope>/<owner>/` (defaults operator/crew/session).
- HTTP: `GET/POST /crew/spaces/{id}/memory`, `GET .../memory/search`, `GET .../memory/export`, `DELETE .../memory/{name}` with `scope` + optional `owner`.
- HUD Save / Search / Export use those endpoints for every chip. Not UI-derived capped facts.
- Recall payloads stay inside the untrusted wrapper. Slash `/remember` still writes only the space collection (no dual-write with standing-policy or CLAIMS.json).

## Acceptance

1. Founder save under space|user|agent|run persists markdown and survives `/clear`.
2. list / search / export exist; HUD calls them.
3. Recall remains fenced as data.
4. Local `pytest tests/test_crew -q`: **219 passed** after rebase onto POLICY #187. This PR does not invent GitHub CI green.

## Out of scope

Control not touched. Freeze lanes not attached. Does not squash-merge itself.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-868ffedc-7fa0-49f5-a309-af7552906ce8?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-868ffedc-7fa0-49f5-a309-af7552906ce8&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

