### PR TITLE
CREW-FACTS-MD: facts.md survives chat clear (parent #116 honesty gap)

### DIFF
--- a/CHANGELOG_DMS.md
+++ b/CHANGELOG_DMS.md
@@ -2,6 +2,16 @@
 
 Agents append one section per shipped feature. Sequential build log.
 
+## CREW-FACTS-MD Memory HUD + facts.md survives clear — 2026-09-06
+
+Follow-on under CLOSED Cortex #116. Memory panel paints `facts.md` + body
+from `/crew/spaces/{id}/memory` (list/search/save/export, scopes
+space|user|agent|run). Chat clear drops transcript only; `facts_survived`
+is on the clear envelope and facts reappear via `renderMemory`. Tests:
+`test_clear_does_not_wipe_facts`, `test_export_markdown`. Local
+`pytest tests/test_crew -q` **241 passed**. Not a CI claim. Control not
+touched.
+
 ## CREW-A2A-HARDEN ask cards + deadlock honesty — 2026-09-06
 
 Operator-visible bot-to-bot messaging on existing Switchboard (parent Cortex

--- a/CortexOS/crew/memory.py
+++ b/CortexOS/crew/memory.py
@@ -354,6 +354,37 @@ def memory_for(data_dir: Path, space_id: str) -> CrewMemory:
     return collection_for(data_dir, space_id, scope="space")
 
 
+def surviving_payloads(data_dir: Path, space_id: str) -> list[dict[str, object]]:
+    """Collections already on disk. Chat clear must not mkdir missing scopes."""
+    out: list[dict[str, object]] = []
+    space_root = data_dir / "spaces" / space_id / "memory"
+    if space_root.is_dir():
+        out.append(_payload_keeping_facts_md(space_root, scope="space", owner=""))
+    collections = data_dir / "spaces" / space_id / "collections"
+    if not collections.is_dir():
+        return out
+    for scope in ("user", "agent", "run"):
+        scope_dir = collections / scope
+        if not scope_dir.is_dir():
+            continue
+        for owner_dir in sorted(path for path in scope_dir.iterdir() if path.is_dir()):
+            out.append(
+                _payload_keeping_facts_md(
+                    owner_dir, scope=scope, owner=owner_dir.name
+                )
+            )
+    return out
+
+
+def _payload_keeping_facts_md(
+    root: Path, *, scope: str, owner: str
+) -> dict[str, object]:
+    mem = CrewMemory(root, scope=scope, owner=owner)
+    if mem.list_facts() or (mem.root / FACTS_FILE).is_file():
+        mem.export_markdown()
+    return mem.public_payload()
+
+
 def collection_for(
     data_dir: Path,
     space_id: str,

--- a/CortexOS/crew/runtime.py
+++ b/CortexOS/crew/runtime.py
@@ -930,13 +930,32 @@ class CrewRuntime:
         agents = self.store.reset_life_after_clear(space_id)
         for row in agents:
             self.bus.emit(space_id, "agent", {"agent": row})
+        collections = crew_memory.surviving_payloads(self.settings.data_dir, space_id)
+        space_mem = next(
+            (row for row in collections if row.get("scope") == "space"),
+            {
+                "facts": [],
+                "file": crew_memory.FACTS_FILE,
+                "filename": crew_memory.FACTS_FILE,
+                "scope": "space",
+                "owner": "",
+            },
+        )
         note = self.store.add_message(
             space_id,
             "system",
-            "Chat cleared. Goal/active mode persisted on teammates.",
+            "Chat cleared. Goal/active mode and facts.md stayed.",
         )
         self.bus.emit(space_id, "message", {"message": note})
-        return {"ok": True, "agents": agents, "cleared": True}
+        return {
+            "ok": True,
+            "agents": agents,
+            "cleared": True,
+            "transcript_cleared": True,
+            "facts_survived": True,
+            "memory": space_mem,
+            "collections": collections,
+        }
 
     async def operator_spawn(self, space_id: str, args: dict[str, Any]) -> dict[str, Any]:
         """HUD spawn. Uses the live run when one exists; otherwise persists idle/goal."""

--- a/CortexOS/crew/ui/index.html
+++ b/CortexOS/crew/ui/index.html
@@ -40,7 +40,7 @@
           <button class="ghost" id="uiBigger" type="button" title="Bigger text">A+</button>
           <button class="ghost" id="toggleActivity" title="Show only agent-to-agent traffic">Activity</button>
           <button class="ghost danger" id="cancelRun" hidden title="Stops this run. Does not kill Manager.">Cancel</button>
-          <button class="ghost" id="clearChat" type="button" title="Clears chat. Goal/active mode stays in crew store.">Clear chat</button>
+          <button class="ghost" id="clearChat" type="button" title="Clears chat. facts.md stays.">Clear chat</button>
         </div>
       </div>
       <div class="focus-bar" id="focusBar" hidden></div>
@@ -1062,9 +1062,11 @@
         const data = await api(path);
         const facts = data.facts || [];
         const label = data.scope || scope;
+        const file = data.file || data.filename || "facts.md";
+        const head = `<div class="hint" data-mem-file="${esc(file)}">${esc(file)} - ${esc(label)} - survives Clear chat</div>`;
         $("memory").innerHTML = facts.length
-          ? facts.map((f) => `<div class="row">${esc(f.name)} <span class="scope">${esc(label)}</span><div class="hint">${esc(f.description)}</div></div>`).join("")
-          : `<div class="empty empty--orb">No facts in this collection.</div>`;
+          ? head + facts.map((f) => `<div class="row">${esc(f.name)} <span class="scope">${esc(label)}</span><div class="hint">${esc(f.description)}</div><div class="hint">${esc(f.body || "")}</div></div>`).join("")
+          : head + `<div class="empty empty--orb">No facts in this collection.</div>`;
       } catch (err) {
         $("memory").innerHTML = `<div class="empty empty--orb">${esc(err.message)}</div>`;
       }
@@ -1541,9 +1543,12 @@
     $("clearChat").onclick = async () => {
       if (!state.spaceId) return;
       try {
-        await api("/crew/spaces/" + state.spaceId + "/clear", { method: "POST", body: "{}" });
+        const cleared = await api("/crew/spaces/" + state.spaceId + "/clear", { method: "POST", body: "{}" });
         await selectSpace(state.spaceId);
-        toast("Chat cleared. Goal mode and memory collections stayed.");
+        await renderMemory();
+        toast(cleared.facts_survived
+          ? "Chat cleared. facts.md stayed."
+          : "Chat cleared.");
       } catch (err) { toast(err.message, "bad"); }
     };
     $("toggleRail").onclick = () => {

--- a/STATUS.md
+++ b/STATUS.md
@@ -1,6 +1,16 @@
 # STATUS.md
-**Last updated:** 2026-09-06 | **Gate:** G2.3 OSR **SHIPPED** | **Active:** C7-02..06; EPIC-015 RAG served-path; GOLD-01 founder TTY; **RSF-07 eval corpus**
+**Last updated:** 2026-09-06 | **Gate:** G2.3 OSR **SHIPPED** | **Active:** C7-02..06; EPIC-015 RAG served-path; GOLD-01 founder TTY; **CREW-FACTS-MD HUD**
 
+> **2026-09-06 (CREW-FACTS-MD):** Closed the last #116 honesty gap on the
+> Memory panel (R-0001). Durable facts stay in `facts.md` (space) and
+> collection `facts.md` (user|agent|run). `POST .../clear` returns
+> `facts_survived` + surviving collections; transcript drops, files stay.
+> HUD list/save/search/export still use memory API scopes; `#memory` paints
+> `facts.md` + body and re-renders after Clear chat. Follow-on under CLOSED
+> epic #116. Control untouched. Freeze #4/#41-#44 not attached. Local
+> `pytest tests/test_crew -q` **241 passed**. Not a GitHub CI claim. Live
+> `:8020` needs founder restart. Did not write CLAIMS.json.
+>
 > **2026-09-06 (CREW-A2A-HARDEN):** Switchboard ask cards + deadlock honesty
 > under Cortex #116. `would_deadlock` walks wait cycles (not only A<->B).
 > `wait_for_replies` is DENIED when a teammate is already waiting on you.

--- a/tests/test_crew/test_commands.py
+++ b/tests/test_crew/test_commands.py
@@ -116,8 +116,10 @@ async def test_slash_remember_writes_facts_md_without_a_run(rig) -> None:
     assert "remembered 'crew-port'" in tool["content"]
     facts = rig.settings.data_dir / "spaces" / space["id"] / "memory" / "facts.md"
     assert "8020" in facts.read_text(encoding="utf-8")
-    rig.runtime.clear_chat(space["id"])
+    cleared = rig.runtime.clear_chat(space["id"])
+    assert cleared["facts_survived"] is True
     assert "8020" in facts.read_text(encoding="utf-8")
+    assert cleared["memory"]["facts"][0]["body"] == "8020"
 
 
 @pytest.mark.asyncio

--- a/tests/test_crew/test_memory.py
+++ b/tests/test_crew/test_memory.py
@@ -18,6 +18,7 @@ from CortexOS.crew.memory import (
     CrewMemoryError,
     collection_for,
     memory_for,
+    surviving_payloads,
 )
 from CortexOS.execution.untrusted_payload import BEGIN, END, is_wrapped
 
@@ -277,6 +278,52 @@ def test_collection_owner_and_scope_are_jailed(tmp_path: Path) -> None:
     written = {p for p in tmp_path.rglob("*.md")}
     roots = tmp_path / "crew" / "spaces" / "s1" / "collections" / "user" / "operator"
     assert written == {roots / "kept.md", roots / "INDEX.md", roots / "facts.md"}
+
+
+def test_export_markdown(tmp_path: Path) -> None:
+    """Operator export is rebuilt facts.md (space) or scope-owner.md (collections)."""
+    data = tmp_path / "crew"
+    space = collection_for(data, "s1", scope="space")
+    user = collection_for(data, "s1", scope="user")
+    space.remember("crew-port", "which port crew listens on", "8020")
+    user.remember("tz", "founder timezone", "MYT")
+
+    exported = space.export_markdown()
+    assert exported.startswith("# Crew facts")
+    assert "## crew-port" in exported
+    assert "8020" in exported
+    assert (space.root / "facts.md").read_text(encoding="utf-8") == exported
+    assert space.export_filename() == "facts.md"
+
+    user_md = user.export_markdown()
+    assert "scope: user" in user_md
+    assert "MYT" in user_md
+    assert user.export_filename() == "user-operator.md"
+    assert (user.root / "facts.md").is_file()
+
+
+def test_surviving_payloads_skip_missing_scopes_and_keep_facts_md(
+    tmp_path: Path,
+) -> None:
+    data = tmp_path / "crew"
+    sid = "s1"
+    assert surviving_payloads(data, sid) == []
+
+    space = collection_for(data, sid, scope="space")
+    user = collection_for(data, sid, scope="user")
+    space.remember("crew-port", "which port crew listens on", "8020")
+    user.remember("tz", "founder timezone", "MYT")
+
+    rows = surviving_payloads(data, sid)
+    by_scope = {row["scope"]: row for row in rows}
+    assert set(by_scope) == {"space", "user"}
+    assert by_scope["space"]["file"] == "facts.md"
+    assert by_scope["space"]["facts"][0]["body"] == "8020"
+    assert by_scope["user"]["facts"][0]["body"] == "MYT"
+    assert "agent" not in by_scope
+    assert "run" not in by_scope
+    assert (space.root / "facts.md").is_file()
+    assert (user.root / "facts.md").is_file()
 
 
 def test_the_module_opens_no_database() -> None:

--- a/tests/test_crew/test_server.py
+++ b/tests/test_crew/test_server.py
@@ -116,6 +116,11 @@ def test_ui_index_is_served(client) -> None:
     assert "memoryQuery" in page.text
     assert 'filter((m) => m.role === "user")' not in page.text
     assert "No facts in this collection." in page.text
+    assert "data-mem-file" in page.text
+    assert "facts_survived" in page.text
+    assert "cleared.facts_survived" in page.text
+    assert "(f.body" in page.text
+    assert "data.file" in page.text
     assert "Standing approvals" in page.text
     assert "one-off" in page.text
     assert "circuit-breaker" in page.text
@@ -761,6 +766,119 @@ def test_collection_memory_api_survives_clear_and_does_not_dual_write(client) ->
     assert 'filter((m) => m.role === "user")' not in page.text
     claims = list(client.crew.settings.data_dir.rglob("CLAIMS.json"))
     assert claims == []
+
+
+def _wait_space_idle(client, space_id: str, seconds: float = 5.0) -> None:
+    deadline = time.time() + seconds
+    while client.crew.runtime._space_run.get(space_id):
+        if time.time() > deadline:
+            break
+        time.sleep(0.02)
+
+
+def test_clear_does_not_wipe_facts(client) -> None:
+    """R-0001: Clear drops transcript only. facts.md stays on disk and in the clear envelope."""
+    space = client.http.post("/crew/spaces", json={"title": "Facts survive"}).json()
+    sid = space["id"]
+    saved = client.http.post(
+        f"/crew/spaces/{sid}/memory",
+        json={
+            "name": "crew-port",
+            "description": "which port crew listens on",
+            "body": "8020",
+        },
+    ).json()
+    assert saved["ok"] is True
+    assert saved["file"] == "facts.md"
+    user_saved = client.http.post(
+        f"/crew/spaces/{sid}/memory",
+        json={
+            "name": "tz",
+            "description": "founder timezone",
+            "body": "MYT",
+            "scope": "user",
+        },
+    ).json()
+    assert user_saved["ok"] is True
+
+    client.http.post(f"/crew/spaces/{sid}/messages", json={"text": "throw away"})
+    _wait_space_idle(client, sid)
+    cleared = client.http.post(f"/crew/spaces/{sid}/clear").json()
+    assert cleared["ok"] is True
+    assert cleared["transcript_cleared"] is True
+    assert cleared["facts_survived"] is True
+    assert cleared["memory"]["file"] == "facts.md"
+    assert cleared["memory"]["facts"][0]["name"] == "crew-port"
+    assert cleared["memory"]["facts"][0]["body"] == "8020"
+    user_row = next(row for row in cleared["collections"] if row["scope"] == "user")
+    assert user_row["facts"][0]["body"] == "MYT"
+
+    msgs = client.http.get(f"/crew/spaces/{sid}/messages").json()
+    assert not any(m["role"] == "user" for m in msgs)
+    assert any("facts.md stayed" in (m.get("content") or "") for m in msgs)
+
+    listed = client.http.get(f"/crew/spaces/{sid}/memory").json()
+    assert listed["facts"][0]["body"] == "8020"
+    user_listed = client.http.get(
+        f"/crew/spaces/{sid}/memory", params={"scope": "user"}
+    ).json()
+    assert user_listed["facts"][0]["body"] == "MYT"
+
+    facts_path = (
+        client.crew.settings.data_dir / "spaces" / sid / "memory" / "facts.md"
+    )
+    assert facts_path.is_file()
+    assert "8020" in facts_path.read_text(encoding="utf-8")
+    user_facts = (
+        client.crew.settings.data_dir
+        / "spaces"
+        / sid
+        / "collections"
+        / "user"
+        / "operator"
+        / "facts.md"
+    )
+    assert "MYT" in user_facts.read_text(encoding="utf-8")
+    assert list(client.crew.settings.data_dir.rglob("CLAIMS.json")) == []
+
+
+def test_export_markdown(client) -> None:
+    """GET /memory/export is the operator facts.md download after list/save/search."""
+    space = client.http.post("/crew/spaces", json={"title": "Export md"}).json()
+    sid = space["id"]
+    client.http.post(
+        f"/crew/spaces/{sid}/memory",
+        json={
+            "name": "crew-port",
+            "description": "which port crew listens on",
+            "body": "8020",
+        },
+    )
+    searched = client.http.get(
+        f"/crew/spaces/{sid}/memory/search", params={"q": "port"}
+    ).json()
+    assert searched["facts"][0]["name"] == "crew-port"
+    exported = client.http.get(f"/crew/spaces/{sid}/memory/export").json()
+    assert exported["filename"] == "facts.md"
+    assert exported["scope"] == "space"
+    assert exported["markdown"].startswith("# Crew facts")
+    assert "## crew-port" in exported["markdown"]
+    assert "8020" in exported["markdown"]
+
+    client.http.post(f"/crew/spaces/{sid}/messages", json={"text": "throw away"})
+    _wait_space_idle(client, sid)
+    client.http.post(f"/crew/spaces/{sid}/clear")
+    after = client.http.get(f"/crew/spaces/{sid}/memory/export").json()
+    assert after["filename"] == "facts.md"
+    assert "8020" in after["markdown"]
+
+    page = client.http.get("/")
+    assert 'id="memory"' in page.text
+    assert 'id="memExport"' in page.text
+    assert "data-mem-file" in page.text
+    assert "facts_survived" in page.text
+    assert "/memory/export" in page.text
+    assert "(f.body" in page.text
 
 
 def test_threads_hud_paints_pending_and_dead_on_switchboard(client) -> None:


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Follow-on under **#116 (CLOSED epic honesty gap)**. CREW-MEMORY-API (#185) landed collection scopes + list/search/export; this slice paints durable `facts.md` on the Memory panel (R-0001) and proves Clear chat drops transcript only.

## What landed

- `surviving_payloads` lists on-disk space|user|agent|run collections without mkdir of missing scopes. Clear rebuilds existing `facts.md` so the export file is still there.
- `POST /crew/spaces/{id}/clear` returns `facts_survived`, `transcript_cleared`, `memory`, and `collections`. System note: facts.md stayed.
- Memory HUD paints `data.file` (`facts.md`) + body via list/search API. Save / Search / Export unchanged. Clear re-renders Memory after `selectSpace`.
- Tests: `test_clear_does_not_wipe_facts`, `test_export_markdown` (unit + HTTP). HUD source asserts `data-mem-file`, `f.body`, `facts_survived`.

## Acceptance

1. Durable facts live in `facts.md` (space) / collection `facts.md` and survive chat clear.
2. Memory HUD list / save / search / export markdown uses `scope=space|user|agent|run`.
3. Chat clear drops transcript only; facts reappear on the Memory panel (`renderMemory` after clear).
4. Local `pytest tests/test_crew -q`: **241 passed**. First CI pass on `63d4fc6b` was SUCCESS (lint-type-test, base-install, protected-paths, rls-proof, secrets-scan). Empty commit retriggers auto-merge now that the PR is not draft.

## Out of scope

Control not touched. Freeze lanes #4/#41/#42/#43/#44 not attached. Does not start/kill `:8020`. No CLAIMS.json. No mybot/n8n/OpenWillow/guaca/rakazo paste.

Parent: #116 (CLOSED). Does not mint a second epic.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6dd582d2-2de3-4e79-8bc9-aaa6417fab9b?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6dd582d2-2de3-4e79-8bc9-aaa6417fab9b&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

