### PR TITLE
Crew: /scale seats existing writers, /build binds skill build + named verify (#116)

### DIFF
--- a/CortexOS/crew/commands.py
+++ b/CortexOS/crew/commands.py
@@ -79,6 +79,22 @@ _DESK: tuple[dict[str, Any], ...] = (
         "title": "Assign teammate (local)",
         "hint": "/assign owner/repo#n | Name. Local bind then teammate run. Refuses SEATED. No GitHub assignee.",
     },
+    {
+        "slash": "build",
+        "aliases": ("implement",),
+        "kind": "desk",
+        "action": "build_issue",
+        "title": "Build ticket (skill build + named verify)",
+        "hint": "/build owner/repo#n | Name | verify cmd. Verifier fails closed without pasted output. Bare /build loads the pack. Refuses SEATED.",
+    },
+    {
+        "slash": "scale",
+        "aliases": ("seat",),
+        "kind": "desk",
+        "action": "scale_tickets",
+        "title": "Scale: seat existing writers",
+        "hint": "/scale n | Name, Name. Idle teammates first, spawn only to cap. Never one agent per issue.",
+    },
 )
 
 _LIFE: tuple[dict[str, Any], ...] = (

--- a/CortexOS/crew/runtime.py
+++ b/CortexOS/crew/runtime.py
@@ -72,6 +72,9 @@ tell the user what was denied and why instead of pretending it ran.
 - The human operator is money and decision authority. Do not auto-pay, auto-send, or auto-merge.
 - Do not spawn infinite Cursor cloud chats. One issue per human-opened chat. Ticket Runner seats \
 existing writers.
+- Operator slashes /build (one ticket: skill build plus a verifier whose criteria name the test \
+command) and /scale (seat existing idle teammates across ready tickets, spawn only to cap) bind \
+tickets locally. You do not seat writers yourself and you never claim a verify command ran.
 - Models go through OpenVault FreeRoute. Cursor chats use grok-4.6 (high), never grok-fast.
 - To check PRs, mail, connectors, the Cursor key, or the GitHub org estate, call desk_status or estate_status. Before shipping, call ship_gate (repo=slug or repo=all). Do not ask the operator to click import or PR buttons. Dropped files already become spaces.
 - Your final plain-text reply is the only thing the user reads. Keep it direct. Plain ASCII only.
@@ -256,19 +259,21 @@ class CrewRuntime:
             and parsed.command.get("action") == "fetch_issues"
             and not parsed.mentions
         )
-        assign_only = bool(
+        bind_only = bool(
             parsed.command
-            and parsed.command.get("action") == "assign_issue"
+            and parsed.command.get("action") in {"assign_issue", "build_issue", "scale_tickets"}
             and not parsed.mentions
         )
-        if desk_only or memory_only or life_only or close_only or fetch_only:
-            return {"ok": True, "command": parsed.command.get("slash"), "run_id": None}
-        if assign_only:
+        if bind_only:
+            # /assign /build /scale already briefed the teammates and started
+            # the run; run_id None here would hide live work from the operator.
             return {
                 "ok": True,
                 "command": parsed.command.get("slash"),
                 "run_id": desk_run_id,
             }
+        if desk_only or memory_only or life_only or close_only or fetch_only:
+            return {"ok": True, "command": parsed.command.get("slash"), "run_id": None}
 
         turn_provider = (provider or "").strip() or None
         turn_model = (model or "").strip() or None
@@ -453,6 +458,16 @@ class CrewRuntime:
             args = {"repos": fetched.get("repos") or []}
         elif action == "assign_issue":
             text, args = await self._assign_issue_slash(space_id, rest)
+        elif action == "build_issue":
+            if not rest.strip():
+                # Bare /build keeps loading the build pack (Ponytail ladder).
+                self._load_slash_pack(
+                    space_id, {"kind": "skill", "action": "build", "slash": "build"}, ""
+                )
+                return None
+            text, args = await self._build_issue_slash(space_id, rest)
+        elif action == "scale_tickets":
+            text, args = await self._scale_slash(space_id, rest)
         else:
             text = f"Unknown desk action {action}"
         msg = self.store.add_message(
@@ -469,7 +484,7 @@ class CrewRuntime:
             },
         )
         self.bus.emit(space_id, "message", {"message": msg})
-        if action == "assign_issue" and text.startswith("Assigned"):
+        if action in {"assign_issue", "build_issue", "scale_tickets"}:
             rid = args.get("run_id")
             return str(rid) if rid else None
         return None
@@ -477,16 +492,126 @@ class CrewRuntime:
     async def _assign_issue_slash(
         self, space_id: str, rest: str
     ) -> tuple[str, dict[str, Any]]:
-        from CortexOS.crew import assign as assign_mod
-        from CortexOS.crew import github as github_mod
-
         bits = [p.strip() for p in rest.split("|")]
         spec = bits[0] if bits else ""
         agent_name = bits[1] if len(bits) > 1 else ""
-        args: dict[str, Any] = {"spec": spec, "name": agent_name}
+        return await self._bind_issue(space_id, spec, agent_name)
+
+    async def _build_issue_slash(
+        self, space_id: str, rest: str
+    ) -> tuple[str, dict[str, Any]]:
+        """Operator /build: one ticket, skill build, verifier with a named command."""
+        from CortexOS.crew import scale as scale_mod
+
+        spec, agent_name, cmd = scale_mod.parse_build_rest(rest)
+        return await self._bind_issue(
+            space_id, spec, agent_name, build=True, verify_cmd=cmd
+        )
+
+    async def _scale_slash(self, space_id: str, rest: str) -> tuple[str, dict[str, Any]]:
+        """Operator /scale: seat existing idle teammates across ready tickets.
+
+        Binds first (no run), then one run briefs every seat. Spawns only while
+        the cap leaves room for the writer and its verifier; the rest is queued
+        with a visible reason. Never one agent per issue, never CLAIMS.json.
+        """
+        from CortexOS.crew import assign as assign_mod
+        from CortexOS.crew import github as github_mod
+        from CortexOS.crew import scale as scale_mod
+
+        limit, names = scale_mod.parse_scale_rest(rest)
+        args: dict[str, Any] = {"limit": limit, "names": names}
+        self.ensure_manager(space_id)
+        bound_rows = assign_mod.load(self.settings.data_dir)
+        bound = {
+            str(r.get("agent") or ""): str(r.get("spec") or "")
+            for r in bound_rows
+            if str(r.get("agent") or "").strip()
+        }
+        tickets = scale_mod.ready_tickets(
+            self.settings.data_dir,
+            bound_specs={str(r.get("spec") or "") for r in bound_rows},
+        )
+        if not tickets:
+            if github_mod.remembered_issues(self.settings.data_dir):
+                why = "every fetched issue is SEATED or already bound"
+            else:
+                why = "no fetched issues cached; /fetch first"
+            return f"DENIED: no ready tickets ({why}). {scale_mod.LAW_SCALE}", args
+        plan = scale_mod.plan_scale(
+            tickets,
+            self.store.list_agents(space_id),
+            cap=self.settings.max_agents_per_space,
+            limit=limit,
+            names=names,
+            bound=bound,
+        )
+        outcomes: list[tuple[Any, bool, str]] = []
+        seated: list[dict[str, Any]] = []
+        for seat in plan.seats:
+            text, bind_args = await self._bind_issue(
+                space_id,
+                seat.spec,
+                seat.writer,
+                build=True,
+                verify_cmd=scale_mod.DEFAULT_VERIFY_CMD,
+                execute=False,
+            )
+            ok = not text.startswith("DENIED")
+            outcomes.append((seat, ok, text))
+            if ok:
+                seated.append(bind_args)
+        run_id: str | None = None
+        for bind_args in seated:
+            row = self.store.get_agent(str(bind_args.get("agent_id") or ""))
+            if row is None:
+                continue
+            rid = self._execute_assigned(space_id, row, str(bind_args.get("goal") or ""))
+            run_id = run_id or rid
+        args.update(
+            {
+                "seated": [
+                    {"spec": seat.spec, "writer": seat.writer, "reused": seat.reused}
+                    for seat, ok, _text in outcomes
+                    if ok
+                ],
+                "queued": [{"spec": spec, "reason": why} for spec, why in plan.queued],
+                "skipped": [{"writer": who, "reason": why} for who, why in plan.skipped],
+                "run_id": run_id,
+            }
+        )
+        return scale_mod.render_scale(plan, outcomes), args
+
+    async def _bind_issue(
+        self,
+        space_id: str,
+        spec: str,
+        agent_name: str,
+        *,
+        build: bool = False,
+        verify_cmd: str = "",
+        execute: bool = True,
+    ) -> tuple[str, dict[str, Any]]:
+        """Local bind of one ticket to a teammate, then brief + run.
+
+        ``build`` copies skill build in and arms the verifier with criteria
+        that name ``verify_cmd``. ``execute=False`` binds without briefing so
+        one caller can start a single run for several seats (``/scale``).
+        Does not write CLAIMS.json. Does not set a GitHub assignee.
+        """
+        from CortexOS.crew import assign as assign_mod
+        from CortexOS.crew import github as github_mod
+        from CortexOS.crew import scale as scale_mod
+
+        usage = (
+            "/build owner/repo#n | Name | verify cmd" if build else "/assign owner/repo#n | Name"
+        )
         parsed = github_mod.parse_issue_spec(spec)
+        if build and parsed is not None and not agent_name:
+            agent_name = scale_mod.job_name(spec)
+        args: dict[str, Any] = {"spec": spec, "name": agent_name}
         if parsed is None or not agent_name:
-            return "DENIED: /assign owner/repo#n | Name", args
+            return f"DENIED: {usage}", args
         seated = github_mod.seated_claim(spec)
         if seated is not None:
             return (
@@ -501,24 +626,34 @@ class CrewRuntime:
         shown = github_mod.show_issue(canon)
         title = str(shown.get("title") or canon).strip()
         body = str(shown.get("body") or "").strip()
-        goal = (
-            f"{canon}: {title}. Execute this issue. "
-            "Close with request_close (HITL) or /done after verify. "
-            "Do not steal SEATED seats. Do not merge PRs."
-        )
-        if body:
-            goal = f"{goal}\n\n{body[:2000]}"
+        cmd = ""
+        criteria: list[str] = []
+        if build:
+            cmd = (verify_cmd or "").strip() or scale_mod.DEFAULT_VERIFY_CMD
+            criteria = scale_mod.build_criteria(cmd)
+            goal = scale_mod.build_goal(canon, title, body, cmd)
+            args["verify"] = cmd
+        else:
+            goal = (
+                f"{canon}: {title}. Execute this issue. "
+                "Close with request_close (HITL) or /done after verify. "
+                "Do not steal SEATED seats. Do not merge PRs."
+            )
+            if body:
+                goal = f"{goal}\n\n{body[:2000]}"
         row = self.store.get_agent_by_name(space_id, agent_name)
         if row is None:
-            spawned = await self.operator_spawn(
-                space_id,
-                {
-                    "name": agent_name,
-                    "mode": life.MODE_GOAL,
-                    "goal": goal,
-                    "brief": canon,
-                },
-            )
+            payload: dict[str, Any] = {
+                "name": agent_name,
+                "mode": life.MODE_GOAL,
+                "goal": goal,
+                "brief": canon,
+            }
+            if build:
+                payload["skills"] = [scale_mod.BUILD_SKILL]
+                payload["verify"] = True
+                payload["verify_criteria"] = criteria
+            spawned = await self.operator_spawn(space_id, payload)
             if spawned.get("error"):
                 return str(spawned["error"]), args
             row = spawned.get("agent")
@@ -527,6 +662,19 @@ class CrewRuntime:
         elif not life.can_accept(row):
             return f"DENIED: {life.dead_reason(row)}", args
         else:
+            if build:
+                # Existing writer: copy the build pack and arm its verifier
+                # before the brief lands, so the run reads verify from the store.
+                self.store.upsert_agent(
+                    space_id,
+                    str(row.get("name") or agent_name),
+                    role_prompt=self._role_with_skills(
+                        str(row.get("role_prompt") or ""), [scale_mod.BUILD_SKILL]
+                    ),
+                    verify=True,
+                    verify_criteria=criteria,
+                    skills=[scale_mod.BUILD_SKILL],
+                )
             updated = self.set_agent_mode(row["id"], life.MODE_GOAL, goal_text=goal)
             row = updated or row
         if not isinstance(row, dict) or not row.get("id"):
@@ -544,10 +692,21 @@ class CrewRuntime:
             "name": row.get("name"),
             "agent_id": row.get("id"),
         }
+        if build:
+            args["verify"] = cmd
         if not bound.get("ok"):
             return str(bound.get("detail") or "DENIED: assign failed"), args
-        run_id = self._execute_assigned(space_id, row, goal)
-        args["run_id"] = run_id
+        if execute:
+            run_id = self._execute_assigned(space_id, row, goal)
+            args["run_id"] = run_id
+        else:
+            args["goal"] = goal
+        if build:
+            return (
+                f"Build {canon} -> {row.get('name')} mode=goal skill=build "
+                f"verify: {cmd}. {scale_mod.LAW_BUILD}",
+                args,
+            )
         return (
             f"Assigned {canon} to {row.get('name')} mode=goal. {bound.get('law')}",
             args,
@@ -1030,6 +1189,14 @@ class CrewRuntime:
         role = str(args.get("role") or "").strip()
         if preset is not None and not role:
             role = preset.role
+        verify = bool(args.get("verify"))
+        criteria = _str_list(args.get("verify_criteria"))
+        if verify and not criteria:
+            verify = False
+        skill_names = _str_list(args.get("skills"))
+        if preset is not None:
+            skill_names = list(dict.fromkeys([*preset.skills, *skill_names]))
+        role = self._role_with_skills(role, skill_names)
         teammate = self.store.upsert_agent(
             space_id,
             name,
@@ -1038,6 +1205,9 @@ class CrewRuntime:
             color=AGENT_COLORS[len(live) % len(AGENT_COLORS)],
             spawned_by=manager["id"],
             capability=(preset.name if preset is not None else cap_name),
+            verify=verify,
+            verify_criteria=criteria,
+            skills=skill_names,
             mode=mode,
             goal_text=goal_text,
         )
@@ -2067,16 +2237,7 @@ class CrewRuntime:
         skill_names = _str_list(args.get("skills"))
         if preset is not None:
             skill_names = list(dict.fromkeys([*preset.skills, *skill_names]))
-        if skill_names:
-            from CortexOS.crew.board import read_skill
-
-            bits = []
-            for title in skill_names:
-                body = read_skill(self.settings.data_dir / "skills", title).strip()
-                if body:
-                    bits.append(f"Skill {title}:\n{body[:3500]}")
-            if bits:
-                role = (role + "\n\n" if role else "") + "\n\n".join(bits)
+        role = self._role_with_skills(role, skill_names)
         model = str(args.get("model") or "").strip()
         mode = life.canonical_mode(str(args.get("mode") or ""))
         if mode == life.MODE_GOAL:
@@ -2124,6 +2285,23 @@ class CrewRuntime:
             extra += "; mode=goal (survives chat clear)"
         return f"spawned {name}; they are working the brief and will report back{extra}"
 
+    def _role_with_skills(self, role: str, skill_names: list[str]) -> str:
+        """Copy each named skill pack into the role prompt once."""
+        if not skill_names:
+            return role
+        from CortexOS.crew.board import read_skill
+
+        bits: list[str] = []
+        for title in skill_names:
+            if f"Skill {title}:" in role:
+                continue
+            body = read_skill(self.settings.data_dir / "skills", title).strip()
+            if body:
+                bits.append(f"Skill {title}:\n{body[:3500]}")
+        if not bits:
+            return role
+        return (role + "\n\n" if role else "") + "\n\n".join(bits)
+
     async def _spawn_verifier(
         self, ctx: RunContext, worker: dict[str, Any], output: str
     ) -> None:
@@ -2131,6 +2309,14 @@ class CrewRuntime:
             return
         agents = self.store.list_agents(ctx.space_id)
         if len(agents) >= self.settings.max_agents_per_space:
+            # A silent skip would read as verified (R-0011). Say it in the transcript.
+            note = self.store.add_message(
+                ctx.space_id,
+                "system",
+                f"DENIED: verify skipped for {worker['name']}: agent cap reached "
+                f"({self.settings.max_agents_per_space}). Not verified; not green.",
+            )
+            self.bus.emit(ctx.space_id, "message", {"message": note})
             return
         gate = roles.by_name("Gate")
         criteria = _str_list(worker.get("verify_criteria"))
@@ -2155,6 +2341,8 @@ class CrewRuntime:
             capability="Gate",
             verify=False,
         )
+        self._set_status(verifier["id"], life.STATUS_ACTIVE)
+        verifier = self.store.get_agent(verifier["id"]) or verifier
         self.bus.emit(ctx.space_id, "agent", {"agent": verifier})
         self._deliver_a2a(ctx, worker, name, brief, kind=a2a.BRIEF, wake=False)
         task = asyncio.create_task(self._teammate_run(ctx, verifier, brief))

--- a/CortexOS/crew/scale.py
+++ b/CortexOS/crew/scale.py
@@ -1,0 +1,329 @@
+"""Scale and Build over tickets: seat existing writers, then verify by a named test.
+
+Scale = seat existing writers, not one agent per issue (FLEET law;
+``docs/subagents_findings/2026-08-24_overnight-watchdog-tickets.md``).
+``/scale`` pairs ready fetched issues with teammates that are alive, parked
+idle and not already bound. It spawns a job-named teammate only while the
+space cap still leaves room for that writer AND its verifier. Everything else
+is queued with a visible reason, never dropped silently (R-0011).
+
+Build = skill ``build`` (Ponytail ladder) plus the existing generator-verifier
+pass. The verify criteria name the exact command. The verifier is a different
+run (R-0003) and must not paint green unless the command's real output is
+pasted.
+
+Local binds only. CLAIMS.json and GitHub assignees are never written. This is
+not a second orchestrator: every seat goes through the same ``/assign`` bind,
+A2A brief, and run that the operator already drives by hand.
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+
+from CortexOS.crew import github as github_mod
+from CortexOS.crew import life
+
+#: Named in ``skill_packs/build.md`` ("Verify default for crew code"). A test
+#: asserts the pack and this constant agree so they cannot drift silently.
+DEFAULT_VERIFY_CMD = "python -m pytest tests/test_crew -q"
+BUILD_SKILL = "build"
+DEFAULT_SCALE_LIMIT = 3
+MAX_SCALE_LIMIT = 20
+#: One verifier row lands after each build worker finishes; it counts against
+#: ``max_agents_per_space`` like any teammate, so a seat reserves its slot now.
+VERIFIER_SLOTS = 1
+
+LAW_BUILD = (
+    "Local bind. Skill build copied in. Verifier runs after the worker finishes "
+    "and fails closed without pasted output. Did not write CLAIMS.json. "
+    "Did not set a GitHub assignee."
+)
+LAW_SCALE = (
+    "Scale = seat existing writers, not one agent per issue. Local binds only. "
+    "Did not write CLAIMS.json. Did not set a GitHub assignee."
+)
+
+REASON_CAP = "cap reached"
+REASON_LIMIT = "over limit"
+REASON_BOUND = "bound to"
+
+
+def job_name(spec: str) -> str:
+    """``owner/repo#n`` -> ``repo-n``. A job name for THIS ticket, not a catalog label."""
+    parsed = github_mod.parse_issue_spec(spec)
+    if parsed is None:
+        return ""
+    _owner, repo, number = parsed
+    slug = re.sub(r"[^A-Za-z0-9_-]+", "-", repo.lower()).strip("-") or "ticket"
+    return f"{slug}-{number}"[:64]
+
+
+def parse_build_rest(rest: str) -> tuple[str, str, str]:
+    """``/build owner/repo#n | Name | verify cmd`` -> (spec, name, cmd).
+
+    Name and command are optional: the name defaults to :func:`job_name` at
+    bind time and the command to :data:`DEFAULT_VERIFY_CMD`.
+    """
+    bits = [p.strip() for p in (rest or "").split("|")]
+    spec = bits[0] if bits else ""
+    name = bits[1] if len(bits) > 1 else ""
+    cmd = "|".join(bits[2:]).strip() if len(bits) > 2 else ""
+    return spec, name, (cmd or DEFAULT_VERIFY_CMD)
+
+
+def parse_scale_rest(rest: str) -> tuple[int, list[str]]:
+    """``/scale [n|all] [| Name, Name]`` -> (limit, preferred existing writers).
+
+    ``/scale Scout, Gate`` (no number) keeps the default limit and names
+    the writers to reuse.
+    """
+    bits = [p.strip() for p in (rest or "").split("|")]
+    head = bits[0] if bits else ""
+    names_blob = ",".join(bits[1:]) if len(bits) > 1 else ""
+    limit = DEFAULT_SCALE_LIMIT
+    if head:
+        token = head.split()[0].rstrip(",")
+        tail = head[len(head.split()[0]) :].strip()
+        if token.isdigit():
+            limit = max(1, min(MAX_SCALE_LIMIT, int(token)))
+            if tail:
+                names_blob = tail + ("," + names_blob if names_blob else "")
+        elif token.lower() == "all":
+            limit = MAX_SCALE_LIMIT
+            if tail:
+                names_blob = tail + ("," + names_blob if names_blob else "")
+        else:
+            names_blob = head + ("," + names_blob if names_blob else "")
+    names: list[str] = []
+    for raw in names_blob.split(","):
+        name = raw.strip()
+        if name and name.lower() not in {n.lower() for n in names}:
+            names.append(name)
+    return limit, names
+
+
+def build_goal(canon: str, title: str, body: str, verify_cmd: str) -> str:
+    """Goal text a build teammate keeps across chat clear (mode=goal)."""
+    goal = (
+        f"{canon}: {title}. Build this issue. Follow skill build: smallest change "
+        "that works, Ponytail ladder, Cortex invariants. "
+        f"Named verify command: {verify_cmd}. Paste its real output; do not claim "
+        "green unless it ran. Close with request_close (HITL) or /done after verify. "
+        "Do not steal SEATED seats. Do not merge PRs."
+    )
+    if body:
+        goal = f"{goal}\n\n{body[:2000]}"
+    return goal
+
+
+def build_criteria(verify_cmd: str) -> list[str]:
+    """Explicit pass/fail checks for the verifier. No criteria = no verifier."""
+    return [
+        f"The named verify command ran: {verify_cmd}",
+        "Its real output is pasted, not summarised; no green claim without it",
+        "Smallest change that works; no git add -A; no weakened refusal; "
+        "no hand-edited contract spec",
+        "SEATED seats untouched; no PR merged; close only via request_close HITL",
+    ]
+
+
+def ready_tickets(data_dir: Path, *, bound_specs: set[str] | None = None) -> list[dict[str, Any]]:
+    """Fetched open issues that are ready: owner/repo#n, not SEATED, not bound."""
+    taken = {github_mod.canonical_spec(s) for s in (bound_specs or set()) if s}
+    out: list[dict[str, Any]] = []
+    seen: set[str] = set()
+    for row in github_mod.remembered_issues(data_dir):
+        spec = github_mod.canonical_spec(str(row.get("spec") or ""))
+        if not spec or spec in seen or spec in taken:
+            continue
+        if github_mod.parse_issue_spec(spec) is None:
+            continue
+        if row.get("seated") or github_mod.seated_claim(spec) is not None:
+            continue
+        seen.add(spec)
+        out.append({"spec": spec, "title": str(row.get("title") or spec)})
+    return out
+
+
+@dataclass(frozen=True)
+class Seat:
+    spec: str
+    title: str
+    writer: str
+    reused: bool  # existing teammate reused vs job-named spawn
+
+    def public(self) -> dict[str, Any]:
+        return {
+            "spec": self.spec,
+            "title": self.title,
+            "writer": self.writer,
+            "reused": self.reused,
+        }
+
+
+@dataclass
+class ScalePlan:
+    cap: int
+    rows: int
+    total: int
+    limit: int
+    seats: list[Seat] = field(default_factory=list)
+    queued: list[tuple[str, str]] = field(default_factory=list)  # (spec, reason)
+    skipped: list[tuple[str, str]] = field(default_factory=list)  # (writer, reason)
+
+    @property
+    def reused(self) -> int:
+        return sum(1 for s in self.seats if s.reused)
+
+    @property
+    def spawned(self) -> int:
+        return sum(1 for s in self.seats if not s.reused)
+
+    def public(self) -> dict[str, Any]:
+        return {
+            "cap": self.cap,
+            "rows": self.rows,
+            "total": self.total,
+            "limit": self.limit,
+            "seats": [s.public() for s in self.seats],
+            "queued": [{"spec": spec, "reason": why} for spec, why in self.queued],
+            "skipped": [{"writer": who, "reason": why} for who, why in self.skipped],
+            "law": LAW_SCALE,
+        }
+
+
+def writer_block(row: dict[str, Any], bound: dict[str, str], *, named: bool) -> str:
+    """Why this teammate cannot take a ticket now. Empty string means it can."""
+    name = str(row.get("name") or "")
+    if name == "Manager":
+        return "Manager never writes"
+    if name.endswith("-verify"):
+        # Generator-verifier rows carry the Gate role and one worker's criteria.
+        return "verifier row, not a writer"
+    status = life.canonical_status(str(row.get("status") or ""))
+    if not life.is_alive(row) or status == life.STATUS_STOPPED:
+        why = str(row.get("stop_reason") or "").strip()
+        return f"stopped ({why})" if why else "stopped"
+    if status == life.STATUS_FAILED:
+        return "failed"
+    if life.is_busy(row):
+        return "busy"
+    spec = bound.get(name.lower())
+    if spec:
+        return f"{REASON_BOUND} {spec}"
+    if not named and status == life.STATUS_WAITING:
+        return "parked waiting (name it to reuse)"
+    if not named and status == life.STATUS_GOAL:
+        return "goal mode (name it to reuse)"
+    return ""
+
+
+def plan_scale(
+    tickets: list[dict[str, Any]],
+    agents: list[dict[str, Any]],
+    *,
+    cap: int,
+    limit: int = DEFAULT_SCALE_LIMIT,
+    names: list[str] | None = None,
+    bound: dict[str, str] | None = None,
+) -> ScalePlan:
+    """Pair ready tickets with writers. Pure: no store, no spawn, no gh.
+
+    Existing writers seat first. A job-named teammate is spawned only while
+    ``cap`` leaves room for the writer and its verifier. ``bound`` maps a
+    teammate name to the ticket it already holds.
+    """
+    plan = ScalePlan(cap=int(cap), rows=len(agents), total=len(tickets), limit=int(limit))
+    bound_lower = {str(k).lower(): str(v) for k, v in (bound or {}).items() if str(k).strip()}
+    by_name = {str(a.get("name") or "").lower(): a for a in agents if a.get("name")}
+    writers: list[str] = []
+    wanted = [n for n in (names or []) if str(n).strip()]
+    if wanted:
+        for raw in wanted:
+            row = by_name.get(str(raw).lower())
+            if row is None:
+                plan.skipped.append((str(raw), "not in this space"))
+                continue
+            why = writer_block(row, bound_lower, named=True)
+            if why:
+                plan.skipped.append((str(row["name"]), why))
+                continue
+            if str(row["name"]) not in writers:
+                writers.append(str(row["name"]))
+    else:
+        for row in agents:
+            why = writer_block(row, bound_lower, named=False)
+            if why:
+                if why != "Manager never writes":
+                    plan.skipped.append((str(row.get("name") or ""), why))
+                continue
+            writers.append(str(row["name"]))
+
+    budget = plan.cap - plan.rows
+    held = set(bound_lower.values())
+    for index, ticket in enumerate(tickets):
+        spec = github_mod.canonical_spec(str(ticket.get("spec") or ""))
+        title = str(ticket.get("title") or spec)
+        if not spec:
+            continue
+        if index >= plan.limit:
+            plan.queued.append((spec, f"{REASON_LIMIT} {plan.limit}"))
+            continue
+        if spec in held:
+            plan.queued.append((spec, "already bound"))
+            continue
+        if writers:
+            if budget < VERIFIER_SLOTS:
+                plan.queued.append((spec, f"{REASON_CAP} ({plan.cap} rows; verifier slot)"))
+                continue
+            writer = writers.pop(0)
+            budget -= VERIFIER_SLOTS
+            plan.seats.append(Seat(spec=spec, title=title, writer=writer, reused=True))
+            continue
+        name = job_name(spec)
+        existing = by_name.get(name.lower())
+        if existing is not None:
+            why = writer_block(existing, bound_lower, named=True)
+            if why:
+                plan.queued.append((spec, f"{existing['name']} {why}"))
+                continue
+            if budget < VERIFIER_SLOTS:
+                plan.queued.append((spec, f"{REASON_CAP} ({plan.cap} rows; verifier slot)"))
+                continue
+            budget -= VERIFIER_SLOTS
+            plan.seats.append(
+                Seat(spec=spec, title=title, writer=str(existing["name"]), reused=True)
+            )
+            continue
+        cost = 1 + VERIFIER_SLOTS
+        if budget < cost:
+            plan.queued.append((spec, f"{REASON_CAP} ({plan.cap} rows; writer + verifier slots)"))
+            continue
+        budget -= cost
+        plan.seats.append(Seat(spec=spec, title=title, writer=name, reused=False))
+    return plan
+
+
+def render_scale(plan: ScalePlan, outcomes: list[tuple[Seat, bool, str]]) -> str:
+    """Operator-visible report. Counts only binds that actually succeeded."""
+    seated = [seat for seat, ok, _text in outcomes if ok]
+    reused = sum(1 for s in seated if s.reused)
+    spawned = len(seated) - reused
+    lines = [
+        f"Scaled {len(seated)}/{plan.total} ready tickets: reused {reused} existing, "
+        f"spawned {spawned} job-named (cap {plan.cap}, {plan.rows} rows before). "
+        f"{LAW_SCALE}"
+    ]
+    for seat, ok, text in outcomes:
+        how = "existing" if seat.reused else "spawned"
+        mark = "" if ok else "FAILED "
+        lines.append(f"- {mark}{seat.spec} -> {seat.writer} ({how}): {text}")
+    for spec, why in plan.queued:
+        lines.append(f"- queued {spec}: {why}")
+    for who, why in plan.skipped:
+        lines.append(f"- skipped {who}: {why}")
+    return "\n".join(lines)

--- a/CortexOS/crew/server.py
+++ b/CortexOS/crew/server.py
@@ -279,6 +279,19 @@ class TaskAssignIn(BaseModel):
     live_ssh: bool = False
 
 
+class TicketBuildIn(BaseModel):
+    spec: str
+    space_id: str
+    name: str = ""
+    verify: str = ""
+
+
+class TicketScaleIn(BaseModel):
+    space_id: str
+    limit: int = 3
+    names: str = ""
+
+
 _LEASE_LAW = (
     "Crew lease. Control display-only. Did not write CLAIMS.json. "
     "Did not set a GitHub assignee."
@@ -1014,6 +1027,51 @@ def build_router(crew: CrewApp) -> APIRouter:
             "ok": True,
             "spec": github_mod.canonical_spec(body.spec),
             "law": "Released local bind. Did not edit CLAIMS.json.",
+        }
+
+    @router.post("/tickets/build")
+    async def build_ticket(body: TicketBuildIn) -> dict[str, Any]:
+        """Operator /build over HTTP: skill build + verifier named test. 409 SEATED."""
+        from CortexOS.crew import scale as scale_mod
+
+        if crew.store.get_space(body.space_id) is None:
+            raise HTTPException(404, "unknown space")
+        rest = f"{body.spec.strip()} | {body.name.strip()} | {body.verify.strip()}"
+        text, args = await crew.runtime._build_issue_slash(body.space_id, rest)
+        if text.startswith("DENIED"):
+            code = 409 if "SEATED" in text else 400
+            raise HTTPException(code, text)
+        return {
+            "ok": True,
+            "detail": text,
+            "args": args,
+            "run_id": args.get("run_id"),
+            "verify": args.get("verify"),
+            "law": scale_mod.LAW_BUILD,
+        }
+
+    @router.post("/tickets/scale")
+    async def scale_tickets(body: TicketScaleIn) -> dict[str, Any]:
+        """Operator /scale over HTTP: seat existing writers, spawn only to cap."""
+        from CortexOS.crew import scale as scale_mod
+
+        if crew.store.get_space(body.space_id) is None:
+            raise HTTPException(404, "unknown space")
+        limit = max(1, min(scale_mod.MAX_SCALE_LIMIT, int(body.limit)))
+        rest = str(limit)
+        if body.names.strip():
+            rest = f"{rest} | {body.names.strip()}"
+        text, args = await crew.runtime._scale_slash(body.space_id, rest)
+        if text.startswith("DENIED"):
+            raise HTTPException(409, text)
+        return {
+            "ok": True,
+            "detail": text,
+            "seated": args.get("seated") or [],
+            "queued": args.get("queued") or [],
+            "skipped": args.get("skipped") or [],
+            "run_id": args.get("run_id"),
+            "law": scale_mod.LAW_SCALE,
         }
 
     @router.post("/tickets/{ticket_id:path}/claim")

--- a/CortexOS/crew/ui/index.html
+++ b/CortexOS/crew/ui/index.html
@@ -170,7 +170,8 @@
           </div>
           <div class="block">
             <h2>Work - Tickets</h2>
-            <p class="hint">Claim is Crew /assign (local). Ticket Runner seats CLAIMS. Control does not assign.</p>
+            <p class="hint">Claim is Crew /assign (local). Build = skill build + named verify command. Scale seats idle teammates first, spawns only to cap, never one agent per issue. Ticket Runner seats CLAIMS. Control does not assign.</p>
+            <div class="row-actions"><button class="ghost" id="ticketsScale" type="button" title="/scale 3: seat existing idle teammates across ready tickets">Scale</button></div>
             <div id="tickets" class="empty">unread</div>
           </div>
         </div>
@@ -1061,12 +1062,17 @@
     function ticketRow(key, seated, mine, extra) {
       const holder = mine && (mine.worker || mine.agent || "");
       const label = seated ? "SEATED" : (holder ? ("leased " + holder) : "ready");
+      // Build needs owner/repo#n; CLAIMS ids like FF-03 have no issue to read.
+      const buildable = !seated && /^[A-Za-z0-9_.-]+\/[A-Za-z0-9_.-]+#\d+$/.test(key);
       const actions = seated
         ? `<small>Ticket Runner owns the seat. Crew does not steal it.</small>`
         : (`<div class="row-actions">`
           + (mine
             ? `<button class="ghost" type="button" data-release="${esc(key)}">Release</button>`
             : `<button class="ghost" type="button" data-claim="${esc(key)}">Claim</button>`)
+          + (buildable
+            ? `<button class="ghost" type="button" data-build="${esc(key)}" title="/build: skill build + verifier with the named test command">Build</button>`
+            : "")
           + `</div>`);
       return `<div class="row">${esc(key)} <span class="claim ${seated ? "" : "unclaimed"}">${esc(label)}</span>`
         + `<small>${esc(extra || "")}</small>`
@@ -1104,6 +1110,7 @@
       $("tickets").innerHTML = assignBlock + claimsBlock + issueBlock;
       $("tickets").querySelectorAll("[data-claim]").forEach((el) => el.onclick = () => checkoutTicket(el.dataset.claim, "claim"));
       $("tickets").querySelectorAll("[data-release]").forEach((el) => el.onclick = () => checkoutTicket(el.dataset.release, "release"));
+      $("tickets").querySelectorAll("[data-build]").forEach((el) => el.onclick = () => buildTicket(el.dataset.build));
     }
     function renderAssign(body) {
       const dests = (body && body.destinations) || [];
@@ -1174,6 +1181,59 @@
         if (board) renderTickets(board);
         const belt = await api("/v1/belt").catch(() => api("/crew/belt").catch(() => null));
         if (belt) renderBelt(belt);
+      } catch (err) {
+        toast(err.message + " - no silent retry.", "bad");
+      } finally {
+        state.claimBusy = null;
+      }
+    }
+    async function buildTicket(spec) {
+      if (!state.spaceId) { toast("Pick a space first.", "bad"); return; }
+      if (state.claimBusy) { toast("Claim in flight. No silent retry.", "warn"); return; }
+      state.claimBusy = spec + ":build";
+      try {
+        const name = (($("spawnName") && $("spawnName").value) || "").trim();
+        const resp = await fetch("/crew/tickets/build", {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ spec: spec, space_id: state.spaceId, name: name })
+        });
+        const data = await resp.json().catch(() => ({}));
+        if (!resp.ok) {
+          toast((data.detail || ("build " + resp.status)) + " - no silent retry.", "bad");
+          return;
+        }
+        toast(data.detail || ("Build " + spec), "ok");
+        await refreshAgents();
+        const board = await api("/crew/tickets").catch(() => null);
+        if (board) renderTickets(board);
+      } catch (err) {
+        toast(err.message + " - no silent retry.", "bad");
+      } finally {
+        state.claimBusy = null;
+      }
+    }
+    async function scaleTickets() {
+      if (!state.spaceId) { toast("Pick a space first.", "bad"); return; }
+      if (state.claimBusy) { toast("Claim in flight. No silent retry.", "warn"); return; }
+      state.claimBusy = "scale";
+      try {
+        const resp = await fetch("/crew/tickets/scale", {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ space_id: state.spaceId, limit: 3 })
+        });
+        const data = await resp.json().catch(() => ({}));
+        if (!resp.ok) {
+          toast((data.detail || ("scale " + resp.status)) + " - no silent retry.", "bad");
+          return;
+        }
+        const seated = (data.seated || []).length;
+        const queued = (data.queued || []).length;
+        toast("Scaled " + seated + " seated, " + queued + " queued. Existing writers first; never one agent per issue.", seated ? "ok" : "warn");
+        await refreshAgents();
+        const board = await api("/crew/tickets").catch(() => null);
+        if (board) renderTickets(board);
       } catch (err) {
         toast(err.message + " - no silent retry.", "bad");
       } finally {
@@ -1909,6 +1969,7 @@
         await loadAssign();
       }
     };
+    $("ticketsScale").onclick = () => scaleTickets();
     $("insightsOntology").onclick = () => runInsights(false);
     $("insightsAsk").onclick = () => runInsights(true);
     $("clearChat").onclick = async () => {

--- a/STATUS.md
+++ b/STATUS.md
@@ -1,5 +1,19 @@
 # STATUS.md
-**Last updated:** 2026-09-07 | **Gate:** G2.3 OSR **SHIPPED** | **Active:** C7-02..06; EPIC-015 RAG served-path; GOLD-01 founder TTY; **CREW-INSIGHTS**
+**Last updated:** 2026-09-12 | **Gate:** G2.3 OSR **SHIPPED** | **Active:** C7-02..06; EPIC-015 RAG served-path; GOLD-01 founder TTY; **CREW-SCALE-BUILD**; CREW-INSIGHTS
+
+> **2026-09-12 (CREW-SCALE-BUILD):** Operator `/scale n | Name, Name` seats
+> existing idle teammates across ready fetched issues (never one agent per
+> issue): a job-named teammate is spawned only while `max_agents_per_space`
+> still leaves a writer + verifier slot; the rest is queued with a visible
+> reason. `/build owner/repo#n | Name | verify cmd` binds one ticket with skill
+> build and a verifier whose criteria name the command (default
+> `python -m pytest tests/test_crew -q`, asserted equal to the pack). Bare
+> `/build` still loads the pack. HUD Build per ready issue + Scale button;
+> `POST /crew/tickets/build|scale`. A verifier skipped at the cap is a visible
+> DENIED in the transcript, not silence; verifier rows are never writers.
+> Local binds only; CLAIMS.json and GitHub assignees untouched. Control stays
+> display-only. Off freeze #4/#41-#44. Did not start/kill `:8020`. Local
+> `pytest tests/test_crew -q` **289 passed**. Not a GitHub CI claim.
 
 > **2026-09-07 (CREW-INSIGHTS):** Cortex #196 ask+ontology spine. Intent retrieves
 > ontology **where** (object/table locations) and **importance** (ranked metrics /

--- a/docs/subagents_findings/2026-09-12_crew-scale-build.md
+++ b/docs/subagents_findings/2026-09-12_crew-scale-build.md
@@ -1,0 +1,29 @@
+# Crew /build and /scale: seat existing writers, verify by a named test
+
+- **Date:** 2026-09-12
+- **Keywords:** crew, scale, build, tickets, seat, verifier, verify-cmd, cap, epic-116, crew-scale-build
+- **Main idea:** `/scale` seats existing idle teammates across ready fetched issues and spawns a job-named teammate only while `max_agents_per_space` still leaves a writer + verifier slot; the rest is queued with a visible reason. `/build owner/repo#n | Name | verify cmd` binds one ticket with skill build and a verifier whose criteria name the test command. A verifier that cannot spawn at the cap now says so in the transcript instead of vanishing.
+- **Verify:** `python -m pytest tests/test_crew -q` (289 passed locally on this branch: 275 before, 14 new in `tests/test_crew/test_scale.py`). Also `ruff check`, `mypy`, `lint-imports` (3 kept), `python scripts/check_versions.py`, `pytest tests/contract tests/packaging tests/invariants` (151 passed).
+- **Does not prove:** live `:8020` HUD until founder restart; that any teammate ran pytest (no shell exec was added, the verifier judges the pasted output and fails closed without it); GitHub CI from this agent.
+- **Cite:** parent EPIC-CREW #116. Law: `2026-08-24_overnight-watchdog-tickets.md` ("Scale = seat existing writers, not one agent per issue"). Pack: `CortexOS/crew/skill_packs/build.md` ("Verify default for crew code").
+
+## Expected vs actual
+
+- **Expected** (prompt "Scale and Build tickets or crew then verify Test", read as a Crew feature): the operator fans work across the Tickets HUD without a swarm, every build names its verify command, and verification is honest.
+- **Actual before:** `/assign` bound one ticket to one named teammate with no skill pack and no verifier. `spawn_agent(verify=true)` lost its verifier silently at the agent cap (`_spawn_verifier` returned without a message) and the verifier row read `idle` until its first tick. HUD `operator_spawn` with no live run dropped `skills` / `verify` / `verify_criteria`, so the same spawn behaved differently depending on whether a run was live.
+
+## Repro (before this change)
+
+1. `settings.max_agents_per_space = 2`, bind a ticket, let the worker finish with `verify=true`: transcript shows neither a verifier report nor a refusal.
+2. `POST /crew/spaces/{id}/agents` with `skills=["build"]` while no run is live: `role_prompt` carries no pack text; the same call during a run does.
+
+## Root-cause class
+
+Silent fallback (verifier skipped at cap with no operator-visible reason) plus a split code path (`_spawn` vs `operator_spawn`) that persisted different fields. Invariants: "Silent fallback is a lie. Degradation has to show in the output." and "A skipped test is a failing test."
+
+## Shape
+
+- No new orchestrator. `/scale` is N x `/build` through the existing `/assign` bind, A2A brief, and one run (`_bind_issue(execute=False)` then `_execute_assigned` per seat).
+- Pure planner `CortexOS/crew/scale.py`: cap arithmetic counts verifier rows because they persist as agents (reuse costs 1 slot, spawn costs 2). Verifier rows and Manager are never writers. Goal-mode or waiting teammates are reused only when named.
+- `/build` with no args still loads the pack; `build` moved from a skill slug to a desk slash. Assumption stated in the PR: the prompt was read as this feature; slash names are cheap to rename.
+- HTTP `POST /crew/tickets/build` (409 SEATED, 400 bad spec) and `POST /crew/tickets/scale` (409 nothing ready). HUD: Build button per ready `owner/repo#n` row, Scale button on the Tickets block. Control stays GET display-only.

--- a/docs/subagents_findings/INDEX.md
+++ b/docs/subagents_findings/INDEX.md
@@ -2,6 +2,7 @@
 
 | Date | Topic | Keywords | Main idea | Path |
 |------|-------|----------|-----------|------|
+| 2026-09-12 | crew-scale-build | crew, scale, build, seat, verifier, verify-cmd, cap, epic-116 | /scale seats existing idle teammates across ready issues, spawns only while cap leaves a writer+verifier slot, queues the rest visibly. /build = skill build + verifier naming the test command. Verifier cap skip is a visible DENIED. | `2026-09-12_crew-scale-build.md` |
 | 2026-09-07 | crew-insights | crew, insights, ontology, where, importance, certify, refuse, #196 | Intent then ontology where+importance then constrained DMS ask. CERTIFIED envelopes carry include/exclude/unsure. | `2026-09-07_crew-insights.md` |
 | 2026-09-06 | cortex-appshell | appshell, crew, control, f-0030, apps, audit, cmd-k | Operator shell wraps Crew: nav + Apps launcher + Control/Audit GET deep-links. No Control spawn. Honest RSF statuses. | `2026-09-06_cortex-appshell.md` |
 | 2026-09-06 | crew-assign-router | crew, assign, destinations, openvault, unarmed, human_stop, airgpt, epic-116 | Assign router POST /crew/assign. OpenVault-only creds. Unarmed refuse. Control display-only map. Preview != live SSH/cloud. | `2026-09-06_crew-assign-router.md` |

--- a/tests/test_crew/test_scale.py
+++ b/tests/test_crew/test_scale.py
@@ -1,0 +1,643 @@
+"""Scale = seat existing writers; Build = skill build + named verify.
+
+Every assertion is on what the operator sees: the stored transcript, the
+agent rows the HUD paints, assignments.json, and HTTP bodies (CLAUDE.md
+section 8). A planner result alone certifies nothing, so the pure tests are
+paired with runtime and HTTP tests that read the same artifacts back.
+"""
+
+from __future__ import annotations
+
+import json
+import time
+from collections.abc import Iterator
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+from fastapi.testclient import TestClient
+
+from CortexOS.crew import github as github_mod
+from CortexOS.crew import scale
+from CortexOS.crew.board import PACKS_DIR
+from CortexOS.crew.llm import LLMResult, ToolCall
+from CortexOS.crew.server import create_app
+from tests.test_crew.conftest import FakeLLM, wait_run_done
+
+
+@pytest.fixture()
+def client(settings, crew_env) -> Iterator[SimpleNamespace]:
+    fake = FakeLLM()
+    app = create_app(settings, llm_chat=fake)
+    with TestClient(app) as tc:
+        yield SimpleNamespace(http=tc, llm=fake, app=app, crew=app.state.crew)
+
+
+# -- pure planner -------------------------------------------------------------
+
+
+def test_default_verify_cmd_matches_build_pack() -> None:
+    """The pack names the command; the constant must not drift from it."""
+    pack = (PACKS_DIR / "build.md").read_text(encoding="utf-8")
+    assert scale.DEFAULT_VERIFY_CMD in pack
+
+
+def test_job_name_and_parsers() -> None:
+    assert scale.job_name("Netie-AI/Cortex#202") == "cortex-202"
+    assert scale.job_name("https://github.com/Netie-AI/Cortex/issues/7") == "cortex-7"
+    assert scale.job_name("FF-03") == ""
+    assert scale.parse_build_rest("Netie-AI/Cortex#202") == (
+        "Netie-AI/Cortex#202",
+        "",
+        scale.DEFAULT_VERIFY_CMD,
+    )
+    assert scale.parse_build_rest("Netie-AI/Cortex#202 | Scout | pytest tests/x -q") == (
+        "Netie-AI/Cortex#202",
+        "Scout",
+        "pytest tests/x -q",
+    )
+    assert scale.parse_scale_rest("") == (scale.DEFAULT_SCALE_LIMIT, [])
+    assert scale.parse_scale_rest("5") == (5, [])
+    assert scale.parse_scale_rest("2 | Scout, Gate") == (2, ["Scout", "Gate"])
+    assert scale.parse_scale_rest("Scout") == (scale.DEFAULT_SCALE_LIMIT, ["Scout"])
+    assert scale.parse_scale_rest("all") == (scale.MAX_SCALE_LIMIT, [])
+    assert scale.parse_scale_rest("999")[0] == scale.MAX_SCALE_LIMIT
+    assert scale.parse_scale_rest("0")[0] == 1
+
+
+def test_build_goal_and_criteria_name_the_command() -> None:
+    goal = scale.build_goal("Netie-AI/Cortex#202", "grant catalog", "body text", "pytest -q")
+    assert "Netie-AI/Cortex#202" in goal and "grant catalog" in goal and "body text" in goal
+    assert "pytest -q" in goal and "skill build" in goal
+    assert "do not claim green unless it ran" in goal
+    crit = scale.build_criteria("pytest -q")
+    assert any("pytest -q" in c for c in crit)
+    assert any("no green claim" in c.lower() for c in crit)
+    assert any("SEATED" in c for c in crit)
+
+
+def _agent(
+    name: str, status: str = "idle", mode: str = "active", alive: int = 1, stop_reason: str = ""
+) -> dict:
+    return {
+        "name": name,
+        "status": status,
+        "mode": mode,
+        "alive": alive,
+        "stop_reason": stop_reason,
+    }
+
+
+def _tickets(*numbers: int) -> list[dict]:
+    return [{"spec": f"Netie-AI/Cortex#{n}", "title": f"ticket {n}"} for n in numbers]
+
+
+def test_plan_scale_seats_existing_idle_first_then_spawns_to_cap() -> None:
+    agents = [
+        _agent("Manager"),
+        _agent("Scout"),  # idle -> reused first
+        _agent("Gate", status="active"),  # busy -> skipped
+        _agent("Ghost", status="stopped", alive=0, stop_reason="operator killed"),
+        _agent("Watch", status="goal", mode="goal"),  # goal mode -> only when named
+    ]
+    plan = scale.plan_scale(_tickets(201, 202, 203, 204), agents, cap=8, limit=3)
+    # 5 rows, cap 8: Scout reuse costs its verifier slot (1), a spawn costs
+    # writer + verifier (2). 3 - 1 - 2 = 0, so #203 queues and #204 is over limit.
+    assert [(s.spec, s.writer, s.reused) for s in plan.seats] == [
+        ("Netie-AI/Cortex#201", "Scout", True),
+        ("Netie-AI/Cortex#202", "cortex-202", False),
+    ]
+    assert plan.reused == 1 and plan.spawned == 1
+    assert plan.queued[0][0] == "Netie-AI/Cortex#203"
+    assert plan.queued[0][1].startswith(scale.REASON_CAP)
+    assert plan.queued[1] == ("Netie-AI/Cortex#204", f"{scale.REASON_LIMIT} 3")
+    assert ("Gate", "busy") in plan.skipped
+    assert ("Ghost", "stopped (operator killed)") in plan.skipped
+    assert ("Watch", "goal mode (name it to reuse)") in plan.skipped
+    assert not any(who == "Manager" for who, _why in plan.skipped)
+    public = plan.public()
+    assert public["seats"][0]["writer"] == "Scout"
+    assert "one agent per issue" in public["law"]
+
+
+def test_plan_scale_named_writers_and_bound_rows() -> None:
+    agents = [_agent("Manager"), _agent("Scout"), _agent("Watch", status="goal", mode="goal")]
+    plan = scale.plan_scale(
+        _tickets(201, 202),
+        agents,
+        cap=8,
+        limit=2,
+        names=["Watch", "Nobody"],
+        bound={"Scout": "Netie-AI/Cortex#150"},
+    )
+    assert [(s.spec, s.writer, s.reused) for s in plan.seats] == [
+        ("Netie-AI/Cortex#201", "Watch", True),
+        ("Netie-AI/Cortex#202", "cortex-202", False),
+    ]
+    assert ("Nobody", "not in this space") in plan.skipped
+    # Unnamed pass: the bound writer is skipped with the ticket it already holds.
+    unnamed = scale.plan_scale(_tickets(201), agents, cap=8, bound={"Scout": "Netie-AI/Cortex#150"})
+    assert ("Scout", f"{scale.REASON_BOUND} Netie-AI/Cortex#150") in unnamed.skipped
+    # A job name that already exists in the roster is reused, not spawned twice.
+    again = scale.plan_scale(_tickets(202), [_agent("Manager"), _agent("cortex-202")], cap=8)
+    assert [(s.writer, s.reused) for s in again.seats] == [("cortex-202", True)]
+    # A ticket already bound elsewhere never seats a second writer.
+    held = scale.plan_scale(_tickets(150), agents, cap=8, bound={"Scout": "Netie-AI/Cortex#150"})
+    assert held.seats == [] and held.queued == [("Netie-AI/Cortex#150", "already bound")]
+    # Verifier rows carry the Gate role; they are never seated as writers.
+    gated = scale.plan_scale(_tickets(201), [_agent("Manager"), _agent("Scout-verify")], cap=8)
+    assert [(s.writer, s.reused) for s in gated.seats] == [("cortex-201", False)]
+    assert ("Scout-verify", "verifier row, not a writer") in gated.skipped
+
+
+def test_plan_scale_cap_leaves_no_verifier_slot() -> None:
+    agents = [_agent("Manager"), _agent("Scout"), _agent("A"), _agent("B"), _agent("C")]
+    plan = scale.plan_scale(_tickets(201, 202), agents, cap=5, limit=2)
+    assert plan.seats == []
+    assert all(why.startswith(scale.REASON_CAP) for _spec, why in plan.queued)
+    assert len(plan.queued) == 2
+
+
+def test_render_scale_counts_only_successful_binds() -> None:
+    plan = scale.plan_scale(
+        _tickets(201, 202, 203), [_agent("Manager"), _agent("Scout")], cap=8, limit=2
+    )
+    outcomes = [
+        (plan.seats[0], True, "Build Netie-AI/Cortex#201 -> Scout"),
+        (plan.seats[1], False, "DENIED: spawn failed"),
+    ]
+    text = scale.render_scale(plan, outcomes)
+    assert text.startswith("Scaled 1/3 ready tickets: reused 1 existing, spawned 0 job-named")
+    assert "- FAILED Netie-AI/Cortex#202 -> cortex-202 (spawned): DENIED: spawn failed" in text
+    assert "- queued Netie-AI/Cortex#203: over limit 2" in text
+    assert "never" not in text.lower() or "one agent per issue" in text
+
+
+def test_ready_tickets_drops_seated_bound_and_non_issue_rows(tmp_path: Path, monkeypatch) -> None:
+    claims = tmp_path / "CLAIMS.json"
+    claims.write_text(
+        '{"tickets":[{"ticket":"Netie-AI/Cortex#128","owner_pr":"Netie-AI/Cortex#128","role":"SEATED"}]}',
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("CREW_CLAIMS", str(claims))
+    github_mod.remember_fetched(
+        tmp_path,
+        {
+            "ok": True,
+            "issues": [
+                {"spec": "Netie-AI/Cortex#128", "title": "seated", "seated": False},
+                {"spec": "Netie-AI/Cortex#150", "title": "bound elsewhere"},
+                {"spec": "Netie-AI/Cortex#202", "title": "grant catalog"},
+                {"spec": "Netie-AI/Cortex#202", "title": "duplicate"},
+                {"spec": "Netie-AI/Cortex#203", "title": "jail", "seated": True},
+                {"spec": "FF-03", "title": "not an issue spec"},
+            ],
+        },
+    )
+    rows = scale.ready_tickets(tmp_path, bound_specs={"Netie-AI/Cortex#150"})
+    assert rows == [{"spec": "Netie-AI/Cortex#202", "title": "grant catalog"}]
+
+
+# -- runtime: operator-visible flow ------------------------------------------
+
+
+def _tc(tool: str, **args: object) -> ToolCall:
+    return ToolCall(id=f"c-{tool}", name=tool, args=dict(args))
+
+
+def _fake_show_issue(spec: str, **_k: object) -> dict:
+    return {
+        "ok": True,
+        "spec": spec,
+        "title": f"title for {spec}",
+        "body": "Acceptance: one named verify command.",
+        "state": "OPEN",
+        "seated": False,
+        "ready": True,
+        "detail": "",
+        "law": "Read only.",
+    }
+
+
+@pytest.mark.asyncio
+async def test_build_slash_binds_skill_verifier_and_paints_verdict(
+    rig, tmp_path, monkeypatch
+) -> None:
+    claims = tmp_path / "CLAIMS.json"
+    claims.write_text(
+        '{"tickets":[{"ticket":"Netie-AI/Cortex#128","owner_pr":"Netie-AI/Cortex#128","role":"SEATED"}]}',
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("CREW_CLAIMS", str(claims))
+    monkeypatch.setattr(github_mod, "show_issue", _fake_show_issue)
+    space = rig.store.create_space("HQ")
+
+    # Bare /build still loads the pack; nothing is bound.
+    bare = await rig.runtime.on_user_message(space["id"], "/build")
+    assert bare.get("run_id") is None
+    loaded = rig.store.list_messages(space["id"])[-1]
+    assert loaded["role"] == "system"
+    assert "Skill /build loaded" in loaded["content"] and "Ponytail" in loaded["content"]
+
+    # SEATED refuses before any spawn.
+    seated = await rig.runtime.on_user_message(space["id"], "/build Netie-AI/Cortex#128")
+    assert seated.get("run_id") is None
+    deny = [m for m in rig.store.list_messages(space["id"]) if m["role"] == "tool"][-1]
+    assert deny["content"].startswith("DENIED") and "SEATED" in deny["content"]
+    assert rig.store.get_agent_by_name(space["id"], "cortex-128") is None
+
+    rig.llm.manager.extend(
+        [
+            LLMResult(tool_calls=[_tc("wait_for_replies", timeout_seconds=8)]),
+            LLMResult(tool_calls=[_tc("wait_for_replies", timeout_seconds=8)]),
+            LLMResult(text="Build reported; verifier reported. Nothing merged."),
+        ]
+    )
+    rig.llm.teammate.extend(
+        [
+            LLMResult(text="Ran python -m pytest tests/test_crew -q: 275 passed (summary only)."),
+            LLMResult(text="passed: false. Output was summarised, not pasted. Not green."),
+        ]
+    )
+    posted = await rig.runtime.on_user_message(space["id"], "/build Netie-AI/Cortex#202")
+    assert posted.get("run_id")
+    assert posted.get("command") == "build"
+    await wait_run_done(rig.runtime, space["id"], timeout=15.0)
+
+    tool = [
+        m
+        for m in rig.store.list_messages(space["id"])
+        if m["role"] == "tool" and (m.get("meta") or {}).get("tool") == "build_issue"
+    ][-1]
+    assert tool["content"].startswith("Build Netie-AI/Cortex#202 -> cortex-202")
+    assert scale.DEFAULT_VERIFY_CMD in tool["content"]
+    assert "Did not write CLAIMS.json" in tool["content"]
+
+    worker = rig.store.get_agent_by_name(space["id"], "cortex-202")
+    assert worker is not None
+    assert int(worker["verify"]) == 1
+    assert scale.DEFAULT_VERIFY_CMD in worker["verify_criteria"]
+    assert "build" in json.loads(worker["skills"])
+    assert "Skill build:" in worker["role_prompt"] and "Ponytail" in worker["role_prompt"]
+    assert worker["mode"] == "goal"
+    assert "Netie-AI/Cortex#202" in worker["goal_text"]
+    assert scale.DEFAULT_VERIFY_CMD in worker["goal_text"]
+    assert "Acceptance: one named verify command." in worker["goal_text"]
+
+    verifier = rig.store.get_agent_by_name(space["id"], "cortex-202-verify")
+    assert verifier is not None
+    assert verifier["capability"] == "Gate"
+    assert scale.DEFAULT_VERIFY_CMD in verifier["role_prompt"]
+
+    painted = " ".join(str(m.get("content") or "") for m in rig.store.list_messages(space["id"]))
+    assert "275 passed (summary only)" in painted
+    assert "passed: false. Output was summarised, not pasted. Not green." in painted
+    assert "Build reported; verifier reported." in painted
+    assert "Cut off" not in painted
+
+    from CortexOS.crew.assign import public as assignment_public
+
+    rows = assignment_public(rig.settings.data_dir)
+    assert rows[0]["spec"] == "Netie-AI/Cortex#202" and rows[0]["agent"] == "cortex-202"
+    assert claims.read_text(encoding="utf-8").count("SEATED") == 1  # CLAIMS untouched
+
+
+@pytest.mark.asyncio
+async def test_build_slash_reuses_named_teammate_with_custom_verify(
+    rig, tmp_path, monkeypatch
+) -> None:
+    claims = tmp_path / "CLAIMS.json"
+    claims.write_text('{"tickets":[]}', encoding="utf-8")
+    monkeypatch.setenv("CREW_CLAIMS", str(claims))
+    monkeypatch.setattr(github_mod, "show_issue", _fake_show_issue)
+    space = rig.store.create_space("HQ")
+    rig.runtime.ensure_manager(space["id"])
+    scout = rig.store.upsert_agent(space["id"], "Scout", role_prompt="Scout the brief.")
+    rig.llm.manager.extend(
+        [
+            LLMResult(tool_calls=[_tc("wait_for_replies", timeout_seconds=8)]),
+            LLMResult(tool_calls=[_tc("wait_for_replies", timeout_seconds=8)]),
+            LLMResult(text="Scout built it."),
+        ]
+    )
+    rig.llm.teammate.extend(
+        [
+            LLMResult(text="pytest tests/test_execution -q\n201 passed in 3.1s"),
+            LLMResult(text="passed: true. Output pasted; 201 passed."),
+        ]
+    )
+    posted = await rig.runtime.on_user_message(
+        space["id"], "/build Netie-AI/Cortex#203 | Scout | pytest tests/test_execution -q"
+    )
+    assert posted.get("run_id")
+    await wait_run_done(rig.runtime, space["id"], timeout=15.0)
+    row = rig.store.get_agent(scout["id"])
+    assert row is not None
+    assert int(row["verify"]) == 1
+    assert "pytest tests/test_execution -q" in row["verify_criteria"]
+    assert row["role_prompt"].startswith("Scout the brief.")
+    assert row["role_prompt"].count("Skill build:") == 1
+    assert "pytest tests/test_execution -q" in row["goal_text"]
+    tool = [
+        m
+        for m in rig.store.list_messages(space["id"])
+        if m["role"] == "tool" and (m.get("meta") or {}).get("tool") == "build_issue"
+    ][-1]
+    assert "-> Scout" in tool["content"]
+    assert "verify: pytest tests/test_execution -q" in tool["content"]
+    painted = " ".join(str(m.get("content") or "") for m in rig.store.list_messages(space["id"]))
+    assert "201 passed in 3.1s" in painted
+    assert "passed: true. Output pasted" in painted
+    assert rig.store.get_agent_by_name(space["id"], "Scout-verify") is not None
+    # Manager stays out of the writer pool.
+    denied = await rig.runtime.on_user_message(space["id"], "/build Netie-AI/Cortex#204 | Manager")
+    assert denied.get("run_id") is None
+    deny = [m for m in rig.store.list_messages(space["id"]) if m["role"] == "tool"][-1]
+    assert "not Manager" in deny["content"]
+
+
+@pytest.mark.asyncio
+async def test_scale_slash_seats_idle_first_spawns_to_cap_and_refuses_empty(
+    rig, tmp_path, monkeypatch
+) -> None:
+    claims = tmp_path / "CLAIMS.json"
+    claims.write_text(
+        '{"tickets":[{"ticket":"Netie-AI/Cortex#128","owner_pr":"Netie-AI/Cortex#128","role":"SEATED"}]}',
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("CREW_CLAIMS", str(claims))
+    monkeypatch.setattr(github_mod, "show_issue", _fake_show_issue)
+    space = rig.store.create_space("HQ")
+
+    # Nothing fetched yet: refuse and say what to do.
+    empty = await rig.runtime.on_user_message(space["id"], "/scale")
+    assert empty.get("run_id") is None
+    deny = [m for m in rig.store.list_messages(space["id"]) if m["role"] == "tool"][-1]
+    assert deny["content"].startswith("DENIED: no ready tickets") and "/fetch" in deny["content"]
+
+    github_mod.remember_fetched(
+        rig.settings.data_dir,
+        {
+            "ok": True,
+            "issues": [
+                {"spec": "Netie-AI/Cortex#128", "title": "seated"},
+                {"spec": "Netie-AI/Cortex#202", "title": "grant catalog"},
+                {"spec": "Netie-AI/Cortex#203", "title": "jail"},
+                {"spec": "Netie-AI/Cortex#204", "title": "dialog"},
+            ],
+        },
+    )
+    rig.store.upsert_agent(space["id"], "Scout", role_prompt="Scout the brief.")
+    rig.store.upsert_agent(space["id"], "Gate", role_prompt="Gate.")
+    rig.runtime.ensure_manager(space["id"])
+    gate = rig.store.get_agent_by_name(space["id"], "Gate")
+    rig.runtime.wait_agent(gate["id"])  # operator-parked waiting: not a free writer
+
+    rig.llm.manager.extend(
+        [
+            LLMResult(tool_calls=[_tc("wait_for_replies", timeout_seconds=8)]),
+            LLMResult(tool_calls=[_tc("wait_for_replies", timeout_seconds=8)]),
+            LLMResult(tool_calls=[_tc("wait_for_replies", timeout_seconds=8)]),
+            LLMResult(tool_calls=[_tc("wait_for_replies", timeout_seconds=8)]),
+            LLMResult(text="Two builds reported and verified. Nothing merged."),
+        ]
+    )
+    rig.llm.teammate.extend(
+        [
+            LLMResult(text="worker report A: output pasted below\n275 passed"),
+            LLMResult(text="worker report B: output pasted below\n275 passed"),
+            LLMResult(text="verifier verdict: passed: true (A)"),
+            LLMResult(text="verifier verdict: passed: true (B)"),
+        ]
+    )
+    posted = await rig.runtime.on_user_message(space["id"], "/scale 2")
+    assert posted.get("run_id")
+    assert posted.get("command") == "scale"
+    await wait_run_done(rig.runtime, space["id"], timeout=20.0)
+
+    tool = [
+        m
+        for m in rig.store.list_messages(space["id"])
+        if m["role"] == "tool" and (m.get("meta") or {}).get("tool") == "scale_tickets"
+    ][-1]
+    text = tool["content"]
+    assert text.startswith("Scaled 2/3 ready tickets: reused 1 existing, spawned 1 job-named")
+    assert "- Netie-AI/Cortex#202 -> Scout (existing): Build Netie-AI/Cortex#202 -> Scout" in text
+    assert (
+        "- Netie-AI/Cortex#203 -> cortex-203 (spawned): Build Netie-AI/Cortex#203 -> cortex-203"
+        in text
+    )
+    assert "- queued Netie-AI/Cortex#204: over limit 2" in text
+    assert "- skipped Gate: parked waiting (name it to reuse)" in text
+    assert "Netie-AI/Cortex#128" not in text
+    assert "one agent per issue" in text
+    args = tool["meta"]["args"]
+    assert [s["writer"] for s in args["seated"]] == ["Scout", "cortex-203"]
+    assert args["queued"] == [{"spec": "Netie-AI/Cortex#204", "reason": "over limit 2"}]
+
+    from CortexOS.crew.assign import public as assignment_public
+
+    rows = {r["spec"]: r["agent"] for r in assignment_public(rig.settings.data_dir)}
+    assert rows == {"Netie-AI/Cortex#202": "Scout", "Netie-AI/Cortex#203": "cortex-203"}
+    names = {a["name"] for a in rig.store.list_agents(space["id"])}
+    assert {"Scout", "Gate", "cortex-203", "Scout-verify", "cortex-203-verify"} <= names
+    assert "cortex-202" not in names  # Scout was reused instead of a fresh spawn
+    assert "cortex-204" not in names  # over limit: not seated, not spawned
+    for name in ("Scout", "cortex-203"):
+        row = rig.store.get_agent_by_name(space["id"], name)
+        assert int(row["verify"]) == 1
+        assert scale.DEFAULT_VERIFY_CMD in row["verify_criteria"]
+        assert row["mode"] == "goal"
+    painted = " ".join(str(m.get("content") or "") for m in rig.store.list_messages(space["id"]))
+    for expected in (
+        "worker report A",
+        "worker report B",
+        "verifier verdict: passed: true (A)",
+        "verifier verdict: passed: true (B)",
+        "Two builds reported and verified.",
+    ):
+        assert expected in painted
+    assert "Cut off" not in painted
+    assert claims.read_text(encoding="utf-8").count("SEATED") == 1
+
+    # Second round: #202/#203 are bound, every teammate is bound, waiting, or a
+    # verifier row, and the cap (6 rows) leaves no writer + verifier slot for #204.
+    # Nothing seats, nothing spawns, and the reason is in the transcript.
+    rig.settings.max_agents_per_space = 6
+    again = await rig.runtime.on_user_message(space["id"], "/scale 2")
+    assert again.get("run_id") is None
+    report = [m for m in rig.store.list_messages(space["id"]) if m["role"] == "tool"][-1]
+    assert report["content"].startswith("Scaled 0/1 ready tickets: reused 0 existing, spawned 0")
+    assert (
+        "- queued Netie-AI/Cortex#204: cap reached (6 rows; writer + verifier slots)"
+        in report["content"]
+    )
+    assert "- skipped Scout: bound to Netie-AI/Cortex#202" in report["content"]
+    assert "- skipped Scout-verify: verifier row, not a writer" in report["content"]
+    assert "cortex-204" not in {a["name"] for a in rig.store.list_agents(space["id"])}
+    assert not rig.runtime._space_run.get(space["id"])
+
+
+@pytest.mark.asyncio
+async def test_verifier_cap_skip_is_visible(rig, tmp_path, monkeypatch) -> None:
+    """A verifier that cannot spawn says so in the transcript. Silent skip = fake green."""
+    claims = tmp_path / "CLAIMS.json"
+    claims.write_text('{"tickets":[]}', encoding="utf-8")
+    monkeypatch.setenv("CREW_CLAIMS", str(claims))
+    monkeypatch.setattr(github_mod, "show_issue", _fake_show_issue)
+    rig.settings.max_agents_per_space = 2  # Manager + one worker: no room for a verifier
+    space = rig.store.create_space("HQ")
+    rig.llm.manager.extend(
+        [
+            LLMResult(tool_calls=[_tc("wait_for_replies", timeout_seconds=8)]),
+            LLMResult(text="Worker reported. Verifier could not spawn."),
+        ]
+    )
+    rig.llm.teammate.append(LLMResult(text="worker done; claims green"))
+    posted = await rig.runtime.on_user_message(space["id"], "/build Netie-AI/Cortex#205")
+    assert posted.get("run_id")
+    await wait_run_done(rig.runtime, space["id"], timeout=15.0)
+    painted = " ".join(str(m.get("content") or "") for m in rig.store.list_messages(space["id"]))
+    assert "worker done; claims green" in painted
+    assert (
+        "DENIED: verify skipped for cortex-205: agent cap reached (2). Not verified; not green."
+        in painted
+    )
+    assert rig.store.get_agent_by_name(space["id"], "cortex-205-verify") is None
+
+
+# -- HTTP + HUD ---------------------------------------------------------------
+
+
+def _wait_http_run(client, space_id: str, timeout: float = 20.0) -> None:
+    deadline = time.time() + timeout
+    while client.crew.runtime._space_run.get(space_id):
+        if time.time() > deadline:
+            raise AssertionError("run did not finish")
+        time.sleep(0.05)
+
+
+def test_http_build_and_scale_endpoints(client, tmp_path, monkeypatch) -> None:
+    claims = tmp_path / "CLAIMS.json"
+    claims.write_text(
+        '{"tickets":[{"ticket":"Netie-AI/Cortex#128","owner_pr":"Netie-AI/Cortex#128","role":"SEATED"}]}',
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("CREW_CLAIMS", str(claims))
+    monkeypatch.setattr(github_mod, "show_issue", _fake_show_issue)
+    space = client.http.post("/crew/spaces", json={"title": "HQ"}).json()
+
+    seated = client.http.post(
+        "/crew/tickets/build", json={"spec": "Netie-AI/Cortex#128", "space_id": space["id"]}
+    )
+    assert seated.status_code == 409 and "SEATED" in seated.json()["detail"]
+    bad = client.http.post("/crew/tickets/build", json={"spec": "FF-03", "space_id": space["id"]})
+    assert bad.status_code == 400 and "/build owner/repo#n" in bad.json()["detail"]
+    missing = client.http.post(
+        "/crew/tickets/build", json={"spec": "Netie-AI/Cortex#1", "space_id": "nope"}
+    )
+    assert missing.status_code == 404
+    empty = client.http.post("/crew/tickets/scale", json={"space_id": space["id"]})
+    assert empty.status_code == 409 and "no ready tickets" in empty.json()["detail"]
+
+    client.llm.manager.extend(
+        [
+            LLMResult(tool_calls=[_tc("wait_for_replies", timeout_seconds=8)]),
+            LLMResult(tool_calls=[_tc("wait_for_replies", timeout_seconds=8)]),
+            LLMResult(text="Built and verified over HTTP."),
+        ]
+    )
+    client.llm.teammate.extend(
+        [
+            LLMResult(text="worker: pasted output\n275 passed"),
+            LLMResult(text="verifier: passed: true"),
+        ]
+    )
+    built = client.http.post(
+        "/crew/tickets/build",
+        json={
+            "spec": "Netie-AI/Cortex#202",
+            "space_id": space["id"],
+            "name": "Scout",
+            "verify": "pytest -q",
+        },
+    )
+    assert built.status_code == 200
+    body = built.json()
+    assert body["ok"] is True and body["run_id"]
+    assert body["verify"] == "pytest -q"
+    assert body["detail"].startswith("Build Netie-AI/Cortex#202 -> Scout")
+    assert "CLAIMS" in body["law"]
+    _wait_http_run(client, space["id"])
+    board = client.http.get("/crew/tickets").json()
+    assert board["assignments"][0] == {
+        "spec": "Netie-AI/Cortex#202",
+        "agent": "Scout",
+        "space_id": space["id"],
+        "title": "title for Netie-AI/Cortex#202",
+        "ready": True,
+    }
+    agents = client.http.get(f"/crew/spaces/{space['id']}/agents").json()
+    by_name = {a["name"]: a for a in agents}
+    assert "Scout" in by_name and "Scout-verify" in by_name
+    painted = " ".join(
+        str(m.get("content") or "")
+        for m in client.http.get(f"/crew/spaces/{space['id']}/messages").json()
+    )
+    assert "worker: pasted output" in painted and "verifier: passed: true" in painted
+
+    github_mod.remember_fetched(
+        client.crew.settings.data_dir,
+        {
+            "ok": True,
+            "issues": [
+                {"spec": "Netie-AI/Cortex#202", "title": "already bound"},
+                {"spec": "Netie-AI/Cortex#203", "title": "jail"},
+                {"spec": "Netie-AI/Cortex#204", "title": "dialog"},
+            ],
+        },
+    )
+    client.llm.manager.extend(
+        [
+            LLMResult(tool_calls=[_tc("wait_for_replies", timeout_seconds=8)]),
+            LLMResult(tool_calls=[_tc("wait_for_replies", timeout_seconds=8)]),
+            LLMResult(text="Scaled one."),
+        ]
+    )
+    client.llm.teammate.extend(
+        [
+            LLMResult(text="worker 203: pasted\n275 passed"),
+            LLMResult(text="verifier 203: passed: true"),
+        ]
+    )
+    scaled = client.http.post(
+        "/crew/tickets/scale", json={"space_id": space["id"], "limit": 1, "names": "Scout"}
+    )
+    assert scaled.status_code == 200
+    plan = scaled.json()
+    # Scout is bound to #202, so the named reuse is skipped and #203 gets a job-named spawn.
+    assert plan["skipped"] == [{"writer": "Scout", "reason": "bound to Netie-AI/Cortex#202"}]
+    assert [s["writer"] for s in plan["seated"]] == ["cortex-203"]
+    assert plan["queued"] == [{"spec": "Netie-AI/Cortex#204", "reason": "over limit 1"}]
+    assert plan["run_id"]
+    assert "one agent per issue" in plan["law"]
+    _wait_http_run(client, space["id"])
+    belt = client.http.get("/v1/belt").json()
+    assigned = {a["spec"]: a["agent"] for a in belt["assignments"]}
+    assert assigned == {"Netie-AI/Cortex#202": "Scout", "Netie-AI/Cortex#203": "cortex-203"}
+
+
+def test_hud_paints_build_and_scale_controls(client) -> None:
+    page = client.http.get("/")
+    assert page.status_code == 200
+    html = page.text
+    assert 'id="ticketsScale"' in html
+    assert "data-build=" in html
+    assert "/crew/tickets/build" in html and "/crew/tickets/scale" in html
+    assert "never one agent per issue" in html
+    commands = client.http.get("/crew/commands").json()["commands"]
+    by_slash = {c["slash"]: c for c in commands}
+    assert by_slash["build"]["kind"] == "desk" and by_slash["build"]["action"] == "build_issue"
+    assert by_slash["scale"]["kind"] == "desk" and by_slash["scale"]["action"] == "scale_tickets"
+    assert "implement" in by_slash["build"]["aliases"]
+    assert "seat" in by_slash["scale"]["aliases"]

--- a/tests/test_crew/test_server.py
+++ b/tests/test_crew/test_server.py
@@ -630,7 +630,12 @@ def test_commands_autocomplete_and_mention_targets(client) -> None:
     body = client.http.get("/crew/commands").json()
     slashes = {c["slash"] for c in body["commands"]}
     assert {"desk", "board", "estate", "ship_gate", "spawn", "kill", "done"} <= slashes
-    assert any(c["kind"] == "skill" and c["slash"] == "build" for c in body["commands"])
+    # /build is a desk bind now (skill build + named verify); bare /build still
+    # loads the pack. Shipped packs stay listed as skills under their own slug.
+    build = next(c for c in body["commands"] if c["slash"] == "build")
+    assert build["kind"] == "desk" and build["action"] == "build_issue"
+    assert any(c["kind"] == "skill" and c["slash"] == "ship" for c in body["commands"])
+    assert any(c["kind"] == "desk" and c["slash"] == "scale" for c in body["commands"])
     assert any(c["kind"] == "routine" for c in body["commands"])
     names = {m["name"] for m in body["mentions"]}
     assert "Manager" in names


### PR DESCRIPTION
Follow-up to Cortex#116 (EPIC-CREW). Ticket draft CREW-SCALE-BUILD. Does not mint a second Crew GitHub issue.

**Reading of the ask.** "Scale and Build tickets or crew then verify Test" was read as a Crew feature: Scale = seat existing writers across the Tickets HUD (never one agent per issue, per the 2026-08-24 overnight finding), Build = the `build` skill pack with one named verify command, verify = the existing generator-verifier pass judging that command's pasted output. Slash names are cheap to rename if a different reading was meant.

## What landed

- `/scale n | Name, Name` pairs ready fetched issues with idle teammates first and spawns a job-named teammate (`cortex-203`) only while `max_agents_per_space` still leaves a writer + verifier slot. The rest is queued with a visible reason (`over limit`, `cap reached`, `already bound`); skipped writers say why (`busy`, `bound to owner/repo#n`, `verifier row, not a writer`, `goal mode (name it to reuse)`).
- `/build owner/repo#n | Name | verify cmd` binds one ticket with skill `build` copied into the teammate and a verifier whose criteria name the command. Default command is `python -m pytest tests/test_crew -q`, asserted equal to the pack so it cannot drift. Bare `/build` still loads the pack. Refuses SEATED and Manager.
- New `CortexOS/crew/scale.py`: pure planner (`plan_scale`, `ready_tickets`, `build_goal`, `build_criteria`, `render_scale`). Runtime: `/assign` body is now the shared `_bind_issue`; `/build` and `/scale` ride the same local bind, A2A brief, and one run. No new orchestrator.
- `operator_spawn` without a live run now persists `skills` / `verify` / `verify_criteria` like `_spawn` does (same spawn behaved differently depending on whether a run was live).
- A verifier skipped at the agent cap is a visible `DENIED ... Not verified; not green.` system line instead of a silent return; verifier rows read `active` as soon as their task exists.
- HTTP: `POST /crew/tickets/build` (409 SEATED, 400 bad spec, 404 unknown space) and `POST /crew/tickets/scale` (409 nothing ready). HUD: Build button per ready `owner/repo#n` row, Scale button on the Tickets block.
- Local binds only. Does not write `CLAIMS.json`. Does not set GitHub assignees. Control stays GET display-only. Did not touch freeze #4/#41-#44. Did not rebind `:8020`.

## Verify

```
python -m pytest tests/test_crew -q
```

Local result on this SHA: **289 passed** (275 before + 14 new in `tests/test_crew/test_scale.py`). Also clean locally: `ruff check`, `mypy`, `lint-imports` (3 kept), `python scripts/check_versions.py`, `pytest tests/contract tests/packaging tests/invariants` (151 passed). The engine OpenAPI spec has no crew routes, so no contract drift.

## Honesty

- Does **not** prove live `:8020` HUD until founder restart.
- No shell exec was added: the verifier judges the worker's pasted output and fails closed without it. Nothing here runs pytest on the teammate's behalf.
- GitHub Actions not asserted green from this agent. Do not read this PR as CI-pass.
- Finding: `docs/subagents_findings/2026-09-12_crew-scale-build.md` (root-cause class: silent fallback + split spawn path).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Dej7TxT1DXjb6mtPD9cWEs

---
_Generated by [Claude Code](https://claude.ai/code/session_01Dej7TxT1DXjb6mtPD9cWEs)_