### PR TITLE
CREW-LIFE-HARDEN: honest wait/idle/stop chips

### DIFF
--- a/CHANGELOG_DMS.md
+++ b/CHANGELOG_DMS.md
@@ -2,6 +2,18 @@
 
 Agents append one section per shipped feature. Sequential build log.
 
+## CREW-LIFE-HARDEN spawn/wait/stop/idle honesty — 2026-09-06
+
+Life verbs were already on main (spawn/kill/stop, slash wait/idle/goal, goal
+survives clear). This slice closes honesty gaps only: parked `waiting` is not
+a live/thinking chip and is not "still working" for `wait_for_replies`;
+`/idle` forces status idle without dropping mode/goal text; HTTP
+`POST .../wait` and `.../idle`; stop parks the HUD immediately then cancels
+work; mode toggle no longer wipes `goal_text`. Stop/idle/wait still DENY
+Manager and do not touch `:8020`. Rebased onto `afbd4ae1` so facts.md
+clear survival from #192 stays. Parent #116. Control untouched. Local
+`pytest tests/test_crew -q`. Not a CI claim.
+
 ## CREW-FACTS-MD Memory HUD + facts.md survives clear — 2026-09-06
 
 Follow-on under CLOSED Cortex #116. Memory panel paints `facts.md` + body

--- a/CHANGELOG_DMS.md
+++ b/CHANGELOG_DMS.md
@@ -12,7 +12,7 @@ a live/thinking chip and is not "still working" for `wait_for_replies`;
 work; mode toggle no longer wipes `goal_text`. Stop/idle/wait still DENY
 Manager and do not touch `:8020`. Rebased onto `afbd4ae1` so facts.md
 clear survival from #192 stays. Parent #116. Control untouched. Local
-`pytest tests/test_crew -q`: **241 passed**. Not a CI claim.
+`pytest tests/test_crew -q`: **245 passed**. Not a CI claim.
 
 ## CREW-FACTS-MD Memory HUD + facts.md survives clear — 2026-09-06
 

--- a/CHANGELOG_DMS.md
+++ b/CHANGELOG_DMS.md
@@ -12,7 +12,7 @@ a live/thinking chip and is not "still working" for `wait_for_replies`;
 work; mode toggle no longer wipes `goal_text`. Stop/idle/wait still DENY
 Manager and do not touch `:8020`. Rebased onto `afbd4ae1` so facts.md
 clear survival from #192 stays. Parent #116. Control untouched. Local
-`pytest tests/test_crew -q`. Not a CI claim.
+`pytest tests/test_crew -q`: **241 passed**. Not a CI claim.
 
 ## CREW-FACTS-MD Memory HUD + facts.md survives clear — 2026-09-06
 

--- a/CortexOS/crew/commands.py
+++ b/CortexOS/crew/commands.py
@@ -112,7 +112,7 @@ _LIFE: tuple[dict[str, Any], ...] = (
         "kind": "life",
         "action": "idle",
         "title": "Park idle",
-        "hint": "/idle name",
+        "hint": "/idle name  (status idle; mode/goal text stay)",
     },
     {
         "slash": "wait",
@@ -120,7 +120,7 @@ _LIFE: tuple[dict[str, Any], ...] = (
         "kind": "life",
         "action": "wait",
         "title": "Park waiting",
-        "hint": "/wait name",
+        "hint": "/wait name  (parks waiting; not running)",
     },
     {
         "slash": "goal",

--- a/CortexOS/crew/life.py
+++ b/CortexOS/crew/life.py
@@ -36,8 +36,10 @@ STATUSES = frozenset(
     }
 )
 
-#: In-loop work. Parked idle/goal is not busy.
-WORKING = frozenset({STATUS_ACTIVE, STATUS_WAITING, "thinking", "acting"})
+#: In-loop work that may keep wait_for_replies blocked. Operator-parked
+#: ``waiting`` is not busy; only a live unparked task is.
+BUSY = frozenset({STATUS_ACTIVE, "thinking", "acting"})
+WORKING = frozenset({*BUSY, STATUS_WAITING})
 
 _STATUS_ALIAS = {
     "thinking": STATUS_ACTIVE,
@@ -65,6 +67,13 @@ def is_alive(row: dict[str, Any] | None) -> bool:
     return canonical_status(str(row.get("status") or "")) != STATUS_STOPPED
 
 
+def is_busy(row: dict[str, Any] | None) -> bool:
+    """True only for in-loop active work. Waiting/idle/goal/stopped are not live."""
+    if not is_alive(row):
+        return False
+    return canonical_status(str((row or {}).get("status") or "")) in BUSY
+
+
 def can_accept(row: dict[str, Any] | None) -> bool:
     """False when the operator would see a dead/failed teammate."""
     if not is_alive(row):
@@ -88,3 +97,36 @@ def park_status(row: dict[str, Any] | None) -> str:
     """Idle unless this teammate is in persisted goal mode."""
     mode = canonical_mode(str((row or {}).get("mode") or MODE_ACTIVE))
     return STATUS_GOAL if mode == MODE_GOAL else STATUS_IDLE
+
+
+def hud_chip(row: dict[str, Any] | None) -> dict[str, Any]:
+    """Operator-visible life chip. Never paints stopped as live/running."""
+    if not row:
+        return {"status": STATUS_IDLE, "kind": "idle", "busy": False, "tone": "idle"}
+    status = canonical_status(str(row.get("status") or ""))
+    if not is_alive(row) or status == STATUS_STOPPED:
+        return {
+            "status": STATUS_STOPPED,
+            "kind": "stopped",
+            "busy": False,
+            "tone": "stranded",
+        }
+    if status == STATUS_FAILED:
+        return {
+            "status": STATUS_FAILED,
+            "kind": "failed",
+            "busy": False,
+            "tone": "stranded",
+        }
+    if status == STATUS_WAITING:
+        return {
+            "status": STATUS_WAITING,
+            "kind": "waiting",
+            "busy": False,
+            "tone": "stall",
+        }
+    if status in BUSY:
+        return {"status": STATUS_ACTIVE, "kind": "active", "busy": True, "tone": "live"}
+    if status == STATUS_GOAL:
+        return {"status": STATUS_GOAL, "kind": "goal", "busy": False, "tone": "goal"}
+    return {"status": STATUS_IDLE, "kind": "idle", "busy": False, "tone": "idle"}

--- a/CortexOS/crew/runtime.py
+++ b/CortexOS/crew/runtime.py
@@ -107,6 +107,9 @@ class AgentHandle:
     row: dict[str, Any]
     task: asyncio.Task[None] | None = None
     parked: bool = False
+    #: Operator halt target so CancelledError does not remap wait/idle to goal.
+    park_as: str | None = None
+    park_force: bool = False
 
 
 @dataclass
@@ -668,21 +671,26 @@ class CrewRuntime:
                         text = str(result["error"])
                     else:
                         text = life.dead_reason(result or row)
-                elif action in {"stop", "idle"}:
+                elif action == "stop":
                     result = self.stop_agent(row["id"])
                     if isinstance(result, dict) and result.get("error"):
                         text = str(result["error"])
                     else:
                         parked = result or row
                         text = f"{parked.get('name')} status={parked.get('status')}"
-                elif action == "wait":
-                    if row["name"] == "Manager":
-                        text = "DENIED: Manager wait is the run; do not park the Manager"
-                    elif not life.can_accept(row):
-                        text = f"DENIED: {life.dead_reason(row)}"
+                elif action == "idle":
+                    result = self.idle_agent(row["id"])
+                    if isinstance(result, dict) and result.get("error"):
+                        text = str(result["error"])
                     else:
-                        self._set_status(row["id"], life.STATUS_WAITING)
-                        parked = self.store.get_agent(row["id"]) or row
+                        parked = result or row
+                        text = f"{parked.get('name')} status={parked.get('status')}"
+                elif action == "wait":
+                    result = self.wait_agent(row["id"])
+                    if isinstance(result, dict) and result.get("error"):
+                        text = str(result["error"])
+                    else:
+                        parked = result or row
                         text = f"{parked.get('name')} status={parked.get('status')}"
                 else:
                     goal_text = extra or more
@@ -853,12 +861,41 @@ class CrewRuntime:
             return None
         if row["name"] == "Manager":
             return {"error": "DENIED: Manager cannot be stopped; cancel the run"}
-        handle = self._handles.get(agent_id)
-        if handle is not None and handle.task is not None and not handle.task.done():
+        return self._halt_work(row, life.park_status(row), force=False)
+
+    def idle_agent(self, agent_id: str) -> dict[str, Any] | None:
+        """Halt work and park status=idle. Mode/goal text stay. Does not kill Manager."""
+        row = self.store.get_agent(agent_id)
+        if row is None:
+            return None
+        if row["name"] == "Manager":
+            return {"error": "DENIED: Manager cannot be idled; cancel the run"}
+        return self._halt_work(row, life.STATUS_IDLE, force=True)
+
+    def wait_agent(self, agent_id: str) -> dict[str, Any] | None:
+        """Park waiting. Not busy. Does not kill Manager or :8020."""
+        row = self.store.get_agent(agent_id)
+        if row is None:
+            return None
+        if row["name"] == "Manager":
+            return {"error": "DENIED: Manager wait is the run; do not park the Manager"}
+        if not life.can_accept(row):
+            return {"error": f"DENIED: {life.dead_reason(row)}"}
+        return self._halt_work(row, life.STATUS_WAITING, force=True)
+
+    def _halt_work(
+        self, row: dict[str, Any], status: str, *, force: bool
+    ) -> dict[str, Any]:
+        """Park HUD status immediately, then cancel in-loop work if any."""
+        handle = self._handle(row)
+        running = handle.task is not None and not handle.task.done()
+        if running:
+            handle.park_as = status
+            handle.park_force = force
+        self._set_status(row["id"], status, remap_idle=not force)
+        if running:
             handle.task.cancel()
-        else:
-            self._park_life(row)
-        parked = self.store.get_agent(agent_id) or row
+        parked = self.store.get_agent(row["id"]) or row
         self.bus.emit(parked["space_id"], "agent", {"agent": parked})
         return parked
 
@@ -890,7 +927,7 @@ class CrewRuntime:
         return killed
 
     def set_agent_mode(
-        self, agent_id: str, mode: str, *, goal_text: str = ""
+        self, agent_id: str, mode: str, *, goal_text: str | None = None
     ) -> dict[str, Any] | None:
         row = self.store.set_agent_mode(agent_id, mode, goal_text)
         if row is None:
@@ -1899,7 +1936,7 @@ class CrewRuntime:
             updated = self.set_agent_mode(
                 target["id"],
                 str(args.get("mode") or ""),
-                goal_text=str(args.get("goal") or ""),
+                goal_text=(str(args["goal"]) if "goal" in args else None),
             )
             if updated is None:
                 return f"DENIED: could not set mode on '{target_name}'"
@@ -2144,13 +2181,21 @@ class CrewRuntime:
     def _task_is_parked(self, task: asyncio.Task[None]) -> bool:
         return any(h.task is task and h.parked for h in self._handles.values())
 
-    def _set_status(self, agent_id: str, status: str) -> None:
-        row = self.store.set_agent_status(agent_id, status)
+    def _set_status(self, agent_id: str, status: str, *, remap_idle: bool = True) -> None:
+        row = self.store.set_agent_status(agent_id, status, remap_idle=remap_idle)
         if row is not None:
             self.bus.emit(row["space_id"], "agent", {"agent": row})
 
     def _park_life(self, row: dict[str, Any]) -> None:
         if not life.is_alive(row):
+            return
+        handle = self._handles.get(row["id"])
+        if handle is not None and handle.park_as:
+            wanted = handle.park_as
+            force = handle.park_force
+            handle.park_as = None
+            handle.park_force = False
+            self._set_status(row["id"], wanted, remap_idle=not force)
             return
         self._set_status(row["id"], life.park_status(row))
 
@@ -2191,7 +2236,7 @@ class CrewRuntime:
         created but has not had its first tick yet still reads as 'idle', so
         judging by status would tell a Manager that just spawned someone that
         nobody is working - and wait_for_replies would return before the
-        teammate had even started.
+        teammate had even started. Operator-parked waiting is not working.
         """
         out: list[str] = []
         for a in self.store.list_agents(space_id):
@@ -2204,7 +2249,12 @@ class CrewRuntime:
                 and not handle.task.done()
                 and not handle.parked
             )
-            if running or a["status"] in life.WORKING:
+            if running:
+                out.append(a["name"])
+                continue
+            if handle is not None and handle.parked:
+                continue
+            if life.is_busy(a):
                 out.append(a["name"])
         return out
 
@@ -2429,8 +2479,6 @@ class CrewRuntime:
             return
         fresh = self.store.get_agent(target["id"]) or target
         if not life.can_accept(fresh):
-            return
-        if fresh["status"] in life.WORKING:
             return
         task = asyncio.create_task(self._teammate_run(ctx, fresh, ""))
         handle.task = task

--- a/CortexOS/crew/server.py
+++ b/CortexOS/crew/server.py
@@ -230,7 +230,7 @@ class AgentSpawnIn(BaseModel):
 
 class AgentModeIn(BaseModel):
     mode: str
-    goal: str = ""
+    goal: str | None = None
 
 
 class AgentKillIn(BaseModel):
@@ -448,6 +448,26 @@ def build_router(crew: CrewApp) -> APIRouter:
         if isinstance(stopped, dict) and stopped.get("error"):
             raise HTTPException(400, str(stopped["error"]))
         return {"ok": True, "agent": stopped}
+
+    @router.post("/spaces/{space_id}/agents/{agent_id}/idle")
+    async def idle_agent(space_id: str, agent_id: str) -> dict[str, Any]:
+        row = crew.store.get_agent(agent_id)
+        if row is None or row.get("space_id") != space_id:
+            raise HTTPException(404, "unknown agent")
+        idled = crew.runtime.idle_agent(agent_id)
+        if isinstance(idled, dict) and idled.get("error"):
+            raise HTTPException(400, str(idled["error"]))
+        return {"ok": True, "agent": idled}
+
+    @router.post("/spaces/{space_id}/agents/{agent_id}/wait")
+    async def wait_agent(space_id: str, agent_id: str) -> dict[str, Any]:
+        row = crew.store.get_agent(agent_id)
+        if row is None or row.get("space_id") != space_id:
+            raise HTTPException(404, "unknown agent")
+        waiting = crew.runtime.wait_agent(agent_id)
+        if isinstance(waiting, dict) and waiting.get("error"):
+            raise HTTPException(400, str(waiting["error"]))
+        return {"ok": True, "agent": waiting}
 
     @router.post("/spaces/{space_id}/agents/{agent_id}/kill")
     async def kill_agent(space_id: str, agent_id: str, body: AgentKillIn | None = None) -> dict[str, Any]:

--- a/CortexOS/crew/store.py
+++ b/CortexOS/crew/store.py
@@ -336,14 +336,16 @@ class CrewStore:
             self._db.commit()
         return self.get_agent(agent_id)
 
-    def set_agent_status(self, agent_id: str, status: str) -> dict[str, Any] | None:
+    def set_agent_status(
+        self, agent_id: str, status: str, *, remap_idle: bool = True
+    ) -> dict[str, Any] | None:
         from CortexOS.crew.life import canonical_status, park_status
 
         row = self.get_agent(agent_id)
         if row is None:
             return None
         wanted = canonical_status(status)
-        if wanted == "idle":
+        if remap_idle and wanted == "idle":
             wanted = park_status(row)
         with self._lock:
             self._db.execute("UPDATE agents SET status = ? WHERE id = ?", (wanted, agent_id))

--- a/CortexOS/crew/ui/crew.css
+++ b/CortexOS/crew/ui/crew.css
@@ -487,6 +487,12 @@ button { cursor: pointer; }
 }
 .claim.unclaimed { color: var(--hitl); border-color: var(--hitl); }
 .claim.stranded { color: var(--dead); border-color: var(--dead); }
+.claim.life-stopped, .claim.life-failed { color: var(--dead); border-color: var(--dead); }
+.claim.life-waiting { color: var(--hitl); border-color: var(--hitl); }
+.claim.life-idle { color: var(--mute); }
+.claim.life-goal { color: var(--lease); }
+.claim.life-active { color: var(--live); border-color: var(--live); }
+.orb.stopped { opacity: 0.45; }
 .scope {
   display: inline-block;
   font: 0.55rem var(--mono);

--- a/CortexOS/crew/ui/index.html
+++ b/CortexOS/crew/ui/index.html
@@ -98,10 +98,11 @@
         </div>
         <div class="block">
           <h2>Crew</h2>
-          <p class="hint">Status: active / idle / waiting / goal. /spawn /kill /stop /idle /wait /goal. Stop parks. Kill refuses with a reason.</p>
+          <p class="hint">Status: active / idle / waiting / goal. /spawn /kill /stop /idle /wait /goal. Stop parks idle/goal. Idle forces idle. Wait parks waiting (not running). Kill refuses with a reason. Cancel never kills Manager.</p>
           <div class="life-spawn">
             <input id="spawnName" placeholder="name" />
             <input id="spawnBrief" placeholder="brief" />
+            <input id="spawnGoal" placeholder="goal (optional)" />
             <select id="spawnMode">
               <option value="active">active</option>
               <option value="goal">goal</option>
@@ -760,6 +761,14 @@
       if (state.confirms.some((c) => c.status === "pending")) chips.push(`<span class="chip-mini stall">interrupt HITL</span>`);
       if (waiting) chips.push(`<span class="chip-mini stall">${waiting} waiting</span>`);
       if (dead) chips.push(`<span class="chip-mini stall">${dead} dead</span>`);
+      const lifeCounts = { idle: 0, waiting: 0, goal: 0, stopped: 0, active: 0, failed: 0 };
+      (state.agents || []).forEach((a) => { lifeCounts[lifeChip(a).kind]++; });
+      if (lifeCounts.active) chips.push(`<span class="chip-mini">${lifeCounts.active} active</span>`);
+      if (lifeCounts.waiting) chips.push(`<span class="chip-mini stall">${lifeCounts.waiting} life-wait</span>`);
+      if (lifeCounts.idle) chips.push(`<span class="chip-mini">${lifeCounts.idle} idle</span>`);
+      if (lifeCounts.goal) chips.push(`<span class="chip-mini">${lifeCounts.goal} goal</span>`);
+      if (lifeCounts.stopped) chips.push(`<span class="chip-mini stall">${lifeCounts.stopped} stopped</span>`);
+      if (lifeCounts.failed) chips.push(`<span class="chip-mini stall">${lifeCounts.failed} failed</span>`);
       if (kinds.ask || kinds.broadcast) chips.push(`<span class="chip-mini">offload</span>`);
       Object.keys(kinds).slice(0, 3).forEach((k) => {
         chips.push(`<span class="chip-mini">${esc(k)}</span>`);
@@ -777,8 +786,18 @@
         bar.innerHTML = chips.join(" ");
       } else { bar.hidden = true; bar.innerHTML = ""; }
     }
+    function lifeChip(a) {
+      const alive = a && a.alive !== 0 && a.alive !== "0";
+      const s = (a && a.status) || "idle";
+      if (!alive || s === "stopped") return { kind: "stopped", busy: false };
+      if (s === "failed") return { kind: "failed", busy: false };
+      if (s === "waiting") return { kind: "waiting", busy: false };
+      if (s === "active" || s === "thinking" || s === "acting") return { kind: "active", busy: true };
+      if (s === "goal") return { kind: "goal", busy: false };
+      return { kind: "idle", busy: false };
+    }
     function lifeBusy(a) {
-      return a.status === "active" || a.status === "waiting" || a.status === "thinking" || a.status === "acting";
+      return lifeChip(a).busy;
     }
     function renderAgents() {
       if (!state.agents.length) { $("agents").innerHTML = `<div class="empty empty--orb">No agents yet.</div>`; return; }
@@ -786,7 +805,8 @@
         const cap = a.capability ? " - " + a.capability : "";
         const model = a.model ? " - " + a.model : "";
         const deny = a.deny_tools ? " - deny " + a.deny_tools : "";
-        const busy = lifeBusy(a);
+        const chip = lifeChip(a);
+        const busy = chip.busy;
         const mode = a.mode || "active";
         const goal = a.goal_text ? esc(String(a.goal_text).slice(0, 80)) : "";
         const reason = a.stop_reason ? `<div class="hint">DENIED: ${esc(a.stop_reason)}</div>` : "";
@@ -795,15 +815,17 @@
           ? `<div class="row-actions"><span class="hint">Cancel stops the run. Does not kill Manager.</span></div>`
           : `<div class="row-actions">`
             + `<button class="ghost" data-act="stop" data-id="${esc(a.id)}" type="button">Stop</button>`
+            + `<button class="ghost" data-act="wait" data-id="${esc(a.id)}" type="button">Wait</button>`
+            + `<button class="ghost" data-act="idle" data-id="${esc(a.id)}" type="button">Idle</button>`
             + `<button class="ghost deny" data-act="kill" data-id="${esc(a.id)}" type="button">Kill</button>`
             + `<button class="ghost" data-act="mode" data-id="${esc(a.id)}" data-mode="${mode === "goal" ? "active" : "goal"}" type="button">${mode === "goal" ? "to active" : "to goal"}</button>`
             + `<button class="ghost" data-act="accept" data-id="${esc(a.id)}" type="button">Accept task</button>`
             + `</div>`;
         return `<div class="agent-card">`
           + `<button class="agent${state.focusAgent === a.id ? " agent--on" : ""}" data-id="${esc(a.id)}" type="button" title="Show only this agent's traffic">`
-          + `<div class="orb ${busy ? "thinking" : ""}" style="background:${esc(a.color || "#7ea0d4")}">${esc((a.icon || a.name || "?").slice(0, 2))}</div>`
+          + `<div class="orb ${busy ? "thinking" : ""} ${chip.kind === "stopped" || chip.kind === "failed" ? "stopped" : ""}" style="background:${esc(a.color || "#7ea0d4")}">${esc((a.icon || a.name || "?").slice(0, 2))}</div>`
           + `<div>${esc(a.name)}<small><span class="id">${esc(a.id || "")}</span>`
-          + ` <span class="claim">${esc(a.status || "idle")}</span>`
+          + ` <span class="claim life-${esc(chip.kind)}">${esc(a.status || "idle")}</span>`
           + ` <span class="scope">${esc(mode)}</span>`
           + `${esc(cap)}${esc(model)}${esc(deny)}</small>`
           + (goal ? `<small>goal: ${goal}</small>` : "")
@@ -1514,8 +1536,15 @@
       const base = "/crew/spaces/" + state.spaceId + "/agents/" + id;
       try {
         if (act === "stop") await api(base + "/stop", { method: "POST", body: "{}" });
+        else if (act === "wait") await api(base + "/wait", { method: "POST", body: "{}" });
+        else if (act === "idle") await api(base + "/idle", { method: "POST", body: "{}" });
         else if (act === "kill") await api(base + "/kill", { method: "POST", body: JSON.stringify({ reason: "operator killed" }) });
-        else if (act === "mode") await api(base + "/mode", { method: "POST", body: JSON.stringify({ mode: mode || "goal", goal: "" }) });
+        else if (act === "mode") {
+          const a = agentOf(id);
+          const payload = { mode: mode || "goal" };
+          if ((mode || "goal") === "goal" && a && a.goal_text) payload.goal = a.goal_text;
+          await api(base + "/mode", { method: "POST", body: JSON.stringify(payload) });
+        }
         else if (act === "accept") await api(base + "/accept", { method: "POST", body: JSON.stringify({ brief: "" }) });
         await refreshAgents();
       } catch (err) { toast(err.message, "bad"); }
@@ -1531,11 +1560,13 @@
             name: name,
             brief: $("spawnBrief").value.trim(),
             mode: $("spawnMode").value || "active",
-            goal: $("spawnMode").value === "goal" ? $("spawnBrief").value.trim() : ""
+            goal: ($("spawnGoal") && $("spawnGoal").value.trim())
+              || ($("spawnMode").value === "goal" ? $("spawnBrief").value.trim() : "")
           })
         });
         $("spawnName").value = "";
         $("spawnBrief").value = "";
+        if ($("spawnGoal")) $("spawnGoal").value = "";
         await refreshAgents();
         toast("Spawned " + name + ".");
       } catch (err) { toast(err.message, "bad"); }

--- a/STATUS.md
+++ b/STATUS.md
@@ -11,7 +11,7 @@
 > keeps `goal_text`; Wait/Idle chips + spawnGoal. Stop still does not
 > kill Manager or `:8020`. Rebased onto `afbd4ae1` so facts.md clear
 > survival from #192 stays. Parent #116. Control untouched. Freeze
-> #4/#41-#44 not attached. Local `pytest tests/test_crew -q` **241 passed**. Live
+> #4/#41-#44 not attached. Local `pytest tests/test_crew -q` **245 passed**. Live
 > `:8020` needs founder restart. Did not write CLAIMS.json.
 >
 > **2026-09-06 (CREW-FACTS-MD):** Closed the last #116 honesty gap on the

--- a/STATUS.md
+++ b/STATUS.md
@@ -11,7 +11,7 @@
 > keeps `goal_text`; Wait/Idle chips + spawnGoal. Stop still does not
 > kill Manager or `:8020`. Rebased onto `afbd4ae1` so facts.md clear
 > survival from #192 stays. Parent #116. Control untouched. Freeze
-> #4/#41-#44 not attached. Local `pytest tests/test_crew -q`. Live
+> #4/#41-#44 not attached. Local `pytest tests/test_crew -q` **241 passed**. Live
 > `:8020` needs founder restart. Did not write CLAIMS.json.
 >
 > **2026-09-06 (CREW-FACTS-MD):** Closed the last #116 honesty gap on the

--- a/STATUS.md
+++ b/STATUS.md
@@ -1,6 +1,19 @@
 # STATUS.md
-**Last updated:** 2026-09-06 | **Gate:** G2.3 OSR **SHIPPED** | **Active:** C7-02..06; EPIC-015 RAG served-path; GOLD-01 founder TTY; **CREW-FACTS-MD HUD**
+**Last updated:** 2026-09-06 | **Gate:** G2.3 OSR **SHIPPED** | **Active:** C7-02..06; EPIC-015 RAG served-path; GOLD-01 founder TTY; **CREW-LIFE-HARDEN**; **CREW-FACTS-MD HUD**
 
+> **2026-09-06 (CREW-LIFE-HARDEN):** Grok-Bot-class lifecycle polish on
+> existing Crew life (`life.py` + slash #158 + spawn/stop/kill #142).
+> **Already present:** spawn/kill/stop, smart-idle mailbox, goal mode
+> survives clear, Manager stop/kill DENIED, slash `/wait`/`/idle`/`/goal`.
+> **Newly hardened:** waiting is not invent-green running (HUD orb +
+> `_busy_names`); `/idle` forces status idle (mode/goal text stay);
+> HTTP `/wait` `/idle`; stop parks immediately then cancels; mode toggle
+> keeps `goal_text`; Wait/Idle chips + spawnGoal. Stop still does not
+> kill Manager or `:8020`. Rebased onto `afbd4ae1` so facts.md clear
+> survival from #192 stays. Parent #116. Control untouched. Freeze
+> #4/#41-#44 not attached. Local `pytest tests/test_crew -q`. Live
+> `:8020` needs founder restart. Did not write CLAIMS.json.
+>
 > **2026-09-06 (CREW-FACTS-MD):** Closed the last #116 honesty gap on the
 > Memory panel (R-0001). Durable facts stay in `facts.md` (space) and
 > collection `facts.md` (user|agent|run). `POST .../clear` returns

--- a/docs/subagents_findings/2026-09-06_crew-life-harden.md
+++ b/docs/subagents_findings/2026-09-06_crew-life-harden.md
@@ -1,0 +1,48 @@
+```yaml
+keywords: [crew, life, spawn, wait, stop, idle, goal, hud, epic-116]
+main_idea: "CREW-LIFE-HARDEN: honest wait/idle/stop chips; wait is not invent-green running; stop does not kill Manager."
+models: [grok-4.6]
+workflow: crew-life-harden
+reuse: 2026-09-06_crew-a2a-harden
+status: verified
+cite: agent: crew-life-harden
+repo: Cortex
+date: 2026-09-06
+```
+
+# CREW-LIFE-HARDEN spawn/wait/stop/idle honesty
+
+PREFLIGHT: PARTIAL
+reuse: 2026-09-06_crew-a2a-harden, c151eb23 life #142, 59ebed31 slash #158
+spawn: skip
+
+## Already on origin/main
+
+- `life.py` statuses, `operator_spawn`, `stop_agent`, `kill_agent`, `set_agent_mode`
+- Slash `/spawn /kill /stop /idle /wait /goal`
+- HTTP spawn/stop/kill/mode/accept
+- Goal mode survives chat clear
+- Manager stop/kill DENIED
+
+## Gaps closed
+
+- HUD `lifeBusy` treated `waiting` as thinking/live (invent-green running).
+- `_busy_names` counted operator-parked waiting as still working.
+- `/idle` aliased stop and remapped to `goal` when mode=goal.
+- No HTTP `/wait` or `/idle`; HUD had no Wait/Idle.
+- Mode toggle sent `goal: ""` and wiped `goal_text`.
+- Stop while a task ran left status `active` until CancelledError.
+
+## Landed
+
+- `hud_chip` / `is_busy`: waiting/idle/goal/stopped are not live.
+- `wait_agent` / `idle_agent`; stop parks immediately then cancels.
+- HTTP POST `.../wait` and `.../idle`. Manager DENIED. No :8020 kill.
+- HUD chips `life-*`, Wait/Idle, spawnGoal; mode toggle keeps goal text.
+- Parent #116. Control untouched. No CLAIMS.json. Freeze lanes not attached.
+
+## Verify
+
+```
+python -m pytest tests/test_crew -q
+```

--- a/docs/subagents_findings/2026-09-06_crew-life-harden.md
+++ b/docs/subagents_findings/2026-09-06_crew-life-harden.md
@@ -44,5 +44,4 @@ spawn: skip
 ## Verify
 
 ```
-python -m pytest tests/test_crew -q
-```
+241 passed locally. Not a GitHub CI claim.

--- a/docs/subagents_findings/2026-09-06_crew-life-harden.md
+++ b/docs/subagents_findings/2026-09-06_crew-life-harden.md
@@ -40,8 +40,12 @@ spawn: skip
 - HTTP POST `.../wait` and `.../idle`. Manager DENIED. No :8020 kill.
 - HUD chips `life-*`, Wait/Idle, spawnGoal; mode toggle keeps goal text.
 - Parent #116. Control untouched. No CLAIMS.json. Freeze lanes not attached.
+- Rebased onto `afbd4ae1` (#192). facts.md clear survival stays.
 
 ## Verify
 
 ```
-241 passed locally. Not a GitHub CI claim.
+python -m pytest tests/test_crew -q
+```
+
+245 passed locally after rebase onto #192. Not a GitHub CI claim.

--- a/docs/subagents_findings/INDEX.md
+++ b/docs/subagents_findings/INDEX.md
@@ -2,6 +2,7 @@
 
 | Date | Topic | Keywords | Main idea | Path |
 |------|-------|----------|-----------|------|
+| 2026-09-06 | crew-life-harden | crew, life, spawn, wait, stop, idle, goal, hud, epic-116 | Honest wait/idle/stop chips. Waiting is not invent-green running. Stop does not kill Manager. | `2026-09-06_crew-life-harden.md` |
 | 2026-09-06 | crew-a2a-harden | crew, a2a, ask-card, deadlock, switchboard, epic-116 | Walk wait cycles, refuse wait-while-owed, paint ask cards from Switchboard HUD. No invented replies. | `2026-09-06_crew-a2a-harden.md` |
 | 2026-09-06 | rsf-07-eval-corpus | rsf, rsf-07, eval, r-0003, audit, operate, #156 | Frozen RSF cases fail on one WRONG CERTIFIED. Audit/Operate traces never paint invented CERTIFIED. | `2026-09-06_rsf-07-eval-corpus.md` |
 | 2026-09-06 | crew-router-harden | crew, router, openvault, freeroute, arm, multi-model, epic-116 | Vault-armed APIs count as configured without crew secrets. FreeRoute preferred when OV live. Unarmed refuse. chosen stamped. | `2026-09-06_crew-router-harden.md` |

--- a/tests/test_crew/test_commands.py
+++ b/tests/test_crew/test_commands.py
@@ -139,7 +139,8 @@ async def test_slash_spawn_kill_idle_wait_goal_without_a_run(rig) -> None:
     parked = await rig.runtime.on_user_message(space["id"], "/idle Scout")
     assert parked.get("run_id") is None
     idle = rig.store.get_agent(scout["id"])
-    assert idle is not None and idle["status"] in {life.STATUS_IDLE, life.STATUS_GOAL}
+    assert idle is not None and idle["status"] == life.STATUS_IDLE
+    assert idle["mode"] == life.MODE_GOAL
     waiting = await rig.runtime.on_user_message(space["id"], "/wait Scout")
     assert waiting.get("run_id") is None
     wait_row = rig.store.get_agent(scout["id"])

--- a/tests/test_crew/test_life.py
+++ b/tests/test_crew/test_life.py
@@ -153,3 +153,86 @@ async def test_mailbox_unget_keeps_smart_idle_accept_order() -> None:
     box.unget(taken)
     drained = box.drain()
     assert [e.text for e in drained] == ["one", "two"]
+
+
+async def test_hud_chip_never_paints_stopped_or_wait_as_busy() -> None:
+    stopped = {
+        "name": "Scout",
+        "status": life.STATUS_STOPPED,
+        "alive": 0,
+        "stop_reason": "operator killed",
+    }
+    chip = life.hud_chip(stopped)
+    assert chip["busy"] is False
+    assert chip["kind"] == "stopped"
+    assert chip["tone"] == "stranded"
+    waiting = {"name": "Scout", "status": life.STATUS_WAITING, "alive": 1}
+    wait_chip = life.hud_chip(waiting)
+    assert wait_chip["busy"] is False
+    assert wait_chip["kind"] == "waiting"
+    assert life.is_busy(waiting) is False
+    active = {"name": "Scout", "status": life.STATUS_ACTIVE, "alive": 1}
+    assert life.hud_chip(active)["busy"] is True
+    assert life.is_busy(active) is True
+
+
+async def test_operator_spawn_wait_stop_idle_path(rig2) -> None:
+    space = rig2.store.create_space("LifePath")
+    spawned = await rig2.runtime.operator_spawn(
+        space["id"], {"name": "Scout", "brief": "watch", "mode": "active"}
+    )
+    scout = spawned["agent"]
+    waiting = rig2.runtime.wait_agent(scout["id"])
+    assert waiting is not None and not waiting.get("error")
+    assert waiting["status"] == life.STATUS_WAITING
+    assert life.hud_chip(waiting)["busy"] is False
+    mgr = rig2.runtime.ensure_manager(space["id"])
+    assert "Scout" not in rig2.runtime._busy_names(space["id"], mgr["id"])
+
+    stopped = rig2.runtime.stop_agent(scout["id"])
+    assert stopped is not None and not stopped.get("error")
+    assert stopped["status"] == life.STATUS_IDLE
+    assert life.can_accept(stopped)
+
+    idled = rig2.runtime.idle_agent(scout["id"])
+    assert idled is not None and idled["status"] == life.STATUS_IDLE
+
+    keeper = await rig2.runtime.operator_spawn(
+        space["id"],
+        {"name": "Keeper", "brief": "hold", "mode": "goal", "goal": "hold the line"},
+    )
+    held = keeper["agent"]
+    assert held["status"] == life.STATUS_GOAL
+    forced = rig2.runtime.idle_agent(held["id"])
+    assert forced is not None
+    assert forced["status"] == life.STATUS_IDLE
+    assert forced["mode"] == life.MODE_GOAL
+    assert forced["goal_text"] == "hold the line"
+
+    deny_wait = rig2.runtime.wait_agent(mgr["id"])
+    assert deny_wait is not None and "DENIED" in str(deny_wait.get("error"))
+    deny_stop = rig2.runtime.stop_agent(mgr["id"])
+    assert deny_stop is not None and "DENIED" in str(deny_stop.get("error"))
+    deny_idle = rig2.runtime.idle_agent(mgr["id"])
+    assert deny_idle is not None and "DENIED" in str(deny_idle.get("error"))
+
+    dead = rig2.runtime.kill_agent(scout["id"], reason="done")
+    assert dead is not None and dead["status"] == life.STATUS_STOPPED
+    refuse_wait = rig2.runtime.wait_agent(scout["id"])
+    assert refuse_wait is not None and "DENIED" in str(refuse_wait.get("error"))
+
+
+async def test_mode_toggle_keeps_goal_text(rig2) -> None:
+    space = rig2.store.create_space("GoalKeep")
+    spawned = await rig2.runtime.operator_spawn(
+        space["id"],
+        {"name": "Scout", "brief": "watch", "mode": "goal", "goal": "hold the line"},
+    )
+    scout = spawned["agent"]
+    again = rig2.runtime.set_agent_mode(scout["id"], life.MODE_GOAL)
+    assert again is not None
+    assert again["goal_text"] == "hold the line"
+    active = rig2.runtime.set_agent_mode(scout["id"], life.MODE_ACTIVE)
+    assert active is not None
+    assert active["goal_text"] == "hold the line"
+    assert active["mode"] == life.MODE_ACTIVE

--- a/tests/test_crew/test_server.py
+++ b/tests/test_crew/test_server.py
@@ -168,6 +168,13 @@ def test_ui_index_is_served(client) -> None:
     assert "ask-card" in page.text
     assert "ask-card--waiting" in page.text
     assert "hop--pending" in page.text
+    assert 'id="spawnGoal"' in page.text
+    assert 'data-act="wait"' in page.text
+    assert 'data-act="idle"' in page.text
+    assert 'kind: "waiting", busy: false' in page.text
+    assert "life-wait" in page.text
+    assert "function lifeChip" in page.text
+    assert "Cancel never kills Manager" in page.text
     stolen = client.http.get("/stolen.css")
     assert stolen.status_code == 410
     css = client.http.get("/crew.css")
@@ -187,6 +194,9 @@ def test_ui_index_is_served(client) -> None:
     assert b"ask-card" in css.content
     assert b"msg--ask" in css.content
     assert b"hop--pending" in css.content
+    assert b"claim.life-stopped" in css.content
+    assert b"claim.life-waiting" in css.content
+    assert b"claim.life-active" in css.content
     assert b"--rail-ground" not in css.content
     assert b"--rk-page" not in css.content
     desk = client.http.get("/crew/desk").json()
@@ -660,6 +670,67 @@ def test_operator_life_routes_spawn_kill_clear(client) -> None:
     )
     assert refuse.status_code == 400
     assert "DENIED" in refuse.json()["detail"]
+
+
+def test_operator_life_spawn_wait_stop_idle(client) -> None:
+    space = client.http.post("/crew/spaces", json={"title": "LifePath"}).json()
+    sid = space["id"]
+    spawned = client.http.post(
+        f"/crew/spaces/{sid}/agents",
+        json={"name": "Scout", "brief": "watch", "mode": "active"},
+    ).json()
+    assert spawned["ok"] is True
+    scout = spawned["agent"]
+    waiting = client.http.post(f"/crew/spaces/{sid}/agents/{scout['id']}/wait")
+    assert waiting.status_code == 200
+    body = waiting.json()
+    assert body["agent"]["status"] == "waiting"
+    listed = client.http.get(f"/crew/spaces/{sid}/agents").json()
+    row = next(a for a in listed if a["name"] == "Scout")
+    assert row["status"] == "waiting"
+
+    stopped = client.http.post(f"/crew/spaces/{sid}/agents/{scout['id']}/stop")
+    assert stopped.status_code == 200
+    assert stopped.json()["agent"]["status"] == "idle"
+
+    idled = client.http.post(f"/crew/spaces/{sid}/agents/{scout['id']}/idle")
+    assert idled.status_code == 200
+    assert idled.json()["agent"]["status"] == "idle"
+
+    keeper = client.http.post(
+        f"/crew/spaces/{sid}/agents",
+        json={
+            "name": "Keeper",
+            "brief": "hold",
+            "mode": "goal",
+            "goal": "hold the line",
+        },
+    ).json()["agent"]
+    assert keeper["status"] == "goal"
+    keep_idle = client.http.post(f"/crew/spaces/{sid}/agents/{keeper['id']}/idle")
+    assert keep_idle.status_code == 200
+    parked = keep_idle.json()["agent"]
+    assert parked["status"] == "idle"
+    assert parked["mode"] == "goal"
+    assert parked["goal_text"] == "hold the line"
+
+    toggled = client.http.post(
+        f"/crew/spaces/{sid}/agents/{keeper['id']}/mode",
+        json={"mode": "goal"},
+    )
+    assert toggled.status_code == 200
+    assert toggled.json()["agent"]["goal_text"] == "hold the line"
+
+    mgr = next(a for a in client.http.get(f"/crew/spaces/{sid}/agents").json() if a["name"] == "Manager")
+    refuse_wait = client.http.post(f"/crew/spaces/{sid}/agents/{mgr['id']}/wait")
+    assert refuse_wait.status_code == 400
+    assert "DENIED" in refuse_wait.json()["detail"]
+    refuse_idle = client.http.post(f"/crew/spaces/{sid}/agents/{mgr['id']}/idle")
+    assert refuse_idle.status_code == 400
+    assert "DENIED" in refuse_idle.json()["detail"]
+    refuse_stop = client.http.post(f"/crew/spaces/{sid}/agents/{mgr['id']}/stop")
+    assert refuse_stop.status_code == 400
+    assert "DENIED" in refuse_stop.json()["detail"]
 
 
 def test_collection_memory_api_survives_clear_and_does_not_dual_write(client) -> None:


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Parent: #116 (EPIC-CREW-01). Netie-native lifecycle polish on existing `CortexOS/crew` life verbs.

Rebased onto `origin/main` at `afbd4ae1` (CREW-FACTS-MD #192). Kept both facts.md clear survival and wait/idle honesty.

## Why

Grok-Bot-class spawn/wait/stop/idle/goal already existed on main (`life.py`, slash #158, spawn/stop/kill #142). Remaining honesty gaps:

- HUD treated `waiting` as a thinking/live orb (invent-green running)
- `_busy_names` counted operator-parked waiting as still working
- `/idle` aliased stop and remapped to `goal` when mode=goal
- No HTTP `/wait` or `/idle`; HUD had no Wait/Idle
- Mode toggle sent `goal: ""` and wiped `goal_text`
- Stop while a task ran left status `active` until cancel landed

## What

1. `hud_chip` / `is_busy`: waiting/idle/goal/stopped are not live.
2. `wait_agent` / `idle_agent`; stop parks HUD immediately then cancels.
3. HTTP `POST .../wait` and `.../idle`. Manager DENIED. Does not kill `:8020`.
4. HUD life chips, Wait/Idle, spawnGoal; mode toggle keeps goal text.
5. Tests: spawn -> wait -> stop -> idle (runtime + HTTP) plus HUD chrome.
6. After #192: `facts_survived` / Memory HUD still on clear.

## Already present vs newly hardened

Already on main: spawn/kill/stop, smart-idle mailbox, goal survives clear, Manager stop/kill DENIED, slash `/wait` `/idle` `/goal`, facts.md survives clear (#192).

Newly hardened: wait honesty, idle force, HTTP wait/idle, immediate stop park, goal toggle keep, HUD chips.

## Do not

Control. Freeze #4/#41/#42/#43/#44. Kill :8020. Paste mybot/n8n/OpenWillow/guaca/rakazo. Dual CLAIMS.json.

## Verify

```
python -m pytest tests/test_crew -q
```

Local: **245 passed** on `2482ad2b` after rebase onto #192. Not a GitHub CI claim. Live `:8020` was not started or killed. Draft until CI green.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-75842573-bf64-46b9-a558-bac3d4b4b0ab?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-75842573-bf64-46b9-a558-bac3d4b4b0ab&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

