### PR TITLE
CREW-ROUTER-HARDEN

### DIFF
--- a/CHANGELOG_DMS.md
+++ b/CHANGELOG_DMS.md
@@ -2,6 +2,16 @@
 
 Agents append one section per shipped feature. Sequential build log.
 
+## CREW-ROUTER-HARDEN OpenVault/FreeRoute multi-API arming — 2026-09-06
+
+Crew inference sources can be armed from OpenVault without keeping API secrets
+in `data/crew/keys.json`. Vault-armed hosts (Groq/Google/OpenRouter/...) show
+as configured, route through FreeRoute when the vault is live, and refuse with
+a reason when unarmed. `GET /crew/providers` and `/crew/health` stamp `chosen`
+(label/model/source/connector). Plugins arm checkboxes call
+`POST /crew/connectors/{slug}/arm`. Grok Bot stays OFFLOADED. Local
+`pytest tests/test_crew -q` 231 passed. Parent #116. Does not prove live `:8020`.
+
 ## RSF-06 distill harness (myn8n/LC/LF/GenCFSM → Netie-native) — 2026-09-06
 
 In-process `run_distill` reads an options-class recipe, studies names-only analog

--- a/CortexOS/crew/config.py
+++ b/CortexOS/crew/config.py
@@ -16,7 +16,7 @@ import json
 import os
 import time
 import urllib.request
-from dataclasses import dataclass, field
+from dataclasses import dataclass, field, replace
 from pathlib import Path
 
 from CortexOS.paths import data_path
@@ -32,6 +32,8 @@ class Provider:
     configured: bool
     active: bool = False
     api_base: str | None = None
+    connector: str = "litellm"
+    armed_via: str = ""
 
     def public(self) -> dict[str, object]:
         return {
@@ -40,6 +42,9 @@ class Provider:
             "source": self.source,
             "configured": self.configured,
             "active": self.active,
+            "armed": self.configured,
+            "connector": self.connector,
+            "armed_via": self.armed_via,
         }
 
 
@@ -140,139 +145,196 @@ def _ollama_first_model(base_url: str, timeout: float = 0.8) -> str | None:
     return found
 
 
+def _arm_flags(
+    label: str, env_ok: bool, ov_ok: bool, vault: dict[str, dict]
+) -> tuple[bool, str, str]:
+    """Return configured, armed_via, connector. FreeRoute wins when measured live."""
+    vault_ok = bool(vault.get(label) and vault[label].get("enabled"))
+    configured = bool(env_ok or vault_ok)
+    if env_ok and vault_ok:
+        via = "both"
+    elif vault_ok:
+        via = "openvault"
+    elif env_ok:
+        via = "env"
+    else:
+        via = ""
+    prefer_ov = bool(ov_ok and vault_ok)
+    connector = "openvault" if (label == "openvault" or prefer_ov) else "litellm"
+    return configured, via, connector
+
+
+def _wrap_freeroute(label: str, model: str, connector: str) -> str:
+    if connector != "openvault" or label in {"openvault", "explicit"}:
+        return model
+    if model.startswith("openvault/"):
+        return model
+    if label == "cursor":
+        from CortexOS.crew.openvault import cursor_model
+
+        return "openvault/" + cursor_model()
+    return "openvault/" + model
+
+
 def resolve_providers() -> list[Provider]:
     """Build the provider chain.
 
     Default: the first configured entry is active. When ``CREW_PROVIDER`` is
     set, only that label may be active; a miss stays inactive (no fallback).
+    A host is configured if its env key is set *or* OpenVault lists an enabled
+    key for that label. Vault-armed hosts route through FreeRoute when the
+    vault is live; crew does not need a local copy of the secret.
     """
     env = os.environ
     chain: list[Provider] = []
-
-    explicit = env.get("CREW_MODEL", "").strip()
-    chain.append(
-        Provider(
-            label="explicit",
-            model=explicit or "(set CREW_MODEL to any litellm model string)",
-            source="CREW_MODEL",
-            configured=bool(explicit),
-        )
-    )
     ov_ok = False
+    vault: dict[str, dict] = {}
     if env.get("CREW_OPENVAULT", "1") != "0":
-        from CortexOS.crew.openvault import healthz
+        from CortexOS.crew.openvault import healthz, vault_sources
 
         ov_ok = bool(healthz().get("ok"))
-    chain.append(
-        Provider(
-            label="openvault",
-            model="openvault/" + (env.get("CREW_OPENVAULT_MODEL", "").strip() or "auto"),
-            source="OpenVault FreeRoute (loopback, keys stay in the vault)",
-            configured=ov_ok,
-            api_base=env.get("CREW_OPENVAULT_URL", "http://127.0.0.1:5000"),
+        vault = vault_sources()
+
+    def add(
+        label: str,
+        model: str,
+        env_source: str,
+        env_ok: bool,
+        api_base: str | None = None,
+        *,
+        connector: str | None = None,
+        via: str | None = None,
+        configured: bool | None = None,
+    ) -> None:
+        cfg, armed_via, conn = _arm_flags(label, env_ok, ov_ok, vault)
+        if configured is not None:
+            cfg = configured
+        if connector is not None:
+            conn = connector
+        if via is not None:
+            armed_via = via
+        source = env_source
+        if conn == "openvault" and label != "explicit":
+            source = "OpenVault FreeRoute (vault-armed)" if label != "openvault" else env_source
+        chain.append(
+            Provider(
+                label=label,
+                model=_wrap_freeroute(label, model, conn),
+                source=source,
+                configured=cfg,
+                api_base=api_base,
+                connector=conn,
+                armed_via=armed_via,
+            )
         )
+
+    explicit = env.get("CREW_MODEL", "").strip()
+    add(
+        "explicit",
+        explicit or "(set CREW_MODEL to any litellm model string)",
+        "CREW_MODEL",
+        bool(explicit),
+        connector="openvault" if explicit.startswith("openvault/") else "litellm",
+        via="env" if explicit else "",
+        configured=bool(explicit),
     )
-    chain.append(
-        Provider(
-            label="anthropic",
-            model="anthropic/" + env.get("CREW_ANTHROPIC_MODEL", "claude-sonnet-5"),
-            source="ANTHROPIC_API_KEY",
-            configured=bool(env.get("ANTHROPIC_API_KEY")),
-        )
+    add(
+        "openvault",
+        "openvault/" + (env.get("CREW_OPENVAULT_MODEL", "").strip() or "auto"),
+        "OpenVault FreeRoute (loopback, keys stay in the vault)",
+        ov_ok,
+        env.get("CREW_OPENVAULT_URL", "http://127.0.0.1:5000"),
+        connector="openvault",
+        via="openvault" if ov_ok else "",
+        configured=ov_ok,
+    )
+    add(
+        "anthropic",
+        "anthropic/" + env.get("CREW_ANTHROPIC_MODEL", "claude-sonnet-5"),
+        "ANTHROPIC_API_KEY",
+        bool(env.get("ANTHROPIC_API_KEY")),
     )
     cursor_base = env.get("CREW_CURSOR_BASE_URL", "https://api.cursor.com/v1").strip() or None
-    chain.append(
-        Provider(
-            label="cursor",
-            model="openai/" + env.get("CREW_CURSOR_MODEL", "grok-4.6"),
-            source="CURSOR_API_KEY",
-            configured=bool(env.get("CURSOR_API_KEY")),
-            api_base=cursor_base,
-        )
+    add(
+        "cursor",
+        "openai/" + env.get("CREW_CURSOR_MODEL", "grok-4.6"),
+        "CURSOR_API_KEY",
+        bool(env.get("CURSOR_API_KEY")),
+        cursor_base,
     )
-    chain.append(
-        Provider(
-            label="openrouter",
-            model="openrouter/" + env.get("CREW_OPENROUTER_MODEL", "deepseek/deepseek-chat"),
-            source="OPENROUTER_API_KEY",
-            configured=bool(env.get("OPENROUTER_API_KEY")),
-        )
+    add(
+        "openrouter",
+        "openrouter/" + env.get("CREW_OPENROUTER_MODEL", "deepseek/deepseek-chat"),
+        "OPENROUTER_API_KEY",
+        bool(env.get("OPENROUTER_API_KEY")),
     )
-    chain.append(
-        Provider(
-            label="xai",
-            model="xai/" + env.get("CREW_XAI_MODEL", "grok-4"),
-            source="XAI_API_KEY",
-            configured=bool(env.get("XAI_API_KEY")),
-        )
+    add(
+        "xai",
+        "xai/" + env.get("CREW_XAI_MODEL", "grok-4"),
+        "XAI_API_KEY",
+        bool(env.get("XAI_API_KEY")),
     )
-    chain.append(
-        Provider(
-            label="deepseek",
-            model="deepseek/" + env.get("CREW_DEEPSEEK_MODEL", "deepseek-chat"),
-            source="DEEPSEEK_API_KEY",
-            configured=bool(env.get("DEEPSEEK_API_KEY")),
-        )
+    add(
+        "deepseek",
+        "deepseek/" + env.get("CREW_DEEPSEEK_MODEL", "deepseek-chat"),
+        "DEEPSEEK_API_KEY",
+        bool(env.get("DEEPSEEK_API_KEY")),
     )
     openai_base = env.get("CREW_OPENAI_BASE_URL", "").strip() or None
-    chain.append(
-        Provider(
-            label="openai-compatible",
-            model="openai/" + env.get("CREW_OPENAI_MODEL", "gpt-4o-mini"),
-            source="OPENAI_API_KEY / CREW_OPENAI_BASE_URL",
-            configured=bool(env.get("OPENAI_API_KEY") or openai_base),
-            api_base=openai_base,
-        )
+    add(
+        "openai-compatible",
+        "openai/" + env.get("CREW_OPENAI_MODEL", "gpt-4o-mini"),
+        "OPENAI_API_KEY / CREW_OPENAI_BASE_URL",
+        bool(env.get("OPENAI_API_KEY") or openai_base),
+        openai_base,
     )
-    chain.append(
-        Provider(
-            label="groq",
-            model="groq/" + env.get("CREW_GROQ_MODEL", "llama-3.3-70b-versatile"),
-            source="GROQ_API_KEY",
-            configured=bool(env.get("GROQ_API_KEY")),
-        )
+    add(
+        "groq",
+        "groq/" + env.get("CREW_GROQ_MODEL", "llama-3.3-70b-versatile"),
+        "GROQ_API_KEY",
+        bool(env.get("GROQ_API_KEY")),
     )
-    chain.append(
-        Provider(
-            label="google",
-            model="gemini/" + env.get("CREW_GOOGLE_MODEL", "gemini-2.0-flash"),
-            source="GOOGLE_API_KEY",
-            configured=bool(env.get("GOOGLE_API_KEY")),
-        )
+    add(
+        "google",
+        "gemini/" + env.get("CREW_GOOGLE_MODEL", "gemini-2.0-flash"),
+        "GOOGLE_API_KEY",
+        bool(env.get("GOOGLE_API_KEY")),
     )
-    chain.append(
-        Provider(
-            label="cerebras",
-            model="cerebras/" + env.get("CREW_CEREBRAS_MODEL", "llama3.1-8b"),
-            source="CEREBRAS_API_KEY",
-            configured=bool(env.get("CEREBRAS_API_KEY")),
-        )
+    add(
+        "cerebras",
+        "cerebras/" + env.get("CREW_CEREBRAS_MODEL", "llama3.1-8b"),
+        "CEREBRAS_API_KEY",
+        bool(env.get("CEREBRAS_API_KEY")),
     )
-    chain.append(
-        Provider(
-            label="mistral",
-            model="mistral/" + env.get("CREW_MISTRAL_MODEL", "mistral-small-latest"),
-            source="MISTRAL_API_KEY",
-            configured=bool(env.get("MISTRAL_API_KEY")),
-        )
+    add(
+        "mistral",
+        "mistral/" + env.get("CREW_MISTRAL_MODEL", "mistral-small-latest"),
+        "MISTRAL_API_KEY",
+        bool(env.get("MISTRAL_API_KEY")),
     )
     ollama_model: str | None = None
     if env.get("CREW_ALLOW_OLLAMA", "1") != "0":
         ollama_model = _ollama_first_model(
             env.get("OLLAMA_HOST", "http://127.0.0.1:11434").rstrip("/")
         )
-    chain.append(
-        Provider(
-            label="ollama",
-            model=f"ollama/{ollama_model}" if ollama_model else "(no local ollama detected)",
-            source="autodetect",
-            configured=bool(ollama_model),
-        )
+    add(
+        "ollama",
+        f"ollama/{ollama_model}" if ollama_model else "(no local ollama detected)",
+        "autodetect",
+        bool(ollama_model),
+        connector="litellm",
+        via="env" if ollama_model else "",
+        configured=bool(ollama_model),
     )
 
     pin = env.get("CREW_PROVIDER", "").strip().lower()
     if pin in {"openai", "ov", "vault", "gemini"}:
-        pin = {"openai": "openai-compatible", "ov": "openvault", "vault": "openvault", "gemini": "google"}[pin]
+        pin = {
+            "openai": "openai-compatible",
+            "ov": "openvault",
+            "vault": "openvault",
+            "gemini": "google",
+        }[pin]
 
     out: list[Provider] = []
     if pin:
@@ -280,27 +342,17 @@ def resolve_providers() -> list[Provider]:
         for p in chain:
             if p.label.lower() == pin:
                 matched = True
-                if p.configured:
-                    out.append(Provider(p.label, p.model, p.source, True, True, p.api_base))
-                else:
-                    out.append(p)
+                out.append(replace(p, active=True) if p.configured else p)
             else:
-                out.append(
-                    Provider(p.label, p.model, p.source, p.configured, False, p.api_base)
-                    if p.active
-                    else p
-                )
+                out.append(replace(p, active=False) if p.active else p)
         if not matched:
-            return [
-                Provider(p.label, p.model, p.source, p.configured, False, p.api_base)
-                for p in chain
-            ]
+            return [replace(p, active=False) if p.active else p for p in chain]
         return out
 
     activated = False
     for p in chain:
         if p.configured and not activated:
-            out.append(Provider(p.label, p.model, p.source, True, True, p.api_base))
+            out.append(replace(p, active=True))
             activated = True
         else:
             out.append(p)

--- a/CortexOS/crew/connectors.py
+++ b/CortexOS/crew/connectors.py
@@ -74,7 +74,11 @@ def _row(
     layer: str,
     connected: bool,
     detail: str,
+    armable: bool = False,
+    armed: bool | None = None,
+    armed_via: str = "",
 ) -> dict[str, Any]:
+    is_armed = connected if armed is None else bool(armed)
     return {
         "slug": slug,
         "name": name,
@@ -84,10 +88,16 @@ def _row(
         "ok": connected,
         "noAuth": True,
         "logo": None,
+        "armable": armable,
+        "armed": is_armed,
+        "armed_via": armed_via,
     }
 
 
 def catalog(*, uacc_enabled: bool = False, uacc_armed: bool = False) -> list[dict[str, Any]]:
+    from CortexOS.crew.openvault import vault_sources
+
+    sources = vault_sources()
     out: list[dict[str, Any]] = []
     for row in _ROWS:
         connected = False
@@ -133,10 +143,29 @@ def catalog(*, uacc_enabled: bool = False, uacc_armed: bool = False) -> list[dic
         )
     for row in _API_ROWS:
         env_key = row["env"]
-        connected = bool(os.environ.get(env_key, "").strip())
-        if row["slug"] == "openai" and not connected:
-            connected = bool(os.environ.get("CREW_OPENAI_BASE_URL", "").strip())
-        detail = f"{env_key} configured" if connected else f"{env_key} unset"
+        env_ok = bool(os.environ.get(env_key, "").strip())
+        if row["slug"] == "openai" and not env_ok:
+            env_ok = bool(os.environ.get("CREW_OPENAI_BASE_URL", "").strip())
+        label = "openai-compatible" if row["slug"] == "openai" else row["slug"]
+        vault_row = sources.get(label)
+        vault_on = bool(vault_row and vault_row.get("enabled"))
+        vault_off = bool(vault_row and not vault_row.get("enabled"))
+        connected = bool(env_ok or vault_on)
+        if env_ok and vault_on:
+            via = "both"
+            detail = f"{env_key} vault-armed"
+        elif vault_on:
+            via = "openvault"
+            detail = f"{env_key} vault-armed"
+        elif env_ok:
+            via = "env"
+            detail = f"{env_key} configured"
+        elif vault_off:
+            via = ""
+            detail = f"{env_key} vault-disarmed"
+        else:
+            via = ""
+            detail = f"{env_key} unset"
         out.append(
             _row(
                 slug=row["slug"],
@@ -144,6 +173,9 @@ def catalog(*, uacc_enabled: bool = False, uacc_armed: bool = False) -> list[dic
                 layer=row["layer"],
                 connected=connected,
                 detail=detail,
+                armable=True,
+                armed=connected,
+                armed_via=via,
             )
         )
     return out
@@ -168,3 +200,29 @@ def require(slug: str, **catalog_kwargs: Any) -> dict[str, Any]:
         reason = str(row.get("detail") or "not connected")
         raise ConnectorError(f"connector {slug} refused: {reason} (no silent fallback)")
     return row
+
+
+_ARMABLE = frozenset({row["slug"] for row in _API_ROWS} | {"cursor"})
+
+
+def arm(slug: str, armed: bool) -> dict[str, Any]:
+    """Arm/disarm an inference API via OpenVault. Fail-closed. No secrets."""
+    needle = (slug or "").strip().lower()
+    if needle == "openai-compatible":
+        needle = "openai"
+    if needle == "grok":
+        raise ConnectorError(
+            "Grok Bot is OFFLOADED; watchdog must not auto-start (no silent fallback)"
+        )
+    if needle not in _ARMABLE:
+        raise ConnectorError(f"unknown connector '{slug}' (no silent fallback)")
+    from CortexOS.crew.openvault import arm_source
+
+    label = "openai-compatible" if needle == "openai" else needle
+    result = arm_source(label, armed, slug=needle)
+    if not result.get("ok"):
+        detail = str(result.get("detail") or "unarmed")
+        if "no silent fallback" not in detail:
+            detail = detail + " (no silent fallback)"
+        raise ConnectorError(detail)
+    return result

--- a/CortexOS/crew/keys.py
+++ b/CortexOS/crew/keys.py
@@ -78,14 +78,25 @@ def save(data_dir: Path, updates: dict[str, str | None]) -> dict[str, Any]:
             current.pop(key, None)
             os.environ.pop(key, None)
         else:
-            current[key] = str(value).strip()
-            os.environ[key] = current[key]
+            stripped = str(value).strip()
+            os.environ[key] = stripped
+            keep_local = True
             if key.endswith("_API_KEY"):
                 from CortexOS.crew.openvault import upsert_env_key
 
-                vaulted = upsert_env_key(key, current[key])
-                if not vaulted.get("ok"):
-                    os.environ["CREW_VAULT_LAST_ERROR"] = str(vaulted.get("detail") or "vault upsert failed")
+                vaulted = upsert_env_key(key, stripped)
+                if vaulted.get("ok"):
+                    # Secret lives in OpenVault. Do not keep a crew copy on disk.
+                    keep_local = False
+                    os.environ.pop("CREW_VAULT_LAST_ERROR", None)
+                else:
+                    os.environ["CREW_VAULT_LAST_ERROR"] = str(
+                        vaulted.get("detail") or "vault upsert failed"
+                    )
+            if keep_local:
+                current[key] = stripped
+            else:
+                current.pop(key, None)
     data_dir.mkdir(parents=True, exist_ok=True)
     path = _path(data_dir)
     path.write_text(json.dumps(current, indent=2), encoding="utf-8")

--- a/CortexOS/crew/llm.py
+++ b/CortexOS/crew/llm.py
@@ -55,6 +55,16 @@ class Route:
     api_base: str | None
     source: str
     connector: str
+    armed_via: str = ""
+
+    def as_public(self) -> dict[str, object]:
+        return {
+            "label": self.label,
+            "model": self.model,
+            "source": self.source,
+            "connector": self.connector,
+            "armed_via": self.armed_via,
+        }
 
 
 _PROVIDER_ALIASES = {
@@ -63,6 +73,21 @@ _PROVIDER_ALIASES = {
     "vault": "openvault",
     "google": "google",
     "gemini": "google",
+}
+
+_MODEL_PREFIX_TO_LABEL = {
+    "openvault": "openvault",
+    "anthropic": "anthropic",
+    "openrouter": "openrouter",
+    "deepseek": "deepseek",
+    "openai": "openai-compatible",
+    "xai": "xai",
+    "groq": "groq",
+    "gemini": "google",
+    "google": "google",
+    "cerebras": "cerebras",
+    "mistral": "mistral",
+    "ollama": "ollama",
 }
 
 
@@ -153,8 +178,23 @@ def _norm_provider(label: str) -> str:
     return _PROVIDER_ALIASES.get(raw, raw)
 
 
-def _connector_for(label: str) -> str:
-    return "openvault" if label == "openvault" else "litellm"
+def _label_for_model(model: str) -> str:
+    raw = (model or "").strip()
+    if not raw:
+        return ""
+    if raw.startswith("openvault/"):
+        return "openvault"
+    if "grok" in raw.lower():
+        return "cursor"
+    prefix = raw.split("/", 1)[0].lower()
+    return _MODEL_PREFIX_TO_LABEL.get(prefix, "")
+
+
+def _connector_for(row: Any) -> str:
+    conn = getattr(row, "connector", None)
+    if conn:
+        return str(conn)
+    return "openvault" if row.label == "openvault" else "litellm"
 
 
 def _refuse_unconfigured(row: Any, pick: str) -> None:
@@ -166,12 +206,13 @@ def _refuse_unconfigured(row: Any, pick: str) -> None:
         detail = str(healthz().get("detail") or "not live")
         raise LLMError(f"OpenVault connector refused: {detail} (no silent fallback)")
     raise LLMError(
-        f"provider '{pick}' is not configured ({row.source}); no silent fallback"
+        f"provider '{pick}' is not configured ({row.source or 'unarmed'}); no silent fallback"
     )
 
 
 def _assert_connector(row: Any) -> None:
-    if row.label == "openvault":
+    connector = _connector_for(row)
+    if connector == "openvault" or row.label == "openvault":
         from CortexOS.crew.openvault import require_live
 
         require_live()
@@ -180,12 +221,32 @@ def _assert_connector(row: Any) -> None:
     from CortexOS.crew.connectors import require as require_connector
 
     slug = "openai" if row.label == "openai-compatible" else row.label
-    if slug in {"explicit", "ollama", "cursor"}:
+    if slug in {"explicit", "ollama"}:
         return
     try:
         require_connector(slug)
     except ConnectorError as exc:
         raise LLMError(str(exc)) from exc
+
+
+def _route_from_row(row: Any, model_s: str) -> Route:
+    connector = _connector_for(row)
+    chosen = model_s or row.model
+    if connector == "openvault" and not chosen.startswith("openvault/"):
+        if row.label == "cursor" and not model_s:
+            from CortexOS.crew.openvault import cursor_model
+
+            chosen = "openvault/" + cursor_model()
+        else:
+            chosen = "openvault/" + chosen.removeprefix("openvault/")
+    return Route(
+        label=row.label,
+        model=chosen,
+        api_base=None if connector == "openvault" else row.api_base,
+        source=row.source,
+        connector=connector,
+        armed_via=str(getattr(row, "armed_via", "") or ""),
+    )
 
 
 def resolve_route(*, provider: str | None = None, model: str | None = None) -> Route:
@@ -201,6 +262,17 @@ def resolve_route(*, provider: str | None = None, model: str | None = None) -> R
     model_s = _rewrite_grok_fast(model or "")
     chain = resolve_providers()
 
+    if not pick and model_s:
+        inferred = _label_for_model(model_s)
+        if inferred:
+            pick = inferred
+        else:
+            explicit = next((p for p in chain if p.label == "explicit" and p.configured), None)
+            if explicit is not None and model_s == explicit.model:
+                pick = "explicit"
+            else:
+                raise LLMError(f"unarmed model '{model_s}' (no silent fallback)")
+
     if pick:
         row = next((p for p in chain if p.label.lower() == pick), None)
         if row is None:
@@ -208,36 +280,7 @@ def resolve_route(*, provider: str | None = None, model: str | None = None) -> R
             raise LLMError(f"unknown provider '{provider}' (known: {known}); no silent fallback")
         _refuse_unconfigured(row, pick)
         _assert_connector(row)
-        chosen = model_s or row.model
-        if row.label == "openvault" and not chosen.startswith("openvault/"):
-            chosen = "openvault/" + chosen.removeprefix("openvault/")
-        return Route(
-            label=row.label,
-            model=chosen,
-            api_base=row.api_base,
-            source=row.source,
-            connector=_connector_for(row.label),
-        )
-
-    if model_s:
-        if model_s.startswith("openvault/"):
-            from CortexOS.crew.openvault import require_live
-
-            require_live()
-            return Route(
-                label="openvault",
-                model=model_s,
-                api_base=None,
-                source="turn-override",
-                connector="openvault",
-            )
-        return Route(
-            label="turn-override",
-            model=model_s,
-            api_base=None,
-            source="turn-override",
-            connector="litellm",
-        )
+        return _route_from_row(row, model_s)
 
     active = active_provider(chain)
     if active is None:
@@ -246,13 +289,18 @@ def resolve_route(*, provider: str | None = None, model: str | None = None) -> R
             " start OpenVault on :5000, or run Ollama); no silent fallback"
         )
     _assert_connector(active)
-    return Route(
-        label=active.label,
-        model=active.model,
-        api_base=active.api_base,
-        source=active.source,
-        connector=_connector_for(active.label),
-    )
+    return _route_from_row(active, "")
+
+
+def chosen_public(
+    *, provider: str | None = None, model: str | None = None
+) -> dict[str, object]:
+    """HUD/API snapshot of the host this turn would use. Null chosen if unarmed."""
+    try:
+        route = resolve_route(provider=provider, model=model)
+        return {"chosen": route.as_public(), "refused": None}
+    except LLMError as exc:
+        return {"chosen": None, "refused": str(exc)}
 
 
 _configured = False

--- a/CortexOS/crew/openvault.py
+++ b/CortexOS/crew/openvault.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 
 import json
 import os
+import time
 from pathlib import Path
 from typing import Any
 
@@ -157,6 +158,183 @@ _ENV_TO_PROVIDER: dict[str, str] = {
     "MISTRAL_API_KEY": "mistral",
 }
 
+_ENV_TO_LABEL: dict[str, str] = {
+    "ANTHROPIC_API_KEY": "anthropic",
+    "OPENROUTER_API_KEY": "openrouter",
+    "DEEPSEEK_API_KEY": "deepseek",
+    "OPENAI_API_KEY": "openai-compatible",
+    "CURSOR_API_KEY": "cursor",
+    "XAI_API_KEY": "xai",
+    "GROQ_API_KEY": "groq",
+    "GOOGLE_API_KEY": "google",
+    "CEREBRAS_API_KEY": "cerebras",
+    "MISTRAL_API_KEY": "mistral",
+}
+
+_PROVIDER_TO_LABEL: dict[str, str] = {
+    "anthropic": "anthropic",
+    "openrouter": "openrouter",
+    "openai": "openai-compatible",
+    "deepseek": "deepseek",
+    "groq": "groq",
+    "google": "google",
+    "gemini": "google",
+    "cerebras": "cerebras",
+    "mistral": "mistral",
+    "xai": "xai",
+    "cursor": "cursor",
+}
+
+_VAULT_CACHE: tuple[float, tuple[dict[str, Any], ...]] = (0.0, ())
+
+
+def reset_vault_cache() -> None:
+    """Test hook. Arm/upsert also busts this so a new key is visible."""
+    global _VAULT_CACHE
+    _VAULT_CACHE = (0.0, ())
+
+
+def _crew_label(raw: dict[str, Any]) -> str:
+    env_key = str(raw.get("env_key") or "").strip()
+    if env_key in _ENV_TO_LABEL:
+        return _ENV_TO_LABEL[env_key]
+    label = str(raw.get("label") or "").strip()
+    if label in _ENV_TO_LABEL:
+        return _ENV_TO_LABEL[label]
+    provider = str(raw.get("provider") or "").strip().lower()
+    return _PROVIDER_TO_LABEL.get(provider, "")
+
+
+def _public_vault_row(raw: Any) -> dict[str, Any] | None:
+    """Strip secrets. Unknown shapes are dropped, not invented."""
+    if not isinstance(raw, dict):
+        return None
+    kid = str(raw.get("id") or "").strip()
+    if not kid:
+        return None
+    enabled = raw.get("enabled") is not False
+    return {
+        "id": kid,
+        "label": str(raw.get("label") or "").strip(),
+        "provider": str(raw.get("provider") or "").strip(),
+        "env_key": str(raw.get("env_key") or "").strip(),
+        "enabled": enabled,
+        "crew_label": _crew_label(raw),
+    }
+
+
+def list_vault_keys(
+    *, timeout: float = 1.5, ttl: float = 5.0, fresh: bool = False
+) -> list[dict[str, Any]]:
+    """Public vault rows. Never includes secret values. Empty if unarmed/down."""
+    if os.environ.get("CREW_OPENVAULT", "1") == "0":
+        return []
+    global _VAULT_CACHE
+    now = time.monotonic()
+    if not fresh and _VAULT_CACHE[0] > 0 and now - _VAULT_CACHE[0] < ttl:
+        return [dict(row) for row in _VAULT_CACHE[1]]
+    try:
+        with httpx.Client(timeout=timeout) as client:
+            resp = client.get(f"{base_url()}/api/keys")
+        if resp.status_code != 200:
+            _VAULT_CACHE = (now, ())
+            return []
+        try:
+            data = resp.json()
+        except Exception:  # noqa: BLE001 - vault body is untrusted
+            data = {}
+        if not isinstance(data, dict):
+            data = {}
+    except httpx.HTTPError:
+        _VAULT_CACHE = (now, ())
+        return []
+    raw_keys = data.get("keys") if isinstance(data, dict) else None
+    if not isinstance(raw_keys, list):
+        raw_keys = []
+    out: list[dict[str, Any]] = []
+    for raw in raw_keys:
+        pub = _public_vault_row(raw)
+        if pub is not None:
+            out.append(pub)
+    _VAULT_CACHE = (now, tuple(out))
+    return [dict(row) for row in out]
+
+
+def vault_sources() -> dict[str, dict[str, Any]]:
+    """crew_label -> public vault row. Enabled wins when duplicates exist."""
+    out: dict[str, dict[str, Any]] = {}
+    for row in list_vault_keys():
+        label = str(row.get("crew_label") or "")
+        if not label:
+            continue
+        prev = out.get(label)
+        if prev is None or (row.get("enabled") and not prev.get("enabled")):
+            out[label] = row
+    return out
+
+
+def vault_armed_labels() -> set[str]:
+    return {label for label, row in vault_sources().items() if row.get("enabled")}
+
+
+def arm_source(label: str, armed: bool, *, slug: str | None = None) -> dict[str, Any]:
+    """Enable/disable matching OpenVault keys. Fail-closed; no silent fallback."""
+    if os.environ.get("CREW_OPENVAULT", "1") == "0":
+        return {"ok": False, "detail": "CREW_OPENVAULT=0 (no silent fallback)", "armed": False}
+    needle = (label or "").strip().lower()
+    if needle in {"openai", "openai-compatible"}:
+        needle = "openai-compatible"
+    if needle in {"ov", "vault"}:
+        needle = "openvault"
+    if needle == "openvault":
+        return {
+            "ok": False,
+            "detail": "OpenVault is the vault host, not an API key row (no silent fallback)",
+            "armed": False,
+        }
+    rows = [r for r in list_vault_keys(fresh=True) if r.get("crew_label") == needle]
+    if not rows:
+        return {
+            "ok": False,
+            "detail": f"connector {slug or needle} has no OpenVault key (no silent fallback)",
+            "armed": False,
+        }
+    patched: list[str] = []
+    errors: list[str] = []
+    try:
+        with httpx.Client(timeout=8.0) as client:
+            for row in rows:
+                resp = client.patch(
+                    f"{base_url()}/api/keys/{row['id']}",
+                    json={"enabled": bool(armed)},
+                )
+                if resp.status_code >= 400:
+                    errors.append(f"{row['id']}: HTTP {resp.status_code}")
+                else:
+                    patched.append(str(row["id"]))
+    except httpx.HTTPError as exc:
+        return {
+            "ok": False,
+            "detail": f"{type(exc).__name__} (no silent fallback)",
+            "armed": False,
+        }
+    reset_vault_cache()
+    if errors and not patched:
+        return {
+            "ok": False,
+            "detail": "; ".join(errors) + " (no silent fallback)",
+            "armed": False,
+        }
+    return {
+        "ok": not errors,
+        "armed": bool(armed),
+        "slug": slug or needle,
+        "label": needle,
+        "ids": patched,
+        "detail": "armed" if armed else "disarmed",
+        "errors": errors,
+    }
+
 
 def upsert_env_key(env_key: str, secret: str) -> dict[str, Any]:
     """Store one secret in OpenVault forever. Never logs the secret."""
@@ -182,8 +360,11 @@ def upsert_env_key(env_key: str, secret: str) -> dict[str, Any]:
         data = resp.json()
         first = (data.get("results") or [{}])[0]
         key = first.get("key") or {}
+        ok = bool(data.get("ok") and first.get("ok"))
+        if ok:
+            reset_vault_cache()
         return {
-            "ok": bool(data.get("ok") and first.get("ok")),
+            "ok": ok,
             "label": env_key,
             "id": key.get("id"),
             "provider": key.get("provider") or provider,

--- a/CortexOS/crew/runtime.py
+++ b/CortexOS/crew/runtime.py
@@ -1127,7 +1127,8 @@ class CrewRuntime:
         brief: str | None = None,
     ) -> None:
         space = self.store.get_space(ctx.space_id) or {}
-        model, api_base, label = self._provider(ctx, space, row)
+        route = self._provider(ctx, space, row)
+        model, api_base, label = route.model, route.api_base, route.label
         self._set_status(row["id"], life.STATUS_ACTIVE)
         last_user = ""
         for m in reversed(self.store.list_messages(ctx.space_id, limit=10_000)):
@@ -1263,6 +1264,9 @@ class CrewRuntime:
                     "model": upstream,
                     "route": model,
                     "provider": label,
+                    "source": route.source,
+                    "connector": route.connector,
+                    "armed_via": route.armed_via,
                     "run_id": ctx.id,
                     "cost_usd": ctx.stats.get("cost_usd"),
                     "prompt_tokens": ctx.stats.get("prompt_tokens"),
@@ -2078,25 +2082,20 @@ class CrewRuntime:
         ctx: RunContext,
         space: dict[str, Any],
         row: dict[str, Any] | None = None,
-    ) -> tuple[str, str | None, str]:
+    ) -> llm_mod.Route:
         agent_model = str((row or {}).get("model") or "").strip()
         if agent_model:
             if "grok" in agent_model.lower() and "fast" in agent_model.lower():
                 agent_model = "openai/grok-4.6"
-            return agent_model, None, "agent-override"
+            return llm_mod.resolve_route(model=agent_model)
         turn_p = (ctx.turn_provider or "").strip()
         turn_m = (ctx.turn_model or "").strip()
         if turn_p or turn_m:
-            route = llm_mod.resolve_route(provider=turn_p or None, model=turn_m or None)
-            return route.model, route.api_base, route.label
+            return llm_mod.resolve_route(provider=turn_p or None, model=turn_m or None)
         override = (space.get("model") or "").strip()
         if override:
-            if override.startswith("openvault/"):
-                route = llm_mod.resolve_route(provider="openvault", model=override)
-                return route.model, route.api_base, route.label
-            return override, None, "space-override"
-        route = llm_mod.resolve_route()
-        return route.model, route.api_base, route.label
+            return llm_mod.resolve_route(model=override)
+        return llm_mod.resolve_route()
 
     def _handle(self, row: dict[str, Any]) -> AgentHandle:
         handle = self._handles.get(row["id"])

--- a/CortexOS/crew/server.py
+++ b/CortexOS/crew/server.py
@@ -308,11 +308,14 @@ def build_router(crew: CrewApp) -> APIRouter:
         chain = resolve_providers()
         active = next((p for p in chain if p.active), None)
         mcp = crew.mcp.status()
-        from CortexOS.crew.llm import usage_view
+        from CortexOS.crew.llm import chosen_public, usage_view
 
+        choice = chosen_public()
         return {
             "ok": True,
             "provider": active.public() if active else None,
+            "chosen": choice["chosen"],
+            "refused": choice["refused"],
             "engine": await crew.bridge.health(),
             "openvault": healthz(),
             "computer_control": crew.settings.master_computer_control,
@@ -325,33 +328,34 @@ def build_router(crew: CrewApp) -> APIRouter:
 
     @router.get("/providers")
     async def providers() -> dict[str, Any]:
+        from CortexOS.crew.llm import chosen_public
+
         chain = resolve_providers()
         active = next((p for p in chain if p.active), None)
+        choice = chosen_public()
         return {
             "active": active.public() if active else None,
             "chain": [p.public() for p in chain],
+            "chosen": choice["chosen"],
+            "refused": choice["refused"],
         }
 
     @router.post("/providers")
     async def pin_provider(body: ProviderPin) -> dict[str, Any]:
         from CortexOS.crew.keys import pin_provider as save_pin
-        from CortexOS.crew.llm import LLMError as RouteError
-        from CortexOS.crew.llm import resolve_route
+        from CortexOS.crew.llm import chosen_public
 
         save_pin(crew.settings.data_dir, body.provider, body.model)
         chain = resolve_providers()
         active = next((p for p in chain if p.active), None)
-        refused: str | None = None
-        if (body.provider or "").strip() or (body.model or "").strip():
-            try:
-                resolve_route(provider=body.provider, model=body.model)
-            except RouteError as exc:
-                refused = str(exc)
+        choice = chosen_public(provider=body.provider, model=body.model)
         return {
-            "ok": refused is None,
+            "ok": choice["refused"] is None
+            or not ((body.provider or "").strip() or (body.model or "").strip()),
             "active": active.public() if active else None,
             "chain": [p.public() for p in chain],
-            "refused": refused,
+            "chosen": choice["chosen"],
+            "refused": choice["refused"],
         }
 
     @router.get("/usage")
@@ -677,6 +681,24 @@ def build_router(crew: CrewApp) -> APIRouter:
             uacc_armed=bool(uacc.get("armed")),
         )
 
+    @router.post("/connectors/{slug}/arm")
+    async def arm_connector(slug: str, body: ArmIn) -> dict[str, Any]:
+        from CortexOS.crew import connectors as connectors_mod
+
+        try:
+            result = connectors_mod.arm(slug, body.armed)
+        except connectors_mod.ConnectorError as exc:
+            raise HTTPException(409, str(exc)) from exc
+        mcp = crew.mcp.status()
+        uacc = next((row for row in mcp if row.get("name") == "uacc"), {})
+        return {
+            **result,
+            "catalog": connectors_mod.catalog(
+                uacc_enabled=bool(uacc.get("enabled")),
+                uacc_armed=bool(uacc.get("armed")),
+            ),
+        }
+
     @router.get("/routines")
     async def list_routines() -> list[dict[str, Any]]:
         from CortexOS.crew.routines import catalog as routine_catalog
@@ -912,14 +934,19 @@ def build_router(crew: CrewApp) -> APIRouter:
 
     @router.post("/keys")
     async def post_keys(body: KeysIn) -> dict[str, Any]:
+        from CortexOS.crew.llm import chosen_public
+
         saved = save_keys(crew.settings.data_dir, body.keys)
         chain = resolve_providers()
         active = next((p for p in chain if p.active), None)
+        choice = chosen_public()
         return {
             "ok": True,
             "status": saved["fields"],
             "active": active.public() if active else None,
             "chain": [p.public() for p in chain],
+            "chosen": choice["chosen"],
+            "refused": choice["refused"],
         }
 
     @router.get("/mcp")

--- a/CortexOS/crew/ui/index.html
+++ b/CortexOS/crew/ui/index.html
@@ -226,7 +226,7 @@
   <div class="scrim" id="settings">
     <div class="dialog">
       <h2>Providers</h2>
-      <p class="hint">Paste a live key. Crew writes it to OpenVault forever and uses FreeRoute for every turn. Values are never shown back.</p>
+      <p class="hint">Paste a live key. Crew writes it to OpenVault forever and does not keep a crew copy. FreeRoute is preferred when the vault is live. Values are never shown back. Unarmed sources refuse; no silent fallback.</p>
       <form id="keysForm"></form>
       <div class="chain" id="providerChain"></div>
       <div class="ladder">
@@ -453,7 +453,10 @@
       const meta = m.meta || {};
       const env = meta.envelope || {};
       if (env.badge) return `<span class="badge">${esc(env.badge)}${env.audit_id ? " " + esc(env.audit_id) : ""}</span>`;
-      if (meta.model) return `<span class="badge">${esc(meta.provider || "")} ${esc(meta.model)}</span>`;
+      if (meta.model) {
+        const via = meta.connector ? (" via " + meta.connector) : "";
+        return `<span class="badge">${esc(meta.provider || "")} ${esc(meta.model)}${esc(via)}</span>`;
+      }
       return "";
     }
     function msgNode(m) {
@@ -635,23 +638,30 @@
       if (!chip) return;
       chip.textContent = "usage " + calls + " calls / " + tokens + " tok / $" + Number(cost).toFixed(4);
     }
-    function setProvider(active, chain) {
-      $("providerChip").textContent = active ? (active.label + " / " + active.model) : "no provider configured";
+    function setProvider(active, chain, chosen) {
+      const shown = chosen || active;
+      if (!shown) {
+        $("providerChip").textContent = "no provider configured (unarmed)";
+      } else {
+        const via = shown.connector ? (" via " + shown.connector) : "";
+        $("providerChip").textContent = shown.label + " / " + shown.model + via;
+      }
       const pick = $("routePick");
       const rows = chain || [];
       if (pick) {
         const current = state.routeProvider || (active && active.label) || "";
         pick.innerHTML = `<option value="">default</option>` + rows.map((p) =>
-          `<option value="${esc(p.label)}" ${p.label === current ? "selected" : ""} ${p.configured ? "" : "disabled"}>${esc(p.label)}${p.configured ? "" : " (unset)"}</option>`
+          `<option value="${esc(p.label)}" ${p.label === current ? "selected" : ""} ${p.configured ? "" : "disabled"}>${esc(p.label)}${p.configured ? "" : " (unarmed)"}</option>`
         ).join("");
         if (current) pick.value = current;
         pick.onchange = () => { state.routeProvider = pick.value || ""; };
       }
       if (chain) {
-        $("providerChain").innerHTML = chain.map((p) =>
-          `<button type="button" class="chain-pick${p.active ? " on" : ""}" data-label="${esc(p.label)}" ${p.configured ? "" : "disabled"}>`
-          + `${esc(p.label)} ${p.configured ? "ready" : "unset"} - ${esc(p.model)}</button>`
-        ).join("");
+        $("providerChain").innerHTML = chain.map((p) => {
+          const via = p.armed_via === "openvault" || p.armed_via === "both" ? "vault-armed" : (p.configured ? "ready" : "unarmed");
+          return `<button type="button" class="chain-pick${p.active ? " on" : ""}" data-label="${esc(p.label)}" ${p.configured ? "" : "disabled"}>`
+            + `${esc(p.label)} ${via} - ${esc(p.model)}</button>`;
+        }).join("");
         $("providerChain").querySelectorAll(".chain-pick").forEach((el) => {
           el.onclick = () => pinProvider(el.dataset.label);
         });
@@ -660,7 +670,7 @@
     async function pinProvider(label) {
       try {
         const saved = await api("/crew/providers", { method: "POST", body: JSON.stringify({ provider: label }) });
-        setProvider(saved.active, saved.chain);
+        setProvider(saved.active, saved.chain, saved.chosen);
         state.routeProvider = label;
         if (saved.refused) toast(saved.refused, "bad");
         else toast("Route pinned: " + label + ". No silent fallback.");
@@ -851,11 +861,36 @@
     function renderPlugins() {
       const q = ($("pluginSearch").value || "").toLowerCase();
       const rows = state.plugins.filter((p) => !q || (p.name + p.slug + p.layer).toLowerCase().indexOf(q) >= 0);
-      $("pluginList").innerHTML = rows.map((p) =>
-        `<div class="plugin-row"><div class="plugin-mark">${esc((p.name || "?")[0])}</div>
-         <div style="flex:1;min-width:0">${esc(p.name)}<small style="display:block;color:#8b91a3">${esc(p.slug)} - ${esc(p.layer)}</small></div>
-         <div class="${p.connected ? "on" : "empty"}">${p.connected ? "connected" : esc(p.detail || "mapped")}</div></div>`
-      ).join("");
+      $("pluginList").innerHTML = rows.map((p) => {
+        const status = p.armable
+          ? `<label class="empty"><input type="checkbox" data-arm-slug="${esc(p.slug)}" ${p.armed ? "checked" : ""} /> arm</label>`
+          : `<div class="${p.connected ? "on" : "empty"}">${p.connected ? "connected" : esc(p.detail || "mapped")}</div>`;
+        const via = p.armed_via ? `<small style="display:block;color:#8b91a3">${esc(p.armed_via)}${p.detail ? " - " + esc(p.detail) : ""}</small>` : `<small style="display:block;color:#8b91a3">${esc(p.slug)} - ${esc(p.layer)}</small>`;
+        return `<div class="plugin-row"><div class="plugin-mark">${esc((p.name || "?")[0])}</div>
+         <div style="flex:1;min-width:0">${esc(p.name)}${via}</div>
+         ${status}</div>`;
+      }).join("");
+      $("pluginList").querySelectorAll("[data-arm-slug]").forEach((el) => {
+        el.onchange = () => armConnector(el.dataset.armSlug, el.checked, el);
+      });
+    }
+    async function armConnector(slug, armed, el) {
+      try {
+        const out = await api("/crew/connectors/" + encodeURIComponent(slug) + "/arm", {
+          method: "POST",
+          body: JSON.stringify({ armed: !!armed })
+        });
+        if (out.catalog) {
+          state.plugins = out.catalog;
+          renderPlugins();
+        }
+        const prov = await api("/crew/providers");
+        setProvider(prov.active, prov.chain, prov.chosen);
+        toast(out.detail || (armed ? "Armed via OpenVault." : "Disarmed."), out.ok === false ? "bad" : "");
+      } catch (err) {
+        toast(err.message, "bad");
+        if (el) el.checked = !armed;
+      }
     }
     function ticketRow(key, seated, mine, extra) {
       const holder = mine && (mine.worker || mine.agent || "");
@@ -1074,7 +1109,7 @@
       renderSkills(state.skills);
       state.keyFields = keys.fields || [];
       renderKeyForm(state.keyFields, keys.status || {});
-      setProvider(prov.active, prov.chain);
+      setProvider(prov.active, prov.chain, prov.chosen);
       paintUsage((health && health.usage) || (desk && desk.usage));
       const ov = health.openvault || {};
       const eng = health.engine || {};
@@ -1601,7 +1636,7 @@
       });
       try {
         const saved = await api("/crew/keys", { method: "POST", body: JSON.stringify({ keys: body }) });
-        setProvider(saved.active, saved.chain);
+        setProvider(saved.active, saved.chain, saved.chosen);
         renderKeyForm(state.keyFields, saved.status);
         $("keysForm").querySelectorAll("input").forEach((el) => { el.value = ""; });
         $("settings").classList.remove("open");

--- a/STATUS.md
+++ b/STATUS.md
@@ -1,6 +1,14 @@
 # STATUS.md
 **Last updated:** 2026-09-06 | **Gate:** G2.3 OSR **SHIPPED** | **Active:** C7-02..06; EPIC-015 RAG served-path; GOLD-01 founder TTY; **RSF-06 distill harness**
 
+> **2026-09-06 (CREW-ROUTER-HARDEN):** Multi-API sources arm via OpenVault
+> (no crew-held secret on disk after a successful vault upsert). Vault-armed
+> hosts prefer FreeRoute when OV is live; unarmed pins refuse (no silent
+> fallback). `GET /crew/providers` and `/crew/health` surface `chosen`
+> label/model/connector. Parent #116. Local `pytest tests/test_crew -q`
+> 231 passed. Live `:8020` needs founder restart. Does not attach #4/#41-#44.
+> Does not write CLAIMS.json.
+>
 > **2026-09-06 (RSF-06 / Cortex#155):** Distill harness
 > `CortexOS.execution.distill_harness.run_distill` takes an options-class recipe
 > (myn8n / langchain / langflow / gencfsm_dag) and emits Netie-native learn traces.

--- a/docs/subagents_findings/2026-09-06_crew-router-harden.md
+++ b/docs/subagents_findings/2026-09-06_crew-router-harden.md
@@ -1,0 +1,8 @@
+# Crew router harden: OpenVault-armed FreeRoute sources
+
+- **Date:** 2026-09-06
+- **Keywords:** crew, router, openvault, freeroute, arm, multi-model, epic-116, grok-bot
+- **Main idea:** CREW-ROUTER (#131) was partial because API hosts were configured only from crew env/keys.json. Operator can now arm multiple inference APIs via OpenVault listing + enable/disable. Vault-armed hosts prefer FreeRoute when OV is live. Unarmed pin/turn refuses. `chosen` is stamped on providers/health/message meta. Secrets that vault successfully are not kept in keys.json.
+- **Verify:** `python -m pytest tests/test_crew -q` (231 passed locally on this branch)
+- **Does not prove:** live `:8020` until founder restart; OpenVault cost/latency bake-off (prefer is measured live via healthz + key listing, not a score). GitHub CI not run from this agent.
+- **Cite:** parent Cortex#116; closed CREW-ROUTER #131 / PR #141

--- a/docs/subagents_findings/INDEX.md
+++ b/docs/subagents_findings/INDEX.md
@@ -2,6 +2,7 @@
 
 | Date | Topic | Keywords | Main idea | Path |
 |------|-------|----------|-----------|------|
+| 2026-09-06 | crew-router-harden | crew, router, openvault, freeroute, arm, multi-model, epic-116 | Vault-armed APIs count as configured without crew secrets. FreeRoute preferred when OV live. Unarmed refuse. chosen stamped. | `2026-09-06_crew-router-harden.md` |
 | 2026-09-06 | rsf-06-distill-harness | rsf, rsf-06, distill, harness, myn8n, langchain, #155 | run_distill emits Netie-native learn traces. Paste as product_engine REFUSE. Scale-check miss is not invent-green COMPLETE. | `2026-09-06_rsf-06-distill-harness.md` |
 | 2026-09-06 | crew-memory-api | crew, memory, collection, facts.md, scope, epic-116 | Collection-scoped Crew memory (space|user|agent|run). HUD uses list/search/export API; files survive chat clear. | `2026-09-06_crew-memory-api.md` |
 | 2026-09-06 | crew-policy-standing | crew, policy, standing, allowlist, session, one-off, circuit-breaker, epic-116 | Settings ladder is Crew policy SoT. decide/decide_with_approvals enforce standing/session/one-off. Repeated deny trips circuit. Per-agent grants only tighten. | `2026-09-06_crew-policy-standing.md` |

--- a/tests/test_crew/conftest.py
+++ b/tests/test_crew/conftest.py
@@ -49,8 +49,10 @@ def crew_env(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setenv("CREW_OPENVAULT", "0")
     monkeypatch.setenv("CREW_LIVE_PROBES", "0")
     from CortexOS.crew.llm import reset_usage
+    from CortexOS.crew.openvault import reset_vault_cache
 
     reset_usage()
+    reset_vault_cache()
 
 
 @pytest.fixture()

--- a/tests/test_crew/test_config_policy.py
+++ b/tests/test_crew/test_config_policy.py
@@ -150,3 +150,32 @@ def test_provider_pin_does_not_fall_through(clean_env: pytest.MonkeyPatch) -> No
     assert config.active_provider(chain) is None
     assert all(not p.active for p in chain)
 
+
+def test_vault_armed_without_env_is_configured(
+    clean_env: pytest.MonkeyPatch, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    from CortexOS.crew import openvault
+
+    clean_env.setenv("CREW_OPENVAULT", "1")
+    monkeypatch.setattr(
+        openvault, "healthz", lambda timeout=1.5: {"ok": True, "url": "http://127.0.0.1:5000"}
+    )
+    monkeypatch.setattr(
+        openvault,
+        "vault_sources",
+        lambda: {
+            "mistral": {
+                "id": "k-m",
+                "label": "MISTRAL_API_KEY",
+                "enabled": True,
+                "crew_label": "mistral",
+            }
+        },
+    )
+    chain = config.resolve_providers()
+    mistral = next(p for p in chain if p.label == "mistral")
+    assert mistral.configured is True
+    assert mistral.connector == "openvault"
+    assert mistral.armed_via == "openvault"
+    assert mistral.public()["armed"] is True
+

--- a/tests/test_crew/test_connectors_import.py
+++ b/tests/test_crew/test_connectors_import.py
@@ -15,6 +15,8 @@ def test_connector_catalog_names_netie_owners() -> None:
     assert uacc["connected"] is True
     cursor = next(r for r in rows if r["slug"] == "cursor")
     assert cursor["connected"] is True
+    groq = next(r for r in rows if r["slug"] == "groq")
+    assert groq["armable"] is True
 
 
 def test_parse_markdown_and_rakazo_thread() -> None:

--- a/tests/test_crew/test_openvault.py
+++ b/tests/test_crew/test_openvault.py
@@ -194,3 +194,113 @@ def test_require_live_refuses_when_disabled(monkeypatch) -> None:
     monkeypatch.setenv("CREW_OPENVAULT", "0")
     with pytest.raises(openvault.LLMError, match="no silent fallback"):
         openvault.require_live()
+
+
+def test_list_vault_keys_strips_secrets_and_maps_labels(monkeypatch) -> None:
+    monkeypatch.setenv("CREW_OPENVAULT", "1")
+    openvault.reset_vault_cache()
+
+    class Client:
+        def __init__(self, *a, **k):  # noqa: ANN002, ANN003
+            pass
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *a):  # noqa: ANN002
+            return False
+
+        def get(self, url: str) -> _FakeResp:
+            assert url.endswith("/api/keys")
+            return _FakeResp(
+                200,
+                {
+                    "keys": [
+                        {
+                            "id": "k-groq",
+                            "label": "GROQ_API_KEY",
+                            "provider": "groq",
+                            "env_key": "GROQ_API_KEY",
+                            "enabled": True,
+                            "secret": "gsk-should-never-leak",
+                            "value": "gsk-should-never-leak",
+                        },
+                        {
+                            "id": "k-cursor",
+                            "label": "CURSOR_API_KEY",
+                            "provider": "custom",
+                            "env_key": "CURSOR_API_KEY",
+                            "enabled": False,
+                        },
+                    ]
+                },
+            )
+
+    monkeypatch.setattr(openvault.httpx, "Client", Client)
+    rows = openvault.list_vault_keys(fresh=True)
+    assert {r["crew_label"] for r in rows} == {"groq", "cursor"}
+    groq = next(r for r in rows if r["crew_label"] == "groq")
+    assert groq["enabled"] is True
+    assert "secret" not in groq
+    assert "gsk-should-never-leak" not in str(rows)
+    sources = openvault.vault_sources()
+    assert sources["groq"]["enabled"] is True
+    assert sources["cursor"]["enabled"] is False
+    assert openvault.vault_armed_labels() == {"groq"}
+
+
+def test_arm_source_patches_enabled(monkeypatch) -> None:
+    monkeypatch.setenv("CREW_OPENVAULT", "1")
+    patched: list[dict] = []
+    listed = {
+        "keys": [
+            {
+                "id": "k-groq",
+                "label": "GROQ_API_KEY",
+                "provider": "groq",
+                "env_key": "GROQ_API_KEY",
+                "enabled": False,
+            }
+        ]
+    }
+
+    class Client:
+        def __init__(self, *a, **k):  # noqa: ANN002, ANN003
+            pass
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *a):  # noqa: ANN002
+            return False
+
+        def get(self, url: str) -> _FakeResp:
+            return _FakeResp(200, listed)
+
+        def patch(self, url: str, json: dict) -> _FakeResp:
+            patched.append({"url": url, **json})
+            return _FakeResp(200, {"id": "k-groq", "enabled": json["enabled"]})
+
+    monkeypatch.setattr(openvault.httpx, "Client", Client)
+    out = openvault.arm_source("groq", True, slug="groq")
+    assert out["ok"] is True
+    assert out["armed"] is True
+    assert patched[0]["enabled"] is True
+    assert "k-groq" in patched[0]["url"]
+
+
+def test_save_does_not_keep_secret_in_crew_when_vault_ok(tmp_path, monkeypatch) -> None:
+    from CortexOS.crew.keys import save
+
+    monkeypatch.setenv("CREW_OPENVAULT", "1")
+    monkeypatch.setattr(
+        openvault,
+        "upsert_env_key",
+        lambda key, secret: {"ok": True, "id": "k3", "label": key},
+    )
+    data_dir = tmp_path / "crew"
+    out = save(data_dir, {"GROQ_API_KEY": "gsk-crew-must-not-store"})
+    assert out["fields"]["GROQ_API_KEY"]["configured"] is True
+    stored = (data_dir / "keys.json").read_text(encoding="utf-8")
+    assert "gsk-crew-must-not-store" not in stored
+    assert "GROQ_API_KEY" not in stored

--- a/tests/test_crew/test_router.py
+++ b/tests/test_crew/test_router.py
@@ -30,6 +30,9 @@ def clean_env(monkeypatch: pytest.MonkeyPatch) -> pytest.MonkeyPatch:
     monkeypatch.setenv("CREW_ALLOW_OLLAMA", "0")
     monkeypatch.setenv("CREW_OPENVAULT", "0")
     monkeypatch.setenv("CREW_LIVE_PROBES", "0")
+    from CortexOS.crew.openvault import reset_vault_cache
+
+    reset_vault_cache()
     return monkeypatch
 
 
@@ -119,3 +122,130 @@ async def test_per_turn_miss_is_a_visible_refuse(rig) -> None:
     assert "no silent fallback" in result["error"]
     sysmsgs = [m for m in rig.store.list_messages(space["id"]) if m["role"] == "system"]
     assert sysmsgs and "anthropic" in sysmsgs[0]["content"]
+
+
+def _live_vault(monkeypatch: pytest.MonkeyPatch, rows: dict[str, dict]) -> None:
+    monkeypatch.setenv("CREW_OPENVAULT", "1")
+    monkeypatch.setattr(
+        openvault, "healthz", lambda timeout=1.5: {"ok": True, "url": "http://127.0.0.1:5000"}
+    )
+    monkeypatch.setattr(openvault, "require_live", lambda timeout=1.5: {"ok": True})
+    monkeypatch.setattr(openvault, "vault_sources", lambda: rows)
+
+
+def test_vault_armed_source_routes_via_freeroute_without_env_secret(
+    clean_env: pytest.MonkeyPatch, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _live_vault(
+        monkeypatch,
+        {
+            "groq": {
+                "id": "k-groq",
+                "label": "GROQ_API_KEY",
+                "provider": "groq",
+                "env_key": "GROQ_API_KEY",
+                "enabled": True,
+                "crew_label": "groq",
+            }
+        },
+    )
+    from CortexOS.crew.config import resolve_providers
+
+    groq = next(p for p in resolve_providers() if p.label == "groq")
+    assert groq.configured is True
+    assert groq.armed_via == "openvault"
+    assert groq.connector == "openvault"
+    assert groq.model.startswith("openvault/")
+    route = resolve_route(provider="groq")
+    assert route.label == "groq"
+    assert route.connector == "openvault"
+    assert route.model.startswith("openvault/")
+    assert route.as_public()["connector"] == "openvault"
+    snap = llm.chosen_public(provider="groq")
+    assert snap["refused"] is None
+    assert snap["chosen"]["label"] == "groq"
+
+
+def test_vault_disarmed_source_refuses_without_fallback(
+    clean_env: pytest.MonkeyPatch, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _live_vault(
+        monkeypatch,
+        {
+            "groq": {
+                "id": "k-groq",
+                "label": "GROQ_API_KEY",
+                "provider": "groq",
+                "env_key": "GROQ_API_KEY",
+                "enabled": False,
+                "crew_label": "groq",
+            }
+        },
+    )
+    with pytest.raises(LLMError, match="no silent fallback"):
+        resolve_route(provider="groq")
+    groq = next(r for r in connectors.catalog() if r["slug"] == "groq")
+    assert groq["connected"] is False
+    assert groq["armable"] is True
+    assert "vault-disarmed" in groq["detail"]
+
+
+def test_env_plus_vault_prefers_freeroute(
+    clean_env: pytest.MonkeyPatch, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    clean_env.setenv("GROQ_API_KEY", "x")
+    _live_vault(
+        monkeypatch,
+        {
+            "groq": {
+                "id": "k-groq",
+                "label": "GROQ_API_KEY",
+                "provider": "groq",
+                "env_key": "GROQ_API_KEY",
+                "enabled": True,
+                "crew_label": "groq",
+            }
+        },
+    )
+    route = resolve_route(provider="groq")
+    assert route.connector == "openvault"
+    assert route.armed_via == "both"
+    groq = next(r for r in connectors.catalog() if r["slug"] == "groq")
+    assert groq["armed"] is True
+    assert groq["armed_via"] == "both"
+
+
+def test_unarmed_model_string_refuses(clean_env: pytest.MonkeyPatch) -> None:
+    with pytest.raises(LLMError, match="no silent fallback"):
+        resolve_route(model="anthropic/claude-sonnet-5")
+    with pytest.raises(LLMError, match="unarmed model"):
+        resolve_route(model="not-a-host/mystery")
+
+
+def test_catalog_marks_vault_armed_api(
+    clean_env: pytest.MonkeyPatch, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _live_vault(
+        monkeypatch,
+        {
+            "openrouter": {
+                "id": "k-or",
+                "label": "OPENROUTER_API_KEY",
+                "provider": "openrouter",
+                "env_key": "OPENROUTER_API_KEY",
+                "enabled": True,
+                "crew_label": "openrouter",
+            }
+        },
+    )
+    row = next(r for r in connectors.catalog() if r["slug"] == "openrouter")
+    assert row["connected"] is True
+    assert row["armed"] is True
+    assert row["armable"] is True
+    assert row["armed_via"] == "openvault"
+    connectors.require("openrouter")
+
+
+def test_arm_grok_offloaded_refuses(clean_env: pytest.MonkeyPatch) -> None:
+    with pytest.raises(connectors.ConnectorError, match="OFFLOADED"):
+        connectors.arm("grok", True)

--- a/tests/test_crew/test_server.py
+++ b/tests/test_crew/test_server.py
@@ -28,6 +28,9 @@ def test_health_and_roles_and_spaces(client) -> None:
     health = client.http.get("/crew/health").json()
     assert health["ok"] is True
     assert health["provider"]["label"] == "explicit"
+    assert health["chosen"]["label"] == "explicit"
+    assert health["chosen"]["connector"]
+    assert health["refused"] is None
     assert health["computer_control"] is False
     assert health["grok_offloaded"] is True
     assert health["grok_autostart"] is False
@@ -184,6 +187,11 @@ def test_ui_index_is_served(client) -> None:
     assert desk["usage"]["llm_calls"] == 0
     assert "id=\"usageChip\"" in page.text
     assert "id=\"routePick\"" in page.text
+    assert "data-arm-slug" in page.text
+    assert "vault-armed" in page.text
+    assert "/crew/connectors/" in page.text
+    assert "unarmed" in page.text
+    assert "via " in page.text
     usage = client.http.get("/crew/usage").json()
     assert usage["llm_calls"] == 0
     assert "tokens" in usage
@@ -233,6 +241,25 @@ def test_pin_and_per_turn_refuse_without_fallback(client) -> None:
     assert msgs[-1]["role"] == "system"
     assert "anthropic" in msgs[-1]["content"]
     client.http.post("/crew/providers", json={"provider": ""})
+
+
+def test_arm_api_connector_fail_closed_when_vault_off(client) -> None:
+    resp = client.http.post("/crew/connectors/groq/arm", json={"armed": True})
+    assert resp.status_code == 409
+    assert "no silent fallback" in resp.json()["detail"]
+    grok = client.http.post("/crew/connectors/grok/arm", json={"armed": True})
+    assert grok.status_code == 409
+    assert "OFFLOADED" in grok.json()["detail"]
+    unknown = client.http.post("/crew/connectors/not-a-plug/arm", json={"armed": True})
+    assert unknown.status_code == 409
+
+
+def test_providers_surface_chosen_route(client) -> None:
+    body = client.http.get("/crew/providers").json()
+    assert body["chosen"]["label"] == "explicit"
+    assert body["chosen"]["model"] == "test/fake-model"
+    assert body["refused"] is None
+    assert body["chain"][0]["armed"] is True
 
 
 def test_computer_control_arm_is_refused(client) -> None:


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Parent: #116 (EPIC-CREW-01). Deepens closed CREW-ROUTER #131.

Netie-native only. No mybot/n8n/OpenWillow/guaca/rakazo paste. Control untouched. Does not attach #4 / #41 / #42 / #43 / #44. Does not bind or kill :8020. Does not write CLAIMS.json.

## Gap this closes

CREW-ROUTER could pin a host only when the secret lived in crew env/`keys.json`. OpenVault-vaulted keys were invisible, so multi-API arming was partial.

## What the operator gets

1. Arm multiple inference APIs via OpenVault (list + enable/disable). A successful vault upsert is not copied into `data/crew/keys.json`.
2. Vault-armed hosts prefer FreeRoute when OpenVault is live (healthz + key listing). Env-only hosts still use litellm when the vault is off.
3. Unarmed pin/turn/model refuses with a reason. No silent fallback. Grok Bot stays OFFLOADED.
4. Router surfaces the chosen host: `GET /crew/providers` and `GET /crew/health` include `chosen` (label/model/source/connector). HUD chip, composer select, and message badge show `via openvault` / `via litellm`. Plugins arm checkboxes call `POST /crew/connectors/{slug}/arm` (409 if the vault is down or the slug is unarmed).

## Verify

`python3 -m pytest tests/test_crew -q` -> 231 passed locally. `ruff check` on touched Python files clean.

Does not prove live `:8020` until founder restart. Does not claim GitHub Actions green from this agent.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-a0a1a396-07a5-4946-947a-809e31bad2d5?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a0a1a396-07a5-4946-947a-809e31bad2d5&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

